### PR TITLE
Split test skip list into separate "Broken", "Permanent" and "Slow" skip lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ You can change this behaviour with:
 to skip only the ``BROKEN`` and ``PERMANENT`` tests and include the ``SLOW`` tests.
 There are also the keywords ``NONE`` or ``ALL`` for convenience.
 
+It is also possible to only run the tests from the skip lists:
+
+`node tests/tester -s runSkipped=SLOW`
+
 ### Debugging
 
 Blockchain tests support `--debug` to verify the postState:

--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ _Note: Requires at least Node.js `8.0.0` installed to run the tests, this is bec
 
 Tests can be found in the ``tests`` directory, with ``FORK_CONFIG`` set in ``tests/tester.js``. There are test runners for [State tests](http://www.ethdocs.org/en/latest/contracts-and-transactions/ethereum-tests/state_tests/index.html) and [Blockchain tests](http://www.ethdocs.org/en/latest/contracts-and-transactions/ethereum-tests/blockchain_tests/index.html). VM tests are disabled since Frontier gas costs are not supported any more. Tests are then executed by the [ethereumjs-testing](https://github.com/ethereumjs/ethereumjs-testing) utility library using the official client-independent [Ethereum tests](https://github.com/ethereum/tests).
 
+For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
+or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).
+
+#### Running different Test Types
+
 Running all the tests:
 
 `npm test`
@@ -223,6 +228,8 @@ Running the Blockchain tests:
 `node ./tests/tester -b`
 
 State tests run significantly faster than Blockchain tests, so it is often a good choice to start fixing State tests.
+
+#### Running Specific Tests
 
 Running all the blockchain tests in a file:
 
@@ -242,19 +249,20 @@ test docs), provided by the index of the array element in the test ``transaction
 
 `node tests/tester -s --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0`
 
-Compare TAP output from blockchain/state tests and produces concise diff of the differences between them (example):
-
-```
-curl https://gist.githubusercontent.com/jwasinger/6cef66711b5e0787667ceb3db6bea0dc/raw/0740f03b4ce90d0955d5aba1e0c30ce698c7145a/gistfile1.txt > output-wip-byzantium.txt
-curl https://gist.githubusercontent.com/jwasinger/e7004e82426ff0a7137a88d273f11819/raw/66fbd58722747ebe4f7006cee59bbe22461df8eb/gistfile1.txt > output-master.txt
-python utils/diffTestOutput.py output-wip-byzantium.txt output-master.txt
-```
-
 Run a state test from a specified source file not under the ``tests`` directory:
 `node ./tests/tester -s --customStateTest='{path_to_file}'`
 
