### PR TITLE
Fix homestead [WIP]

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,7 @@
 exports.ERROR = {
   OUT_OF_GAS: 'out of gas',
   STACK_UNDERFLOW: 'stack underflow',
+  STACK_OVERFLOW: 'stack overflow',
   INVALID_JUMP: 'invalid JUMP',
   INVALID_OPCODE: 'invalid opcode'
 }

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -133,6 +133,7 @@ module.exports = {
   },
   SIGNEXTEND: function (k, val, runState) {
     k = new BN(k)
+    val = new Buffer(val) // use clone, don't modify object reference
     var extendOnes = false
 
     if (k.cmpn(31) <= 0) {
@@ -146,7 +147,6 @@ module.exports = {
       for (var i = 30 - k; i >= 0; i--) {
         val[i] = extendOnes ? 0xff : 0
       }
-
     }
 
     return val

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -555,8 +555,12 @@ module.exports = {
         return
       }
       if (!exists) {
-        // can't wrap because we are in a callback
-        runState.gasLeft.isub(new BN(fees.callNewAccountGas.v))
+        try {
+          subGas(runState, new BN(fees.callNewAccountGas.v))
+        } catch (e) {
+          done(e.error)
+          return
+        }
       }
       makeCall(runState, options, localOpts, done)
     })

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -546,13 +546,12 @@ module.exports = {
       options.gasLimit.iadd(new BN(fees.callStipend.v))
     }
 
-    checkCallMemCost(runState, options, localOpts)
-
     stateManager.exists(toAddress, function (err, exists) {
       if (err) {
         done(err)
         return
       }
+
       if (!exists) {
         try {
           subGas(runState, new BN(fees.callNewAccountGas.v))
@@ -561,6 +560,14 @@ module.exports = {
           return
         }
       }
+
+      try {
+        checkCallMemCost(runState, options, localOpts)
+      } catch (e) {
+        done(e.error)
+        return
+      }
+
       makeCall(runState, options, localOpts, done)
     })
   },

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -131,14 +131,12 @@ module.exports = {
 
     return result
   },
-  SIGNEXTEND: function (k, runState) {
+  SIGNEXTEND: function (k, val, runState) {
     k = new BN(k)
     var extendOnes = false
 
     if (k.cmpn(31) <= 0) {
       k = k.toNumber()
-
-      var val = new Buffer(utils.setLengthLeft(runState.stack.pop(), 32))
 
       if (val[31 - k] & 0x80) {
         extendOnes = true
@@ -149,8 +147,9 @@ module.exports = {
         val[i] = extendOnes ? 0xff : 0
       }
 
-      return val
     }
+
+    return val
   },
   // 0x10 range - bit ops
   LT: function (a, b, runState) {

--- a/lib/opcodes.js
+++ b/lib/opcodes.js
@@ -12,7 +12,7 @@ const codes = {
   0x08: ['ADDMOD', 8, 3, 1, false],
   0x09: ['MULMOD', 8, 3, 1, false],
   0x0a: ['EXP', 10, 2, 1, false],
-  0x0b: ['SIGNEXTEND', 5, 1, 1, false],
+  0x0b: ['SIGNEXTEND', 5, 2, 1, false],
 
   // 0x10 range - bit ops
   0x10: ['LT', 3, 2, 1, false],

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -109,9 +109,6 @@ module.exports = function (opts, cb) {
   }
 
   function iterateVm (done) {
-    if (runState.stack.length > 1024) {
-      return done(ERROR.INVALID_OPCODE)
-    }
 
     var opCode = runState.code[runState.programCounter]
     var opInfo = lookupOpInfo(opCode)
@@ -129,6 +126,10 @@ module.exports = function (opts, cb) {
     // check for stack underflows
     if (runState.stack.length < opInfo.in) {
       return done(ERROR.STACK_UNDERFLOW)
+    }
+
+    if ((runState.stack.length - opInfo.in + opInfo.out) > 1024) {
+      return done(ERROR.STACK_OVERFLOW)
     }
 
     async.series([


### PR DESCRIPTION
The first commit prevents `runState.gasLimit` from going negative and failing the test case [call_OOG_additionalGasCosts1](https://github.com/ethereum/tests/blob/e8ba92a9e20a252d215cbc95d314eba22b1d79c5/src/GeneralStateTestsFiller/stCallCodes/call_OOG_additionalGasCosts1Filler.json) under Homestead.

The second commit fixes the [shallowStack_d10g0v0_Homestead](https://github.com/ethereum/tests/blob/cffb263d6c9075e1396e72d5d8febc21329b6600/src/GeneralStateTestsFiller/stStackTests/shallowStackFiller.json#L42) test case, which executes the bytecode `0x60010b600055`:

```
[1] PUSH1 0x01 
[2] SIGNEXTEND 
[4] PUSH1 0x00 
[5] SSTORE 
```
and should throw an OOG due to a stack underflow.

The third commit fixes some failing edge cases in the [stackOverflow](https://github.com/ethereum/tests/blob/cffb263d6c9075e1396e72d5d8febc21329b6600/src/GeneralStateTestsFiller/stStackTests/stackOverflowFiller.json) tests.