### PR TITLE
Use ecrecover() from ethereumjs-util in the ecrecover precompiled contract

### DIFF
--- a/lib/precompiled/01-ecrecover.js
+++ b/lib/precompiled/01-ecrecover.js
@@ -2,34 +2,9 @@ const utils = require('ethereumjs-util')
 const BN = utils.BN
 const error = require('../constants.js').ERROR
 const fees = require('ethereum-common')
-const ecdsa = require('secp256k1')
 const gasCost = new BN(fees.ecrecoverGas.v)
 
 module.exports = function (opts) {
-  /**
-   * ecrecover
-   * @param  {Buffer} msgHash [description]
-   * @param  {Buffer} v       [description]
-   * @param  {Buffer} r       [description]
-   * @param  {Buffer} s       [description]
-   * @return {Buffer}         public key otherwise null
-   */
-  function ecrecover (msgHash, v, r, s) {
-    var sig = Buffer.concat([utils.pad(r, 32), utils.pad(s, 32)], 64)
-    var recid = utils.bufferToInt(v) - 27
-    var senderPubKey
-    try {
-      senderPubKey = ecdsa.recoverSync(msgHash, sig, recid)
-      senderPubKey = ecdsa.publicKeyConvert(senderPubKey, false)
-    } catch (e) {}
-
-    if (senderPubKey && senderPubKey.toString('hex') !== '') {
-      return senderPubKey
-    } else {
-      return null
-    }
-  }
-
   var results = {}
 
   if (opts.gasLimit.cmp(gasCost) === -1) {
@@ -48,12 +23,14 @@ module.exports = function (opts) {
   var r = data.slice(64, 96)
   var s = data.slice(96, 128)
 
-  var publicKey = ecrecover(msgHash, v, r, s)
-
-  if (!publicKey) {
+  var publicKey
+  try {
+    publicKey = utils.ecrecover(msgHash, v, r, s)
+  } catch (e) {
     return results
   }
 
   results.return = utils.pad(utils.publicToAddress(publicKey), 32)
+  results.exception = 1
   return results
 }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
     "ethereum-common": "0.0.16",
     "ethereumjs-account": "^2.0.1",
     "ethereumjs-block": "^1.2.0",
-    "ethereumjs-util": "^2.5.0",
+    "ethereumjs-util": "^3.0.0",
     "functional-red-black-tree": "^1.0.1",
-    "merkle-patricia-tree": "^2.1.1",
-    "secp256k1": "^2.0.7"
+    "merkle-patricia-tree": "^2.1.1"
   },
   "devDependencies": {
     "ethereumjs-blockchain": "^1.3.4",


### PR DESCRIPTION
This also fixes ecrecover in browsers and removes secp256k1 as a dependency for ethereumjs-vm.