### PR TITLE
band-aid patch over ethereumjs-util v5 changes

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -7,6 +7,37 @@ const logTable = require('./logTable.js')
 const ERROR = constants.ERROR
 const MAX_INT = 9007199254740991
 
+// revert changes in ethereumjs-util v5.0: bufferToInt, sha3, and ecrecover
+
+// TODO: fix use of utils.bufferToInt
+utils.bufferToInt = function (buf) {
+  return parseInt(utils.bufferToHex(buf), 16)
+}
+
+// TODO: fix use of utils.sha3
+const SHA3 = require('keccakjs')
+utils.sha3 = function (a, bytes) {
+  a = utils.toBuffer(a)
+  if (!bytes) bytes = 256
+
+  var h = new SHA3(bytes)
+  if (a) {
+    h.update(a)
+  }
+  return new Buffer(h.digest('hex'), 'hex')
+}
+
+// TODO: fix use of utils.ecrecover
+utils.ecrecover = function (msgHash, v, r, s) {
+  var signature = Buffer.concat([utils.setLength(r, 32), utils.setLength(s, 32)], 64)
+  var recovery = utils.bufferToInt(v) - 27
+  if (recovery !== 0 && recovery !== 1) {
+    throw new Error('Invalid signature v value')
+  }
+  var senderPubKey = utils.secp256k1.recover(msgHash, signature, recovery)
+  return utils.secp256k1.publicKeyConvert(senderPubKey, false).slice(1)
+}
+
 // the opcode functions
 module.exports = {
   STOP: function (runState) {


### PR DESCRIPTION
Temporarily patch things that https://github.com/ethereumjs/ethereumjs-vm/pull/104 broke (`utils.bufferToInt`, `utils.sha3`, and `utils.ecrecover`).