### PR TITLE
EIP-6: Rename SUICIDE opcode to SELFDESTRUCT

### DIFF
--- a/examples/run-transactions-simple/bundle.js
+++ b/examples/run-transactions-simple/bundle.js
@@ -1139,7 +1139,7 @@ module.exports = {
     runState.returnValue = memLoad(runState, offset, length)
   },
   // '0x70', range - other
-  SUICIDE: function (suicideToAddress, runState, cb) {
+  SELFDESTRUCT: function (suicideToAddress, runState, cb) {
     var stateManager = runState.stateManager
     var contract = runState.contract
     var contractAddress = runState.address
@@ -1498,7 +1498,7 @@ const codes = {
   0xf3: ['RETURN', 0, 2, 0, false],
 
   // '0x70', range - other
-  0xff: ['SUICIDE', 0, 1, 0, false]
+  0xff: ['SELFDESTRUCT', 0, 1, 0, false]
 }
 
 module.exports = function (op, full) {

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -669,7 +669,7 @@ module.exports = {
     runState.returnValue = memLoad(runState, offset, length)
   },
   // '0x70', range - other
-  SUICIDE: function (suicideToAddress, runState, cb) {
+  SELFDESTRUCT: function (suicideToAddress, runState, cb) {
     var stateManager = runState.stateManager
     var contract = runState.contract
     var contractAddress = runState.address

--- a/lib/opcodes.js
+++ b/lib/opcodes.js
@@ -149,7 +149,7 @@ const codes = {
   0xf4: ['DELEGATECALL', 40, 6, 1, true],
 
   // '0x70', range - other
-  0xff: ['SUICIDE', 0, 1, 0, false]
+  0xff: ['SELFDESTRUCT', 0, 1, 0, false]
 }
 
 module.exports = function (op, full) {


### PR DESCRIPTION
# EIP-6: Renaming SUICIDE opcode
- https://github.com/ethereum/EIPs/blob/master/EIPS/eip-6.md

I only renamed the opcode rather than all of the variable names with a reference to suicide b/c the `ethereum-common` module would have to change as well. 
If you like I can rename just the local variables and leave the module reference alone.