### PR TITLE
Avoid rustbn exceptions, check for empty values

### DIFF
--- a/lib/precompiled/06-ecadd.js
+++ b/lib/precompiled/06-ecadd.js
@@ -23,17 +23,17 @@ module.exports = function (opts) {
     return results
   }
 
-  try {
-    let returnData = ecAddPrecompile(inputHexStr)
-    results.return = Buffer.from(returnData, 'hex')
-    results.exception = 1
-  } catch (e) {
-    console.log('exception in ecAdd precompile is expected. ignore previous panic...')
-    // console.log(e)
+  let returnData = ecAddPrecompile(inputHexStr)
+
+  // check ecadd success or failure by comparing the output length
+  if (returnData.length !== 128) {
     results.return = Buffer.alloc(0)
     results.exception = 0
     results.gasUsed = new BN(opts.gasLimit)
     results.exceptionError = error.OUT_OF_GAS
+  } else {
+    results.return = Buffer.from(returnData, 'hex')
+    results.exception = 1
   }
 
   return results

--- a/lib/precompiled/07-ecmul.js
+++ b/lib/precompiled/07-ecmul.js
@@ -24,15 +24,15 @@ module.exports = function (opts) {
     return results
   }
 
-  try {
-    let returnData = ecMulPrecompile(inputHexStr)
-    results.return = Buffer.from(returnData, 'hex')
-    results.exception = 1
-  } catch (e) {
-    console.log('exception in ecMul precompile is expected. ignore previous panic...')
-    // console.log(e)
+  let returnData = ecMulPrecompile(inputHexStr)
+
+  // check ecmul success or failure by comparing the output length
+  if (returnData.length !== 128) {
     results.return = Buffer.alloc(0)
     results.exception = 0
+  } else {
+    results.return = Buffer.from(returnData, 'hex')
+    results.exception = 1
   }
 
   return results

--- a/lib/precompiled/08-ecpairing.js
+++ b/lib/precompiled/08-ecpairing.js
@@ -27,17 +27,17 @@ module.exports = function (opts) {
     return results
   }
 
-  try {
-    let returnData = ecPairingPrecompile(inputHexStr)
-    results.return = Buffer.from(returnData, 'hex')
-    results.exception = 1
-  } catch (e) {
-    console.log('exception in ecPairing precompile is expected, ignore previous panic...')
-    // console.log(e)
+  let returnData = ecPairingPrecompile(inputHexStr)
+
+  // check ecpairing success or failure by comparing the output length
+  if (returnData.length !== 64) {
     results.return = Buffer.alloc(0)
     results.gasUsed = opts.gasLimit
     results.exceptionError = error.OUT_OF_GAS
     results.exception = 0
+  } else {
+    results.return = Buffer.from(returnData, 'hex')
+    results.exception = 1
   }
 
   return results

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fake-merkle-patricia-tree": "^1.0.1",
     "functional-red-black-tree": "^1.0.1",
     "merkle-patricia-tree": "^2.1.2",
-    "rustbn.js": "~0.1.0",
+    "rustbn.js": "~0.1.1",
     "safe-buffer": "^5.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
These changes checks for empty values returned by rustbn (depends on ethereumjs/rustbn.js#5 )