### PR TITLE
Fix emptying of contract code

### DIFF
--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -148,8 +148,8 @@ module.exports = function (opts, cb) {
         // if not enough gas
         if (totalGas.cmp(gasLimit) <= 0) {
           results.gasUsed = totalGas
-        } else {
           results.return = new Buffer([])
+        } else {
           if (opts.block.isHomestead()) {
             results.exception = 0
             err = results.exceptionError = ERROR.OUT_OF_GAS


### PR DESCRIPTION
Otherwise during contract creation, `runCode` always re-intializes return to an empty buffer and `saveCode` doesn't save the contract code in the `stateManager` since it runs after.