### PR TITLE
Emit tx log step after cache is flushed

### DIFF
--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -43,14 +43,7 @@ module.exports = function (opts, cb) {
     runTxHook,
     runCall,
     saveTries,
-    function (cb) {
-      self.stateManager.cache.flush(function () {
-        if (opts.populateCache) {
-          self.stateManager.cache.clear()
-        }
-        cb()
-      })
-    },
+    flushCache,
     runAfterTxHook
   ], function (err) {
     cb(err, results)
@@ -207,6 +200,15 @@ module.exports = function (opts, cb) {
 
   function saveTries (cb) {
     self.stateManager.commitContracts(cb)
+  }
+
+  function flushCache (cb) {
+    self.stateManager.cache.flush(function () {
+      if (opts.populateCache) {
+        self.stateManager.cache.clear()
+      }
+      cb()
+    })
   }
 }
 

--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -43,7 +43,6 @@ module.exports = function (opts, cb) {
     runTxHook,
     runCall,
     saveTries,
-    runAfterTxHook,
     function (cb) {
       self.stateManager.cache.flush(function () {
         if (opts.populateCache) {
@@ -51,7 +50,8 @@ module.exports = function (opts, cb) {
         }
         cb()
       })
-    }
+    },
+    runAfterTxHook
   ], function (err) {
     cb(err, results)
   })


### PR DESCRIPTION
Otherwise, the resulting trie is incorrect (because contents in the cache are not included if they are not flushed)