### PR TITLE
fix bug when a zero-value call creates a new account (homestead)

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -555,8 +555,12 @@ module.exports = {
         return
       }
       if (!exists) {
-        // can't wrap because we are in a callback
-        runState.gasLeft.isub(new BN(fees.callNewAccountGas.v))
+        try {
+          subGas(runState, new BN(fees.callNewAccountGas.v))
+        } catch (e) {
+          done(e.error)
+          return
+        }
       }
       makeCall(runState, options, localOpts, done)
     })


### PR DESCRIPTION
Prevents `runState.gasLimit` from going negative and failing the test case [call_OOG_additionalGasCosts1](https://github.com/ethereum/tests/blob/e8ba92a9e20a252d215cbc95d314eba22b1d79c5/src/GeneralStateTestsFiller/stCallCodes/call_OOG_additionalGasCosts1Filler.json) under Homestead.