### PR TITLE
increase maximum stack size for testBlockchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "testVM": "node --harmony ./tests/tester -v",
     "testState": "node --harmony ./tests/tester -s",
-    "testBlockchain": "node --harmony ./tests/tester -b",
+    "testBlockchain": "node --stack-size=1500 --harmony ./tests/tester -b",
     "lint": "standard",
     "test": "node --harmony ./tests/tester -a"
   },


### PR DESCRIPTION
This solves an issue which causes `npm run testBlockchain` to fail under node8