### PR TITLE
Minor pre Byzantium release 2.2.2 to prevent 2.2.x breaking on ethereumjs-block update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## [2.3.0] - Unreleased
 - TODO
 
+## [2.2.2] - Unreleased
+- Fixed issues with [handling large numbers](https://github.com/ethereumjs/ethereumjs-vm/issues/167)
+  and [certain edge cases](https://github.com/ethereumjs/ethereumjs-vm/pull/188)
+- Fixed various smaller bugs and improved code consistency
+- Some VM speedups
+- Narrowed down ``ethereumjs-block`` dependency for ``2.2.x`` install still work
+  after Byzantium release
+
 ## [2.2.1] - 2017-08-04
 - Fixed bug prevent the library to be used in the browser
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-vm",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "an ethereum VM implementation",
   "main": "index.js",
   "dependencies": {
@@ -8,7 +8,7 @@
     "async-eventemitter": "^0.2.2",
     "ethereum-common": "0.1.0",
     "ethereumjs-account": "^2.0.3",
-    "ethereumjs-block": "^1.2.2",
+    "ethereumjs-block": "~1.6.0",
     "ethereumjs-util": "4.5.0",
     "fake-merkle-patricia-tree": "^1.0.1",
     "functional-red-black-tree": "^1.0.1",


### PR DESCRIPTION
This PR narrows down the ``ethereumjs-block`` dependency in ``package.json`` to ``~1.6.0`` from ``^1.2.2`` to keep the dependency version in the ``1.6.x`` range once a ``1.7.0`` Byzantium release comes out (with changes to block difficulty). The PR has to be accompanied with a minor ``ethereumjs-vm`` ``2.2.2`` release (with a date added to the changelog file).

Rationale:
Once a Byzantium-compatible ``ethereumjs-block`` library is released, the ``2.2.x`` (pre-Byzantium) series of ``ethereumjs-vm`` install will immediately break (by auto-installing the Byzantium-compatible ``ethereumjs-block`` library). This is unfavorable especially in the testing/transition period of Byzantium, when people still might want to install the older version of the library.