### PR TITLE
fix selfdestruct revert bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Runs EVM code
   - `gas` - the amount of gas left as a `bignum`
   - `gasUsed` - the amount of gas as a `bignum` the code used to run. 
   - `gasRefund` - a `Bignum` containing the amount of gas to refund from deleting storage values
-  - `suicides` - an `Array` of accounts that have suicided.
-  - `suicideTo` - the account that the suicide refund should go to.
+  - `suicides` - an `Object` with keys for accounts that have suicided and values for balance transfer recipient accounts.
   - `logs` - an `Array` of logs that the contract emitted.
   - `exception` - `0` if the contract encountered an exception, `1` otherwise.
   - `exceptionError` - a `String` describing the exception if there was one.

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -669,7 +669,6 @@ module.exports = {
       runState.gasRefund = runState.gasRefund.add(new BN(fees.suicideRefundGas.v))
     }
 
-    runState.suicideTo = suicideToAddress
     runState.suicides[contractAddress.toString('hex')] = suicideToAddress
     runState.stopped = true
 

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -48,7 +48,6 @@ module.exports = function (opts, cb) {
     returnValue: false,
     stopped: false,
     vmError: false,
-    suicideTo: undefined,
     programCounter: 0,
     opCode: undefined,
     opName: undefined,
@@ -217,7 +216,6 @@ module.exports = function (opts, cb) {
     var results = {
       runState: runState,
       suicides: runState.suicides,
-      suicideTo: runState.suicideTo,
       gasRefund: runState.gasRefund,
       exception: err ? 0 : 1,
       exceptionError: err,
@@ -228,6 +226,7 @@ module.exports = function (opts, cb) {
 
     if (results.exceptionError) {
       delete results.gasRefund
+      delete results.suicides
     }
 
     if (err) {


### PR DESCRIPTION
This fixes https://github.com/ethereumjs/ethereumjs-vm/issues/113.

It also updates the README to correctly document the `suicides` variable, which was [already](https://github.com/ethereumjs/ethereumjs-vm/blob/d2713ce43816417f67611cdd84f7ebe9d3f97ddb/lib/runTx.js#L177-L18) an `Object` and not an `Array`. And it removes the `runState.suicideTo` variable since that information is already in `suicides`.

This change was tested by manually adding the [ZeroValue_SUICIDE_OOGRevert.json](
https://github.com/ethereum/tests/blob/3b90fbfaf0b6180be9276bbd050ac2475b95d949/BlockchainTests/GeneralStateTests/stZeroCallsRevert/ZeroValue_SUICIDE_OOGRevert.json) test file to `node_modules/ethereumjs-testing/tests/BlockchainTests`, in lieu of the pending test runner update https://github.com/ethereumjs/ethereumjs-vm/pull/105.

Here is the test output before the change:
```
Macbooks-MacBook:ethereumjs-vm macbook$ npm run testBlockchain

> ethereumjs-vm@2.0.2 testBlockchain /Users/macbook/dev_js-vm-bug/ethereumjs-vm
> ./tests/tester -b

TAP version 13
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_EIP150
ok 1 correct pre stateRoot
ok 2 correct genesis RLP
not ok 3 last block hash
  ---
    operator: equal
    expected: |-
      '971f29f154e5a2622f81045f14141c70d72e73f518bc3d7080a24e68eece3cf8'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: Immediate.callNext (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/memdown/memdown.js:173:5)
  ...
not ok 4 correct header block
  ---
    operator: equal
    expected: |-
      '971f29f154e5a2622f81045f14141c70d72e73f518bc3d7080a24e68eece3cf8'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: replenish (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/async/dist/async.js:977:25)
  ...
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_EIP158
ok 5 correct pre stateRoot
ok 6 correct genesis RLP
not ok 7 last block hash
  ---
    operator: equal
    expected: |-
      '951fea154307f1975c7a01ee8862a90673e0685a1ff964fe0dd86e614d3fd2bb'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: Immediate.callNext (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/memdown/memdown.js:173:5)
  ...
not ok 8 correct header block
  ---
    operator: equal
    expected: |-
      '951fea154307f1975c7a01ee8862a90673e0685a1ff964fe0dd86e614d3fd2bb'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: replenish (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/async/dist/async.js:977:25)
  ...
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_Frontier
ok 9 correct pre stateRoot
ok 10 correct genesis RLP
not ok 11 last block hash
  ---
    operator: equal
    expected: |-
      '0cfcaa288259c45f4d6f21b7b2ec7c9698b6a07bd72b7665ac90e3a1b13d0445'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: Immediate.callNext (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/memdown/memdown.js:173:5)
  ...
not ok 12 correct header block
  ---
    operator: equal
    expected: |-
      '0cfcaa288259c45f4d6f21b7b2ec7c9698b6a07bd72b7665ac90e3a1b13d0445'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: replenish (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/async/dist/async.js:977:25)
  ...
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_Homestead
ok 13 correct pre stateRoot
ok 14 correct genesis RLP
not ok 15 last block hash
  ---
    operator: equal
    expected: |-
      'ca385bce877f50064c9fe22dcf4f1187ca1356e8f34a1477e6d9e7dcbade99c9'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: Immediate.callNext (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/memdown/memdown.js:173:5)
  ...
not ok 16 correct header block
  ---
    operator: equal
    expected: |-
      'ca385bce877f50064c9fe22dcf4f1187ca1356e8f34a1477e6d9e7dcbade99c9'
    actual: |-
      'be08b4dd48caae4f151e3dc47f1d6e25353a978bc1b6075858912fa9a4b59868'
    at: replenish (/Users/macbook/dev_js-vm-bug/ethereumjs-vm/node_modules/async/dist/async.js:977:25)
  ...
```

Here is the test output after the change:
```
Macbooks-MacBook:ethereumjs-vm macbook$ npm run testBlockchain

> ethereumjs-vm@2.0.2 testBlockchain /Users/macbook/dev_js-vm-bug/ethereumjs-vm
> ./tests/tester -b

TAP version 13
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_EIP150
ok 1 correct pre stateRoot
ok 2 correct genesis RLP
ok 3 last block hash
ok 4 correct header block
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_EIP158
ok 5 correct pre stateRoot
ok 6 correct genesis RLP
ok 7 last block hash
ok 8 correct header block
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_Frontier
ok 9 correct pre stateRoot
ok 10 correct genesis RLP
ok 11 last block hash
ok 12 correct header block
# [!ZeroValue_SUICIDE_OOGRevert] ZeroValue_SELFDESTRUCT_OOGRevert_d0g0v0_Homestead
ok 13 correct pre stateRoot
ok 14 correct genesis RLP
ok 15 last block hash
ok 16 correct header block
```


