### PR TITLE
Reintegrate blockchain tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,10 @@ matrix:
     - os: linux
       node_js: "8"
       env: CXX=g++-4.8 TEST_SUITE=testState
-# temporarily disable testBlockchain
-#    - os: linux
-#      node_js: "8"
-#      env: CXX=g++-4.8 TEST_SUITE=testBlockchain
+    - os: linux
+      node_js: "8"
+      env: CXX=g++-4.8 TEST_SUITE=testBlockchainBlockGasLimit
+    - os: linux
+      node_js: "8"
+      env: CXX=g++-4.8 TEST_SUITE=testBlockchainTotalDifficulty
 script: npm run $TEST_SUITE

--- a/README.md
+++ b/README.md
@@ -158,48 +158,6 @@ Emits the Transaction that is about to be processed.
 #### `afterTx`
 Emits the result of the transaction.
 
-# TESTING
-
-### Running Tests
-
-_Note: Requires at least Node.js `8.0.0` installed to run the tests, this is because `ethereumjs-testing` uses `async/await` and other ES2015 language features_
-
-Tests can be found in the ``tests`` directory, with ``FORK_CONFIG`` set in ``tests/tester.js``. There are test runners for [State tests](http://www.ethdocs.org/en/latest/contracts-and-transactions/ethereum-tests/state_tests/index.html) and [Blockchain tests](http://www.ethdocs.org/en/latest/contracts-and-transactions/ethereum-tests/blockchain_tests/index.html). VM tests are disabled since Frontier gas costs are not supported any more. Tests are then executed by the [ethereumjs-testing](https://github.com/ethereumjs/ethereumjs-testing) utility library using the official client-independent [Ethereum tests](https://github.com/ethereum/tests).
-
-Running all the tests:
-
-`npm test`
-
-Running the State tests:
-
-`node ./tests/tester -s`
-
-Running the Blockchain tests:
-
-`node ./tests/tester -b`
-
-State tests run significantly faster than Blockchain tests, so it is often a good choice to start fixing State tests.
-
-Running all the blockchain tests in a file:
-
-`node ./tests/tester -b --file='randomStatetest303'`
-
-Running a specific state test case:
-
-`node ./tests/tester -s --test='stackOverflow'`
-
-For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
-or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).
-
-### Debugging
-
-Blockchain tests support `--debug` to verify the postState:
-
-`node ./tests/tester -b  --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
-
-All/most State tests are replicated as Blockchain tests in a ``GeneralStateTests`` [sub directory](https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests) in the Ethereum tests repo, so for debugging single test cases the Blockchain test version of the State test can be used.
-
-For comparing ``EVM`` traces [here](https://gist.github.com/cdetrio/41172f374ae32047a6c9e97fa9d09ad0) are some instructions for setting up ``pyethereum`` to generate corresponding traces for state tests.
 
 # Internal Structure
 The VM processes state changes at many levels.
@@ -232,6 +190,54 @@ The VM processes state changes at many levels.
   * calculate fee
 
 The opFns for `CREATE`, `CALL`, and `CALLCODE` call back up to `runCall`.
+
+
+# TESTING
+
+### Running Tests
+
+_Note: Requires at least Node.js `8.0.0` installed to run the tests, this is because `ethereumjs-testing` uses `async/await` and other ES2015 language features_
+
+Tests can be found in the ``tests`` directory, with ``FORK_CONFIG`` set in ``tests/tester.js``. There are test runners for [State tests](http://www.ethdocs.org/en/latest/contracts-and-transactions/ethereum-tests/state_tests/index.html) and [Blockchain tests](http://www.ethdocs.org/en/latest/contracts-and-transactions/ethereum-tests/blockchain_tests/index.html). VM tests are disabled since Frontier gas costs are not supported any more. Tests are then executed by the [ethereumjs-testing](https://github.com/ethereumjs/ethereumjs-testing) utility library using the official client-independent [Ethereum tests](https://github.com/ethereum/tests).
+
+Running all the tests:
+
+`npm test`
+
+Running the State tests:
+
+`node ./tests/tester -s`
+
+Running the Blockchain tests:
+
+`node ./tests/tester -b`
+
+State tests run significantly faster than Blockchain tests, so it is often a good choice to start fixing State tests.
+
+Running all the blockchain tests in a file:
+
+`node ./tests/tester -b --file='randomStatetest303'`
+
+Running tests from a specific directory:
+
+`node ./tests/tester -b --dir='bcBlockGasLimitTest'`
+
+Running a specific state test case:
+
+`node ./tests/tester -s --test='stackOverflow'`
+
+For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
+or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).
+
+### Debugging
+
+Blockchain tests support `--debug` to verify the postState:
+
+`node ./tests/tester -b  --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
+
+All/most State tests are replicated as Blockchain tests in a ``GeneralStateTests`` [sub directory](https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests) in the Ethereum tests repo, so for debugging single test cases the Blockchain test version of the State test can be used.
+
+For comparing ``EVM`` traces [here](https://gist.github.com/cdetrio/41172f374ae32047a6c9e97fa9d09ad0) are some instructions for setting up ``pyethereum`` to generate corresponding traces for state tests.
 
 
 # LICENSE

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
     - "npm rebuild"
 test:
   override:
-# testVM disabled. testBlockchain temporarily disabled
+# testVM disabled.
 #   - case $CIRCLE_NODE_INDEX in 0) npm run lint ;; 1) npm run testVM ;; 2) npm run testState ;; 3) npm run testBlockchain ;; esac:
     - case $CIRCLE_NODE_INDEX in 0) npm run lint ;; 1) npm run testState ;; esac:
         parallel: true

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "testVM": "node ./tests/tester -v",
     "testState": "node ./tests/tester -s",
     "testBlockchain": "node --stack-size=1500 ./tests/tester -b",
+    "testBlockchainBlockGasLimit": "node --stack-size=1500 ./tests/tester -b --dir='bcBlockGasLimitTest'",
+    "testBlockchainValid": "node --stack-size=1500 ./tests/tester -b --dir='bcValidBlockTest'",
+    "testBlockchainTotalDifficulty": "node --stack-size=1500 ./tests/tester -b --dir='bcTotalDifficultyTest'",
     "lint": "standard",
     "test": "node ./tests/tester -a"
   },

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -136,6 +136,8 @@ function runTests (name, runnerArgs, cb) {
   testGetterArgs.forkConfig = FORK_CONFIG
   testGetterArgs.file = argv.file
   testGetterArgs.test = argv.test
+  testGetterArgs.dir = argv.dir
+  testGetterArgs.excludeDir = argv.excludeDir
 
   runnerArgs.forkConfig = FORK_CONFIG
   runnerArgs.debug = argv.debug // for BlockchainTests


### PR DESCRIPTION
This reintegrates the blockchain tests to be run on travis builds (leaving ``BlockchainTests/GeneralStateTests``).

PR should be merged also on travis build failure since blockchain tests are failing for other reasons atm and this is just a basis for testing/fixing this.