### PR TITLE
Add option to skip balance check.

### DIFF
--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -10,6 +10,7 @@ const Block = require('ethereumjs-block')
  * @param opts
  * @param opts.tx {Transaciton} - a transaction
  * @param opts.skipNonce - skips the nonce check
+ * @param opts.skipBalance - skips the balance check
  * @param opts.block {Block} needed to process the transaction, if no block is given a default one is created
  * @param cb {Function} - the callback
  */
@@ -87,7 +88,7 @@ module.exports = function (opts, cb) {
     var fromAccount = self.stateManager.cache.get(tx.from)
     var message
 
-    if (new BN(fromAccount.balance).cmp(tx.getUpfrontCost()) === -1) {
+    if (!opts.skipBalance && new BN(fromAccount.balance).cmp(tx.getUpfrontCost()) === -1) {
       message = "sender doesn't have enough funds to send tx. The upfront cost is: " + tx.getUpfrontCost().toString() + ' and the sender\s account only has: ' + new BN(fromAccount.balance).toString()
       cb(new Error(message))
       return


### PR DESCRIPTION
Good for running `eth_call`'s in the provider engine and the testrpc in cases where the address specified has zero balance. `eth_call`'s are free, and in other ethereum implementations run just fine, and don't error when the sender doesn't have enough Ether.  