### PR TITLE
null address check before deleting account from trie

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -127,9 +127,6 @@ Cache.prototype.clear = function () {
 }
 
 Cache.prototype.del = function (key) {
-  if (key.toString('hex') === '') {
-    return
-  }
   this._deletes.push(key)
   key = key.toString('hex')
   this._cache = this._cache.remove(key)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -127,6 +127,9 @@ Cache.prototype.clear = function () {
 }
 
 Cache.prototype.del = function (key) {
+  if (key.toString('hex') === '') {
+    return
+  }
   this._deletes.push(key)
   key = key.toString('hex')
   this._cache = this._cache.remove(key)

--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -71,10 +71,12 @@ module.exports = function (opts, cb) {
   function populateCache (cb) {
     var accounts = new Set()
     accounts.add(tx.from.toString('hex'))
-    accounts.add(tx.to.toString('hex'))
     accounts.add(block.header.coinbase.toString('hex'))
 
-    self.stateManager.touched.push(tx.to)
+    if (tx.to.toString('hex') !== '') {
+      accounts.add(tx.to.toString('hex'))
+      self.stateManager.touched.push(tx.to)
+    }
 
     if (opts.populateCache === false) {
       return cb()


### PR DESCRIPTION
This fixes a bug introduced in [0b9e9a](https://github.com/ethereumjs/ethereumjs-vm/commit/0b9e9a340a608cd97c5d36e9d7b50d6c3f8a97ce) that was causing [examples/run-transaction-complete](https://github.com/cdetrio/ethereumjs-vm/blob/fix-cache-del/examples/run-transactions-complete/index.js) to fail with:
```
address created: 692a70d2e424a56d2c6c27aa97d1a86395877b3a
----running tx-------
/ethereumjs-vm/examples/run-transactions-complete/index.js:74
    createdAddress = results.createdAddress
                            ^

TypeError: Cannot read property 'createdAddress' of undefined
```