-For a wider picture about how to use tests to implement EIPs you can have a look at this [reddit post](https://www.reddit.com/r/ethereum/comments/6kc5g3/ethereumjs_team_is_seeking_contributors/)
-or the associated YouTube video introduction to [core development with Ethereumjs-vm](https://www.youtube.com/watch?v=L0BVDl6HZzk&feature=youtu.be).
+#### Skipping Tests
+
+There are three types of skip lists (``BROKEN``, ``PERMANENT`` and ``SLOW``) which
+can be found in ``tests/tester.js``. By default tests from all skip lists are omitted.
+
+You can change this behaviour with:
+
+`node tests/tester -s --skip=BROKEN,PERMANENT`˘
+
+to skip only the ``BROKEN`` and ``PERMANENT`` tests and include the ``SLOW`` tests.
+There are also the keywords ``NONE`` or ``ALL`` for convenience.
 
 ### Debugging
 
@@ -265,6 +273,14 @@ Blockchain tests support `--debug` to verify the postState:
 All/most State tests are replicated as Blockchain tests in a ``GeneralStateTests`` [sub directory](https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests) in the Ethereum tests repo, so for debugging single test cases the Blockchain test version of the State test can be used.
 
 For comparing ``EVM`` traces [here](https://gist.github.com/cdetrio/41172f374ae32047a6c9e97fa9d09ad0) are some instructions for setting up ``pyethereum`` to generate corresponding traces for state tests.
+
+Compare TAP output from blockchain/state tests and produces concise diff of the differences between them (example):
+
+```
+curl https://gist.githubusercontent.com/jwasinger/6cef66711b5e0787667ceb3db6bea0dc/raw/0740f03b4ce90d0955d5aba1e0c30ce698c7145a/gistfile1.txt > output-wip-byzantium.txt
+curl https://gist.githubusercontent.com/jwasinger/e7004e82426ff0a7137a88d273f11819/raw/66fbd58722747ebe4f7006cee59bbe22461df8eb/gistfile1.txt > output-master.txt
+python utils/diffTestOutput.py output-wip-byzantium.txt output-master.txt
+```
 
 
 # LICENSE

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -206,7 +206,8 @@ function getSkipTests (choices, defaultChoice) {
 function runTests (name, runnerArgs, cb) {
   let testGetterArgs = {}
 
-  testGetterArgs.skipTests = getSkipTests(argv.skip, 'ALL')
+  testGetterArgs.skipTests = getSkipTests(argv.skip, argv.runSkipped ? 'NONE' : 'ALL')
+  testGetterArgs.runSkipped = getSkipTests(argv.runSkipped, 'NONE')
   testGetterArgs.skipVM = skipVM
   testGetterArgs.forkConfig = FORK_CONFIG
   testGetterArgs.file = argv.file
@@ -255,8 +256,14 @@ function runTests (name, runnerArgs, cb) {
             test.testName = testName
             runner(runnerArgs, test, t, resolve)
           } else {
-            t.comment(`file: ${fileName} test: ${testName}`)
-            runner(runnerArgs, test, t, resolve)
+            let runSkipped = testGetterArgs.runSkipped
+            let inRunSkipped = runSkipped.includes(fileName)
+            if (runSkipped.length === 0 || inRunSkipped) {
+              t.comment(`file: ${fileName} test: ${testName}`)
+              runner(runnerArgs, test, t, resolve)
+            } else {
+              resolve()
+            }
           }
         }).catch(err => console.log(err))
       }, testGetterArgs).then(() => {

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -181,10 +181,32 @@ function randomized (stateTest) {
   })
 }
 
+function getSkipTests (choices, defaultChoice) {
+  let skipTests = []
+  if (!choices) {
+    choices = defaultChoice
+  }
+  choices = choices.toLowerCase()
+  if (choices !== 'none') {
+    let choicesList = choices.split(',')
+    let all = choicesList.includes('all')
+    if (all || choicesList.includes('broken')) {
+      skipTests = skipTests.concat(skipBroken)
+    }
+    if (all || choicesList.includes('permanent')) {
+      skipTests = skipTests.concat(skipPermanent)
+    }
+    if (all || choicesList.includes('slow')) {
+      skipTests = skipTests.concat(skipSlow)
+    }
+  }
+  return skipTests
+}
+
 function runTests (name, runnerArgs, cb) {
   let testGetterArgs = {}
-  let skipTests = skipBroken.concat(skipPermanent).concat(skipSlow)
-  testGetterArgs.skipTests = skipTests
+
+  testGetterArgs.skipTests = getSkipTests(argv.skip, 'ALL')
   testGetterArgs.skipVM = skipVM
   testGetterArgs.forkConfig = FORK_CONFIG
   testGetterArgs.file = argv.file

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -3,9 +3,9 @@ const async = require('async')
 const tape = require('tape')
 const testing = require('ethereumjs-testing')
 const FORK_CONFIG = argv.fork || 'Byzantium'
-const skip = [
+// tests which should be fixed
+const skipBroken = [
   'CreateHashCollision', // impossible hash collision on generating address
-  'SuicidesMixingCoinbase', // sucides to the coinbase, since we run a blockLevel we create coinbase account.
   'TransactionMakeAccountBalanceOverflow',
   'RecursiveCreateContracts',
   'sha3_bigSize',
@@ -13,6 +13,48 @@ const skip = [
   'mload32bitBound_return',
   'mload32bitBound_return2',
   'QuadraticComplexitySolidity_CallDataCopy', // tests hash collisoin, sending from a contract
+  'uncleBlockAtBlock3AfterBlock3',
+  'ForkUncle', // correct behaviour unspecified (?)
+  'UncleFromSideChain', // same as ForkUncle, the TD is the same for two diffent branches so its not clear which one should be the finally chain
+  'bcSimpleTransitionTest', // HF stuff
+  'CALL_Bounds', // nodejs crash
+  'CALLCODE_Bounds', // nodejs crash
+  'CREATE_Bounds', // nodejs crash
+  'CreateCollisionToEmpty', // temporary till fixed (2017-09-21)
+  'TransactionCollisionToEmptyButCode', // temporary till fixed (2017-09-21)
+  'TransactionCollisionToEmptyButNonce', // temporary till fixed (2017-09-21)
+  'randomStatetest642', // temporary till fixed (2017-09-25)
+  'DELEGATECALL_Bounds', // nodejs crash
+  'RevertDepthCreateAddressCollision', // test case is wrong
+  'zeroSigTransactionInvChainID', // metropolis test
+  'randomStatetest643',
+  'static_CreateHashCollision', // impossible hash collision on generating address
+  'static_TransactionMakeAccountBalanceOverflow',
+  'static_RecursiveCreateContracts',
+  'static_sha3_bigSize',
+  'static_createJS_ExampleContract', // creates an account that already exsists
+  'static_mload32bitBound_return',
+  'static_mload32bitBound_return2',
+  'static_QuadraticComplexitySolidity_CallDataCopy', // tests hash collisoin, sending from a contract
+  'static_uncleBlockAtBlock3AfterBlock3',
+  'static_ForkUncle', // correct behaviour unspecified (?)
+  'static_UncleFromSideChain', // same as ForkUncle, the TD is the same for two diffent branches so its not clear which one should be the finally chain
+  'static_bcSimpleTransitionTest', // HF stuff
+  'static_CALL_Bounds', // nodejs crash
+  'static_CALLCODE_Bounds', // nodejs crash
+  'static_CREATE_Bounds', // nodejs crash
+  'static_DELEGATECALL_Bounds', // nodejs crash
+  'static_RevertDepthCreateAddressCollision', // test case is wrong
+  'static_zeroSigTransactionInvChainID', // metropolis test
+  'zeroSigTransactionInvChainID' // metropolis test
+]
+// tests skipped due to system specifics / design considerations
+const skipPermanent = [
+  'SuicidesMixingCoinbase', // sucides to the coinbase, since we run a blockLevel we create coinbase account.
+  'static_SuicidesMixingCoinbase' // sucides to the coinbase, since we run a blockLevel we create coinbase account.
+]
+// tests running slow (run from time to time)
+const skipSlow = [
   'Call50000', // slow
   'Call50000_ecrec', // slow
   'Call50000_identity', // slow
@@ -32,30 +74,6 @@ const skip = [
   'Callcode50000', // slow
   'Return50000', // slow
   'Return50000_2', // slow
-  'uncleBlockAtBlock3AfterBlock3',
-  'ForkUncle', // correct behaviour unspecified (?)
-  'UncleFromSideChain', // same as ForkUncle, the TD is the same for two diffent branches so its not clear which one should be the finally chain
-  'bcSimpleTransitionTest', // HF stuff
-  'CALL_Bounds', // nodejs crash
-  'CALLCODE_Bounds', // nodejs crash
-  'CREATE_Bounds', // nodejs crash
-  'CreateCollisionToEmpty', // temporary till fixed (2017-09-21)
-  'TransactionCollisionToEmptyButCode', // temporary till fixed (2017-09-21)
-  'TransactionCollisionToEmptyButNonce', // temporary till fixed (2017-09-21)
-  'randomStatetest642', // temporary till fixed (2017-09-25)
-  'DELEGATECALL_Bounds', // nodejs crash
-  'RevertDepthCreateAddressCollision', // test case is wrong
-  'zeroSigTransactionInvChainID', // metropolis test
-  'randomStatetest643',
-  'static_CreateHashCollision', // impossible hash collision on generating address
-  'static_SuicidesMixingCoinbase', // sucides to the coinbase, since we run a blockLevel we create coinbase account.
-  'static_TransactionMakeAccountBalanceOverflow',
-  'static_RecursiveCreateContracts',
-  'static_sha3_bigSize',
-  'static_createJS_ExampleContract', // creates an account that already exsists
-  'static_mload32bitBound_return',
-  'static_mload32bitBound_return2',
-  'static_QuadraticComplexitySolidity_CallDataCopy', // tests hash collisoin, sending from a contract
   'static_Call50000', // slow
   'static_Call50000_ecrec', // slow
   'static_Call50000_identity', // slow
@@ -67,18 +85,7 @@ const skip = [
   'static_Call1MB1024Calldepth', // slow
   'static_Callcode50000', // slow
   'static_Return50000', // slow
-  'static_Return50000_2', // slow
-  'static_uncleBlockAtBlock3AfterBlock3',
-  'static_ForkUncle', // correct behaviour unspecified (?)
-  'static_UncleFromSideChain', // same as ForkUncle, the TD is the same for two diffent branches so its not clear which one should be the finally chain
-  'static_bcSimpleTransitionTest', // HF stuff
-  'static_CALL_Bounds', // nodejs crash
-  'static_CALLCODE_Bounds', // nodejs crash
-  'static_CREATE_Bounds', // nodejs crash
-  'static_DELEGATECALL_Bounds', // nodejs crash
-  'static_RevertDepthCreateAddressCollision', // test case is wrong
-  'static_zeroSigTransactionInvChainID', // metropolis test
-  'zeroSigTransactionInvChainID' // metropolis test
+  'static_Return50000_2' // slow
 ]
 
 /*
@@ -176,7 +183,8 @@ function randomized (stateTest) {
 
 function runTests (name, runnerArgs, cb) {
   let testGetterArgs = {}
-  testGetterArgs.skipTests = skip
+  let skipTests = skipBroken.concat(skipPermanent).concat(skipSlow)
+  testGetterArgs.skipTests = skipTests
   testGetterArgs.skipVM = skipVM
   testGetterArgs.forkConfig = FORK_CONFIG
   testGetterArgs.file = argv.file


### PR DESCRIPTION
This should largely help to bring failing tests from the skip lists under control. PR shouldn't also be too problematic since existing behavior of running tests with currently existing arguments stays the same.

The PR splits the existing tests skip list into three separate lists:

- ``BROKEN``: for tests which should be fixed
- ``PERMANENT``: for tests skipped due to system specifics / design considerations
- ``SLOW``: for tests running slow (run from time to time)

At the same time two new testing CL args are introduced, ``skip`` for skipping tests from one or more of the lists and ``runSkipped`` for only run the skipped-list tests.

These can be used like this:

```
node tests/tester -s --skip=BROKEN,PERMANENT
node tests/tester -s --runSkipped=SLOW
```

This allows for scenarios like only running the currently broken tests or include the slow tests from time-to-time and should overall improve library quality and ease fixing tests from the skip list.

Note:
This PR doesn't touch the entries from the skip list itself - apart from some rough sorting into the new different skip lists.