### PR TITLE
debug flag for Blockchain test post state; disable VM tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,19 +164,20 @@ Emits the result of the transaction.
 
 _Note: Requires at least Node.js `8.0.0` installed to run the tests, this is because `ethereumjs-testing` uses `async/await` and other ES2015 language features_
 
-`npm test`  
-if you want to just run the Blockchain tests run
-`node ./tests/tester -b`
-if you want to just run the VM tests run
-`node ./tests/tester -v`
+`npm test`
 if you want to just run the State tests run
 `node ./tests/tester -s`
+if you want to just run the Blockchain tests run
+`node ./tests/tester -b`
 
-To run the all the tests in a file:
+To run the all the blockchain tests in a file:
 `node ./tests/tester -b --file='randomStatetest303'`
 
-or to run a specific test case:
-`node ./tests/tester -v --test='log0_nonEmptyMem_logMemSize1_logMemStart31'``
+To run a specific state test case:
+`node ./tests/tester -s --test='stackOverflow'`
+
+Blockchain tests support `--debug` to verify the postState:
+`node ./tests/tester -b  --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
 
 # Internal Structure
 The VM processes state changes at many levels.

--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -93,7 +93,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
         // imported if it is not equal to the expected postState. it is useful
         // for debugging to skip this, so that verifyPostConditions will compare
         // testData.postState to the actual postState, rather than to the preState.
-        if (!options.debugging) {
+        if (!options.debug) {
           // make sure the state is set before checking post conditions
           state.root = block.header.stateRoot
         }
@@ -101,7 +101,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
       })
     },
     function (done) {
-      if (options.debugging) {
+      if (options.debug) {
         testUtil.verifyPostConditions(state, testData.postState, t, done)
       } else {
         done()

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -37,6 +37,8 @@ const skip = [
 ]
 
 /*
+NOTE: VM tests have been disabled since they are generated using Frontier gas costs, and ethereumjs-vm doesn't support historical fork rules
+
 TODO: some VM tests do not appear to be executing (don't print an "ok" statement):
 ...
 # file: vmLogTest test: log0_emptyMem
@@ -135,7 +137,7 @@ function runTests (name, runnerArgs, cb) {
   testGetterArgs.test = argv.test
 
   runnerArgs.forkConfig = FORK_CONFIG
-  // runnerArgs.debugging = true; // for BlockchainTests
+  runnerArgs.debug = argv.debug // for BlockchainTests
   // runnerArgs.vmtrace = true; // for VMTests
 
   tape(name, t => {
@@ -164,7 +166,7 @@ function runAll () {
   require('./cacheTest.js')
   require('./genesishashes.js')
   async.series([
-    runTests.bind(this, 'VMTests', {}),
+    // runTests.bind(this, 'VMTests', {}), // VM tests disabled since we don't support Frontier gas costs
     runTests.bind(this, 'GeneralStateTests', {}),
     runTests.bind(this, 'BlockchainTests', {})
   ])


### PR DESCRIPTION
VM tests are disabled since they use Frontier gas costs, and ethereumjs-vm doesn't support historical forks.