### PR TITLE
Fixes randomStatetest643 exception

### DIFF
--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -160,6 +160,12 @@ module.exports = function (opts, cb) {
         var totalGas = results.gasUsed
         if (!results.runState.vmError) {
           var returnFee = results.return.length * fees.createDataGas.v
+
+          // avoid BN assertion failure when returnFee is greater than 0x4000000
+          if (returnFee > gasLimit.toNumber()) {
+            returnFee = gasLimit.toNumber() + 1
+          }
+
           totalGas = totalGas.addn(returnFee)
         }
         // if not enough gas

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -12,8 +12,7 @@ const skipBroken = [
   'TransactionCollisionToEmptyButCode', // temporary till fixed (2017-09-21)
   'TransactionCollisionToEmptyButNonce', // temporary till fixed (2017-09-21)
   'RevertDepthCreateAddressCollision', // test case is wrong
-  'randomStatetest642', // BROKEN, rustbn.js error
-  'randomStatetest643' // BROKEN, breaks tests run (leave at the end), rustbn.js error
+  'randomStatetest642' // BROKEN, rustbn.js error
 ]
 // tests skipped due to system specifics / design considerations
 const skipPermanent = [


### PR DESCRIPTION
Current exception in randomStatetest is because an assertion in the bn.js module, it checks that the number to be added is less than 0x4000000

https://github.com/indutny/bn.js/blob/master/lib/bn.js#L2129

These changes checks returnFee, if its greater than gasLimit set it as gasLimit + 1, this avoids BN assertion failure when returnFee is bigger than 0x4000000 and ending as an OOG exception as expected.

Closes https://github.com/ethereumjs/ethereumjs-vm/issues/195