### PR TITLE
EIP-141: Designated INVALID instruction

### DIFF
--- a/lib/opcodes.js
+++ b/lib/opcodes.js
@@ -149,11 +149,12 @@ const codes = {
   0xf4: ['DELEGATECALL', 700, 6, 1, true],
 
   // '0x70', range - other
+  0xfe: ['INVALID', 0, 0, 0, false],
   0xff: ['SELFDESTRUCT', 5000, 1, 0, false]
 }
 
 module.exports = function (op, full) {
-  var code = codes[op] ? codes[op] : ['INVALID', 0]
+  var code = codes[op] ? codes[op] : ['INVALID', 0, 0, 0, false]
   var opcode = code[0]
 
   if (full) {


### PR DESCRIPTION
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-141.md

Since all unknown OP code will fallback to `INVALID` pseudo instruction
https://github.com/ethereumjs/ethereumjs-vm/blob/master/lib/opcodes.js#L156

and `runCode` already handle the `opName === 'INVALID'` case, 
https://github.com/ethereumjs/ethereumjs-vm/blob/master/lib/runCode.js#L119

it's a 2 lines patch

Do i need to enable or write certain test cases to test this?
