### PR TITLE
add location information to `invalid JUMP' errors

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -429,7 +429,7 @@ module.exports = {
     dest = utils.bufferToInt(dest)
 
     if (!jumpIsValid(runState, dest)) {
-      trap(ERROR.INVALID_JUMP + " at " + describeLocation(runState))
+      trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
     }
 
     runState.programCounter = dest
@@ -441,7 +441,7 @@ module.exports = {
     var dest = i ? c : runState.programCounter
 
     if (i && !jumpIsValid(runState, dest)) {
-      trap(ERROR.INVALID_JUMP + " at " + describeLocation(runState))
+      trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
     }
 
     runState.programCounter = dest
@@ -701,10 +701,10 @@ module.exports = {
 module.exports._DC = module.exports.DELEGATECALL
 
 function describeLocation (runState) {
-  var hash = utils.sha3(runState.code).toString("hex")
-  var address = runState.address.toString("hex")
+  var hash = utils.sha3(runState.code).toString('hex')
+  var address = runState.address.toString('hex')
   var pc = runState.programCounter - 1
-  return hash + "/" + address + ":" + pc
+  return hash + '/' + address + ':' + pc
 }
 
 function subGas (runState, amount) {

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -429,7 +429,7 @@ module.exports = {
     dest = utils.bufferToInt(dest)
 
     if (!jumpIsValid(runState, dest)) {
-      trap(ERROR.INVALID_JUMP)
+      trap(ERROR.INVALID_JUMP + " at " + describeLocation(runState))
     }
 
     runState.programCounter = dest
@@ -441,7 +441,7 @@ module.exports = {
     var dest = i ? c : runState.programCounter
 
     if (i && !jumpIsValid(runState, dest)) {
-      trap(ERROR.INVALID_JUMP)
+      trap(ERROR.INVALID_JUMP + " at " + describeLocation(runState))
     }
 
     runState.programCounter = dest
@@ -699,6 +699,13 @@ module.exports = {
 }
 
 module.exports._DC = module.exports.DELEGATECALL
+
+function describeLocation (runState) {
+  var hash = utils.sha3(runState.code).toString("hex")
+  var address = runState.address.toString("hex")
+  var pc = runState.programCounter - 1
+  return hash + "/" + address + ":" + pc
+}
 
 function subGas (runState, amount) {
   runState.gasLeft.isub(amount)


### PR DESCRIPTION
Creating a PR for @dbrock's commit that adds some tasty debugging information.

comments appreciated -- maybe instead of reporting a string as an error we can use a more structured object