### PR TITLE
Special treatment of value in DELEGATECALL (as per Yellow Paper Section 8)

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -817,6 +817,7 @@ function makeCall (runState, callOptions, localOpts, cb) {
   callOptions.block = runState.block
   callOptions.populateCache = false
   callOptions.suicides = runState.suicides
+  callOptions.opName = runState.opName
 
   // increment the runState.depth
   callOptions.depth = runState.depth + 1

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -43,13 +43,14 @@ module.exports = function (opts, cb) {
   var depth = opts.depth
   var suicides = opts.suicides
   var enableHomestead = this.opts.enableHomestead === undefined ? block.isHomestead() : this.opts.enableHomestead
+  var opName = opts.opName
 
   txValue = new BN(txValue)
 
   stateManager.checkpoint()
 
   // run and parse
-  subTxValue()
+  if(opName != 'DELEGATECALL') subTxValue()
 
   async.series([
     loadToAccount,
@@ -90,7 +91,7 @@ module.exports = function (opts, cb) {
   }
 
   function loadCode (cb) {
-    addTxValue()
+    if(opName != 'DELEGATECALL') addTxValue()
     // loads the contract's code if the account is a contract
     if (code || !(toAccount.isContract() || ethUtil.isPrecompiled(toAddress))) {
       cb()


### PR DESCRIPTION
This change avoids incorrectly deducting value from the caller's account when a `DELEGATECALL` is invoked from a `payable` function ([issue](https://github.com/ethereumjs/ethereumjs-vm/issues/121)).

From Section 8 of yellow paper:

`Note that we need to differentiate between the value that
is to be transferred, v, from the value apparent in the execution
context, ˜v, for the DELEGATECALL instruction.`