### PR TITLE
add support for specifying tests repo path as a command line argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "testVM": "node ./tests/tester -v",
     "testState": "node ./tests/tester -s",
     "testBlockchain": "node --stack-size=1500 ./tests/tester -b",
+    "testBlockchainGeneralStateTests": "node --stack-size=1500 ./tests/tester -b --dir='GeneralStateTests'",
     "testBlockchainBlockGasLimit": "node --stack-size=1500 ./tests/tester -b --dir='bcBlockGasLimitTest'",
     "testBlockchainValid": "node --stack-size=1500 ./tests/tester -b --dir='bcValidBlockTest'",
     "testBlockchainTotalDifficulty": "node --stack-size=1500 ./tests/tester -b --dir='bcTotalDifficultyTest'",

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -138,6 +138,7 @@ function runTests (name, runnerArgs, cb) {
   testGetterArgs.test = argv.test
   testGetterArgs.dir = argv.dir
   testGetterArgs.excludeDir = argv.excludeDir
+  testGetterArgs.testsDir = argv.testsDir
 
   runnerArgs.forkConfig = FORK_CONFIG
   runnerArgs.debug = argv.debug // for BlockchainTests

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -138,7 +138,7 @@ function runTests (name, runnerArgs, cb) {
   testGetterArgs.test = argv.test
   testGetterArgs.dir = argv.dir
   testGetterArgs.excludeDir = argv.excludeDir
-  testGetterArgs.testsDir = argv.testsDir
+  testGetterArgs.testsPath = argv.testsPath
 
   runnerArgs.forkConfig = FORK_CONFIG
   runnerArgs.debug = argv.debug // for BlockchainTests


### PR DESCRIPTION
This goes hand-in-hand with https://github.com/ethereumjs/ethereumjs-testing/pull/11