### PR TITLE
fixed boolean logic to match the spec fixes #48

### DIFF
--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -210,7 +210,7 @@ module.exports = function (opts, cb) {
       suicides: runState.suicides,
       suicideTo: runState.suicideTo,
       gasRefund: runState.gasRefund,
-      exception: err ? 0 : 1,
+      exception: err ? true : false,
       exceptionError: err,
       logs: runState.logs,
       gas: runState.gasLeft,


### PR DESCRIPTION
as per README.md:
  - `exception` - a `boolean`, whether or not the contract encountered an exception