### PR TITLE
Remove all ES6 features

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,8 @@ VM.deps = {
  * @param {Blockchain} [opts.blockchain] A blockchain object for storing/retrieving blocks (ignored if stateManager is passed)
  * @param {Boolean} [opts.activatePrecompiles] Create entries in the state tree for the precompiled contracts
  */
-function VM (opts = {}) {
+function VM (opts) {
+  opts = opts || {}
   this.opts = opts
 
   if (opts.stateManager) {

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -871,7 +871,7 @@ function memStore (runState, offset, val, valOffset, length, skipSubMem) {
     safeLen = val.length
   }
 
-  let i = 0
+  var i = 0
   if (safeLen > 0) {
     safeLen = safeLen > length ? length : safeLen
     for (; i < safeLen; i++) {

--- a/lib/precompiled/06-ecadd.js
+++ b/lib/precompiled/06-ecadd.js
@@ -10,9 +10,9 @@ const ecAddPrecompile = bn128Module.cwrap('ec_add', 'string', ['string'])
 module.exports = function (opts) {
   assert(opts.data)
 
-  let results = {}
-  let data = opts.data
-  let inputHexStr = data.toString('hex')
+  var results = {}
+  var data = opts.data
+  var inputHexStr = data.toString('hex')
 
   results.gasUsed = new BN(fees.ecAddGas.v)
   if (opts.gasLimit.lt(results.gasUsed)) {
@@ -23,7 +23,7 @@ module.exports = function (opts) {
     return results
   }
 
-  let returnData = ecAddPrecompile(inputHexStr)
+  var returnData = ecAddPrecompile(inputHexStr)
 
   // check ecadd success or failure by comparing the output length
   if (returnData.length !== 128) {

--- a/lib/precompiled/07-ecmul.js
+++ b/lib/precompiled/07-ecmul.js
@@ -10,10 +10,10 @@ const ecMulPrecompile = bn128Module.cwrap('ec_mul', 'string', ['string'])
 module.exports = function (opts) {
   assert(opts.data)
 
-  let results = {}
-  let data = opts.data
+  var results = {}
+  var data = opts.data
 
-  let inputHexStr = data.toString('hex')
+  var inputHexStr = data.toString('hex')
   results.gasUsed = new BN(fees.ecMulGas.v)
 
   if (opts.gasLimit.lt(results.gasUsed)) {
@@ -24,7 +24,7 @@ module.exports = function (opts) {
     return results
   }
 
-  let returnData = ecMulPrecompile(inputHexStr)
+  var returnData = ecMulPrecompile(inputHexStr)
 
   // check ecmul success or failure by comparing the output length
   if (returnData.length !== 128) {

--- a/lib/precompiled/08-ecpairing.js
+++ b/lib/precompiled/08-ecpairing.js
@@ -10,14 +10,14 @@ const ecPairingPrecompile = bn128Module.cwrap('ec_pairing', 'string', ['string']
 module.exports = function (opts) {
   assert(opts.data)
 
-  let results = {}
-  let data = opts.data
+  var results = {}
+  var data = opts.data
 
-  let inputHexStr = data.toString('hex')
-  let inputData = Buffer.from(inputHexStr, 'hex')
-  let inputDataSize = Math.floor(inputData.length / 192)
+  var inputHexStr = data.toString('hex')
+  var inputData = Buffer.from(inputHexStr, 'hex')
+  var inputDataSize = Math.floor(inputData.length / 192)
 
-  const gascost = fees.ecPairingGas.v + (inputDataSize * fees.ecPairingWordGas.v)
+  var gascost = fees.ecPairingGas.v + (inputDataSize * fees.ecPairingWordGas.v)
   results.gasUsed = new BN(gascost)
 
   if (opts.gasLimit.ltn(gascost)) {
@@ -27,7 +27,7 @@ module.exports = function (opts) {
     return results
   }
 
-  let returnData = ecPairingPrecompile(inputHexStr)
+  var returnData = ecPairingPrecompile(inputHexStr)
 
   // check ecpairing success or failure by comparing the output length
   if (returnData.length !== 64) {


### PR DESCRIPTION
If the library is included in a project that uses create-react-app, the following error will be thrown when built:

```
Creating an optimized production build...
Failed to compile.

Failed to minify the code from this file:

 	./node_modules/ethereumjs-vm/lib/index.js:37

Read more here: http://bit.ly/2tRViJ9
```

The magnification expects all packages to be ES5. This package is almost entirely ES5 with the exception of a few `let`/`const` declarations and a default parameter.

This PR changes those lines back to ES5.