### PR TITLE
Replace Buffer.from(bn.toArray()) with bn.toArrayLike(Buffer)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function VM (opts = {}) {
 
   if (this.opts.activatePrecompiles) {
     for (var i = 1; i <= 4; i++) {
-      this.trie.put(Buffer.from(new BN(i).toArray('be', 20)), new Account().serialize())
+      this.trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
     }
   }
 

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -14,19 +14,16 @@ module.exports = {
     runState.stopped = true
   },
   ADD: function (a, b, runState) {
-    return Buffer.from(
-      new BN(a)
+    return new BN(a)
         .iadd(new BN(b))
         .mod(utils.TWO_POW256)
-        .toArray('be', 32))
+        .toArrayLike(Buffer, 'be', 32)
   },
   MUL: function (a, b, runState) {
-    return Buffer.from(
-      new BN(a)
+    return new BN(a)
         .imul(new BN(b))
         .mod(utils.TWO_POW256)
-        .toArray('be', 32)
-    )
+        .toArrayLike(Buffer, 'be', 32)
   },
   SUB: function (a, b, runState) {
     return utils.toUnsigned(
@@ -37,39 +34,32 @@ module.exports = {
   DIV: function (a, b, runState) {
     b = new BN(b)
 
-    var r
     if (b.isZero()) {
-      r = [0]
+      return Buffer.from([0])
     } else {
       a = new BN(a)
-      r = a.div(b).toArray('be', 32)
+      return a.div(b).toArrayLike(Buffer, 'be', 32)
     }
-    return Buffer.from(r)
   },
   SDIV: function (a, b, runState) {
     b = utils.fromSigned(b)
 
-    var r
     if (b.isZero()) {
-      r = Buffer.from([0])
+      return Buffer.from([0])
     } else {
       a = utils.fromSigned(a)
-      r = utils.toUnsigned(a.div(b))
+      return utils.toUnsigned(a.div(b))
     }
-
-    return r
   },
   MOD: function (a, b, runState) {
     b = new BN(b)
-    var r
+
     if (b.isZero()) {
-      r = [0]
+      return Buffer.from([0])
     } else {
       a = new BN(a)
-      r = a.mod(b).toArray('be', 32)
+      return a.mod(b).toArrayLike(Buffer, 'be', 32)
     }
-
-    return Buffer.from(r)
   },
   SMOD: function (a, b, runState) {
     b = utils.fromSigned(b)
@@ -90,47 +80,38 @@ module.exports = {
   },
   ADDMOD: function (a, b, c, runState) {
     c = new BN(c)
-    var r
 
     if (c.isZero()) {
-      r = [0]
+      return Buffer.from([0])
     } else {
       a = new BN(a).iadd(new BN(b))
-      r = a.mod(c).toArray('be', 32)
+      return a.mod(c).toArrayLike(Buffer, 'be', 32)
     }
-
-    return Buffer.from(r)
   },
   MULMOD: function (a, b, c, runState) {
     c = new BN(c)
-    var r
 
     if (c.isZero()) {
-      r = [0]
+      return Buffer.from([0])
     } else {
       a = new BN(a).imul(new BN(b))
-      r = a.mod(c).toArray('be', 32)
+      return a.mod(c).toArrayLike(Buffer, 'be', 32)
     }
-
-    return Buffer.from(r)
   },
   EXP: function (base, exponent, runState) {
     base = new BN(base)
     exponent = new BN(exponent)
     var m = BN.red(utils.TWO_POW256)
-    var result
 
     base = base.toRed(m)
 
     if (!exponent.isZero()) {
       var bytes = 1 + logTable(exponent)
       subGas(runState, new BN(bytes).muln(fees.expByteGas.v))
-      result = Buffer.from(base.redPow(exponent).toArray('be', 32))
+      return base.redPow(exponent).toArrayLike(Buffer, 'be', 32)
     } else {
-      result = Buffer.from([1])
+      return Buffer.from([1])
     }
-
-    return result
   },
   SIGNEXTEND: function (k, val, runState) {
     k = new BN(k)
@@ -183,28 +164,24 @@ module.exports = {
     return Buffer.from([a.isZero()])
   },
   AND: function (a, b, runState) {
-    return Buffer.from(
-      new BN(a)
+    return new BN(a)
         .iand(new BN(b))
-        .toArray('be', 32))
+        .toArrayLike(Buffer, 'be', 32)
   },
   OR: function (a, b, runState) {
-    return Buffer.from(
-      new BN(a)
+    return new BN(a)
         .ior(new BN(b))
-        .toArray('be', 32))
+        .toArrayLike(Buffer, 'be', 32)
   },
   XOR: function (a, b, runState) {
-    return Buffer.from(
-      new BN(a)
+    return new BN(a)
         .ixor(new BN(b))
-        .toArray('be', 32))
+        .toArrayLike(Buffer, 'be', 32)
   },
   NOT: function (a, runState) {
-    return Buffer.from(
-      new BN(a)
+    return new BN(a)
         .inotn(256)
-        .toArray('be', 32))
+        .toArrayLike(Buffer, 'be', 32)
   },
   BYTE: function (pos, word, runState) {
     pos = new BN(pos)
@@ -456,7 +433,7 @@ module.exports = {
     return utils.intToBuffer(runState.memoryWordCount * 32)
   },
   GAS: function (runState) {
-    return Buffer.from(runState.gasLeft.toArray('be', 32))
+    return runState.gasLeft.toArrayLike(Buffer, 'be', 32)
   },
   JUMPDEST: function (runState) {},
   PUSH: function (runState) {
@@ -748,7 +725,7 @@ module.exports = {
         runState.selfdestruct[contractAddress.toString('hex')] = selfdestructToAddress
         runState.stopped = true
 
-        var newBalance = Buffer.from(new BN(contract.balance).add(new BN(toAccount.balance)).toArray())
+        var newBalance = new BN(contract.balance).add(new BN(toAccount.balance)).toArrayLike(Buffer)
         async.series([
           stateManager.putAccountBalance.bind(stateManager, selfdestructToAddress, newBalance),
           stateManager.putAccountBalance.bind(stateManager, contractAddress, new BN(0))

--- a/lib/runBlock.js
+++ b/lib/runBlock.js
@@ -117,7 +117,7 @@ module.exports = function (opts, cb) {
         var txLogs = result.vm.logs || []
         var rawTxReceipt = [
           self.trie.root,
-          Buffer.from(gasUsed.toArray()),
+          gasUsed.toArrayLike(Buffer),
           result.bloom.bitvector,
           txLogs
         ]

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -138,7 +138,7 @@ module.exports = function (opts, cb) {
       address: toAddress,
       origin: origin,
       caller: caller,
-      value: Buffer.from(txValue.toArray()),
+      value: txValue.toArrayLike(Buffer),
       block: block,
       depth: depth,
       selfdestruct: selfdestruct,

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -310,7 +310,7 @@ proto.generateGenesis = function (initState, cb) {
   var addresses = Object.keys(initState)
   async.eachSeries(addresses, function (address, done) {
     var account = new Account()
-    account.balance = Buffer.from((new BN(initState[address])).toArray())
+    account.balance = new BN(initState[address]).toArrayLike(Buffer)
     address = Buffer.from(address, 'hex')
     self.trie.put(address, account.serialize(), done)
   }, cb)


### PR DESCRIPTION
The point of this is to avoid double serialisation. Currently bn.js is serialised to a Javascript Array which is then ported into a Javascript Buffer. After this change it is directly serialised into a Buffer.