### PR TITLE
[WIP] Switched to commit-versioned ethereumjs-testing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babelify": "^7.3.0",
     "ethereumjs-blockchain": "~2.1.0",
-    "ethereumjs-testing": "https://github.com/ethereumjs/ethereumjs-testing",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#15a72e5",
     "ethereumjs-tx": "1.3.3",
     "level": "^1.4.0",
     "leveldown": "^1.4.6",


### PR DESCRIPTION
Imminent due to CircleCI tests currently breaking on first run which can only be fixed by re-run with "Rebuild without Cache", which is annoying.

This generally helps with:
- Better TravisCI cache handling
- More predictive/deterministic testing

See also discussion here: https://github.com/ethereumjs/ethereumjs-vm/pull/244#issuecomment-360449191