### PR TITLE
proper error objects on callbacks

### DIFF
--- a/lib/runBlock.js
+++ b/lib/runBlock.js
@@ -85,7 +85,7 @@ module.exports = function (opts, cb) {
     function processTx (tx, cb) {
       var gasLimitIsHigherThanBlock = new BN(block.header.gasLimit).lt(new BN(tx.gasLimit).add(gasUsed))
       if (gasLimitIsHigherThanBlock) {
-        cb('tx has a higher gas limit than the block')
+        cb(new Error('tx has a higher gas limit than the block'))
         return
       }
 
@@ -177,7 +177,7 @@ module.exports = function (opts, cb) {
           error: err
         }
 
-        afterBlock(cb.bind(this, err, result))
+        afterBlock(cb.bind(this, new Error(err), result))
       })
     })
   }


### PR DESCRIPTION
It is a best practice to pass an error object to a callback instead of a string.

~In this pull request I updated standard (to catch this errors in the future) and removed an unnecessary `return` statement (reported by `standard`).~