### PR TITLE
Utility Script to produce diff of test output between runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,14 @@ test docs), provided by the index of the array element in the test ``transaction
 
 `node tests/tester -s --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0`
 
+Compare TAP output from blockchain/state tests and produces concise diff of the differences between them (example):
+
+```
+curl https://gist.githubusercontent.com/jwasinger/6cef66711b5e0787667ceb3db6bea0dc/raw/0740f03b4ce90d0955d5aba1e0c30ce698c7145a/gistfile1.txt > output-wip-byzantium.txt
+curl https://gist.githubusercontent.com/jwasinger/e7004e82426ff0a7137a88d273f11819/raw/66fbd58722747ebe4f7006cee59bbe22461df8eb/gistfile1.txt > output-master.txt
+python utils/diffTestOutput.py output-wip-byzantium.txt output-master.txt
+```
+
 For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
 or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).
 

--- a/utils/diffTestOutput.py
+++ b/utils/diffTestOutput.py
@@ -1,0 +1,72 @@
+import sys, re
+
+'''
+given the name (or path) of a file, returns a 'summary' object containing which tests pass/fail
+'''
+def getTestSummary(f):
+  summary = {
+    'success': set(),
+    'fail': set()
+  }
+  curTestName = ''
+  fp = open(f)
+
+  for i, line in enumerate(fp):
+    if line.startswith("# file"):
+      if curTestName != '':
+        if not curTestName in summary['fail']:
+          summary['success'].add(curTestName)
+      curTestName = getTestName(line)  
+    elif line.startswith("ok"):
+      continue
+    elif line.startswith("1.."):
+      break
+    elif line.startswith("not ok"):
+      summary['fail'].add(curTestName)
+    elif line.startswith(" "):
+      if not curTestName in summary['fail']:
+        summary['fail'].add(curTestName)
+
+  return summary
+
+def getDiff(summary1, summary2):
+  all_failed = summary1['fail'] | summary2['fail'] # set union
+  all_successful = summary1['success'] | summary2['success']
+
+  print("\n\nDiff of failed tests:\n")
+  for failed_test in all_failed:
+    if not failed_test in summary2['fail']:
+      print("< "+failed_test)
+    elif not failed_test in summary1['fail']:
+      print("> "+failed_test)
+
+  print("\n\nDiff of successful tests:\n")
+  for successful_test in all_successful:
+    if not successful_test in summary2['success']:
+      print("< "+successful_test)
+    elif not successful_test in summary1['success']:
+      print("> "+successful_test)
+
+
+def getTestName(line):
+  r = re.compile("^.*test: (.*)$")
+  x = r.search(line)
+
+  if not x.group(1):
+    raise Exception(line)
+  else:
+    s = x.group(1).replace('_EIP158', '').replace('_Byzantium', '')
+    return s
+
+if __name__ == "__main__":
+  if len(sys.argv) < 3:
+    print("need two files to diff..")
+    sys.exit(-1)
+
+  file1Name = sys.argv[1]
+  file2Name = sys.argv[2]
+
+  summary1 = getTestSummary(file1Name)
+  summary2 = getTestSummary(file2Name)
+
+  getDiff(summary1, summary2)


### PR DESCRIPTION
This PR contains a script which takes two files containing TAP output from blockchain/state tests and produces concise diff of the differences between them.

Here is an example that compares the differences between the master branch and https://github.com/jwasinger/wip/metropolis (the work-in-progress branch for Byzantium implementation):
```
curl https://gist.githubusercontent.com/jwasinger/6cef66711b5e0787667ceb3db6bea0dc/raw/0740f03b4ce90d0955d5aba1e0c30ce698c7145a/gistfile1.txt > output-wip-byzantium.txt
curl https://gist.githubusercontent.com/jwasinger/e7004e82426ff0a7137a88d273f11819/raw/66fbd58722747ebe4f7006cee59bbe22461df8eb/gistfile1.txt > output-master.txt
python diffTestOutput.py output-wip-byzantium.txt output-master.txt
```
Results:
```


Diff of failed tests:

< futureUncleTimestamp2
< RPC_API_Test
< uncleHeaderAtBlock2
< twoUncle
< sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4
< correct
< oneUncleGeneration6
< oneUncleGeneration4
< oneUncleGeneration5
< oneUncleGeneration2
< oneUncleGeneration3
< uncleBloomNot0
< oneUncle
< futureUncleTimestampDifficultyDrop


Diff of successful tests:

> futureUncleTimestampDifficultyDrop
> RPC_API_Test
> oneUncle
> correct
> uncleHeaderAtBlock2
> futureUncleTimestamp2
> twoUncle
> sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4
> oneUncleGeneration6
> oneUncleGeneration4
> oneUncleGeneration5
> oneUncleGeneration2
> oneUncleGeneration3
> uncleBloomNot0

```