### PR TITLE
dont run testVM on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       env: CXX=g++-4.8 TEST_SUITE=lint
     - os: linux
       node_js: "7"
-      env: CXX=g++-4.8 TEST_SUITE=testVM
+      env: CXX=g++-4.8 TEST_SUITE=testState
 # temporarily disable testBlockchain
 #    - os: linux
 #      node_js: "7"

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
     - "npm rebuild"
 test:
   override:
-# testBlockchain temporarily disabled
+# testVM disabled. testBlockchain temporarily disabled
 #   - case $CIRCLE_NODE_INDEX in 0) npm run lint ;; 1) npm run testVM ;; 2) npm run testState ;; 3) npm run testBlockchain ;; esac:
-    - case $CIRCLE_NODE_INDEX in 0) npm run lint ;; 1) npm run testVM ;; 2) npm run testState ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) npm run lint ;; 1) npm run testState ;; esac:
         parallel: true


### PR DESCRIPTION
VMTests use Frontier gas costs, which means they fail if run in a VM using EIP150 gas costs. ethereumjs-vm would need conditional fork logic to continue passing the VM tests.