### PR TITLE
[WIP] Use CircleCI over Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 
 language: node_js
 node_js:
-  - "8"
+  - "8.6"
 
 addons:
   apt:

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,8 @@
-machine:
-  node:
-    version: 8.0.0
-dependencies:
-  pre:
-    - "npm rebuild"
-test:
-  override:
-# testVM disabled.
-#   - case $CIRCLE_NODE_INDEX in 0) npm run lint ;; 1) npm run testVM ;; 2) npm run testState ;; 3) npm run testBlockchain ;; esac:
-    - case $CIRCLE_NODE_INDEX in 0) npm run testState ;; esac:
-        parallel: true
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - run: npm install && npm run testState

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,12 @@
 version: 2
 jobs:
   build:
+    working_directory: /home/circleci/project/ethereumjs-vm
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:8.6
     steps:
       - checkout
-      - run: npm install && npm run testState
+      - run: npm install 
+      #- run: npm run testState
+      - run: ls /home/circleci/project/ethereumjs-vm/node_modules/ethereumjs-testing
+      - run: npm run testState


### PR DESCRIPTION
CircleCI seems to have some key advantages over Travis:
- Being able to run builds locally: easier debugging
- Ability to specify a custom build image.

Recently we ran into an issue where NodeJS was updated to version 8.7 introducing a bug with npm that broke our build.  If we were to use a custom container for builds, we could lock down dependencies and prevent this from happening.