### PR TITLE
Fix #81 by checking it.value is valid

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -87,7 +87,7 @@ Cache.prototype.flush = function (cb) {
   async.whilst(function () {
     return next
   }, function (done) {
-    if (it.value.modified) {
+    if (it.value && it.value.modified) {
       it.value.modified = false
       it.value.val = it.value.val.serialize()
       self._trie.put(Buffer.from(it.key, 'hex'), it.value.val, function () {


### PR DESCRIPTION
Tests pass, so looks like the trivial workaround doesn't break anything below.
  