### PR TITLE
BLOCKHASH reading past genesis is handled elsewhere, so handle actual errors)

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -311,12 +311,8 @@ module.exports = {
     }
 
     stateManager.getBlockHash(number, function (err, blockHash) {
-      if (err) {
-        // if we are at a low block height and request a blockhash before the genesis block
-        cb(null, Buffer.from([0]))
-      } else {
-        cb(null, blockHash)
-      }
+      if (err) return cb(err)
+      cb(null, blockHash)
     })
   },
   COINBASE: function (runState) {


### PR DESCRIPTION
It is handled above in the `if (diff < 0)`.