### PR TITLE
Add nix support for local development

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+  name = "env";
+  env = buildEnv { name = name; paths = buildInputs; };
+  buildInputs = [
+    nodejs-8_x
+  ];
+}


### PR DESCRIPTION
Since we get this requirement to run the test

```
Note: Requires at least Node.js 8.0.0 installed to run the tests, this is because ethereumjs-testing uses async/await and other ES2015 language features
```

So I think we'd better get a `nix-shell` for the local development.

Just simply run `nix-shell` to get into the isolated development environment and Node-8.2.1 is already installed there.

![image](https://user-images.githubusercontent.com/6234553/28767185-501e07e4-7605-11e7-90c1-bd88b1f73b09.png)
