### PR TITLE
Add support to test a custom state test

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ curl https://gist.githubusercontent.com/jwasinger/e7004e82426ff0a7137a88d273f118
 python utils/diffTestOutput.py output-wip-byzantium.txt output-master.txt
 ```
 
+Run a state test from a specified source file not under the ``tests`` directory:
+`node ./tests/tester -s --stateTestSource='{path_to_file}'`
+
 For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
 or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ python utils/diffTestOutput.py output-wip-byzantium.txt output-master.txt
 ```
 
 Run a state test from a specified source file not under the ``tests`` directory:
-`node ./tests/tester -s --stateTestSource='{path_to_file}'`
+`node ./tests/tester -s --customStateTest='{path_to_file}'`
 
 For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
 or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babelify": "^7.3.0",
     "ethereumjs-blockchain": "https://github.com/ethereumjs/ethereumjs-blockchain",
-    "ethereumjs-testing": "https://github.com/ethereumjs/ethereumjs-testing",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#test-from-source",
     "ethereumjs-tx": "1.3.3",
     "level": "^1.4.0",
     "leveldown": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babelify": "^7.3.0",
     "ethereumjs-blockchain": "https://github.com/ethereumjs/ethereumjs-blockchain",
-    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#test-from-source",
+    "ethereumjs-testing": "https://github.com/ethereumjs/ethereumjs-testing",
     "ethereumjs-tx": "1.3.3",
     "level": "^1.4.0",
     "leveldown": "^1.4.6",

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -185,7 +185,7 @@ function runTests (name, runnerArgs, cb) {
   testGetterArgs.excludeDir = argv.excludeDir
   testGetterArgs.testsPath = argv.testsPath
 
-  testGetterArgs.stateTestSource = argv.stateTestSource
+  testGetterArgs.customStateTest = argv.customStateTest
 
   runnerArgs.forkConfig = FORK_CONFIG
   runnerArgs.jsontrace = argv.jsontrace

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -198,7 +198,7 @@ function runTests (name, runnerArgs, cb) {
 
   // runnerArgs.vmtrace = true; // for VMTests
 
-  if (argv.stateTestSource) {
+  if (argv.customStateTest) {
     const stateTestRunner = require('./GeneralStateTestsRunner.js')
     let fileName = argv.stateTestSource
     tape(name, t => {

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -200,7 +200,7 @@ function runTests (name, runnerArgs, cb) {
 
   if (argv.customStateTest) {
     const stateTestRunner = require('./GeneralStateTestsRunner.js')
-    let fileName = argv.stateTestSource
+    let fileName = argv.customStateTest
     tape(name, t => {
       testing.getTestFromSource(fileName, (err, test) => {
         if (err) {


### PR DESCRIPTION
This PR adds the ability to test against custom-generated state tests.  The argument `--customStateTest` is used to specify the relative path of a file containing a custom test.

This PR is necessary for implementing trace equivalence testing and fuzz testing with EthereumjsVM.

Depends on changes in https://github.com/ethereumjs/ethereumjs-testing/tree/test-from-source