### PR TITLE
Limit call stack to 1024 total

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -868,7 +868,7 @@ function makeCall (runState, callOptions, localOpts, cb) {
 
   // check if account has enough ether
   // Note: in the case of delegatecall, the value is persisted and doesn't need to be deducted again
-  if (runState.depth >= fees.stackLimit.v || (callOptions.delegatecall !== true && new BN(runState.contract.balance).cmp(callOptions.value) === -1)) {
+  if (runState.depth + 1 >= fees.stackLimit.v || (callOptions.delegatecall !== true && new BN(runState.contract.balance).cmp(callOptions.value) === -1)) {
     runState.stack.push(new Buffer([0]))
     cb()
   } else {


### PR DESCRIPTION
If we do something like 

```
pragma solidity ^0.4.0;

contract Recur {
    function rec() {
      this.rec();
    }
}
```

And run a debugger, in the end it will reach 1025 frames in total (from 0th to 1024th)

<img width="105" alt="screen shot 2017-08-07 at 3 55 19 pm" src="https://user-images.githubusercontent.com/174693/29027342-f974ca20-7b88-11e7-97ea-575ff6e52b4d.png">

AFAIK EVM limit is 1024 frames in total. The problem is initial runState.depth is 0, so this change will make VM stop on 1024th frame (1023+1).
