### PR TITLE
Move initial iterateVm checks to after step hook

### DIFF
--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -116,20 +116,6 @@ module.exports = function (opts, cb) {
     runState.opName = opName
     runState.opCode = opCode
 
-    // check for invalid opcode
-    if (opName === 'INVALID') {
-      return done(new VmError(ERROR.INVALID_OPCODE))
-    }
-
-    // check for stack underflows
-    if (runState.stack.length < opInfo.in) {
-      return done(new VmError(ERROR.STACK_UNDERFLOW))
-    }
-
-    if ((runState.stack.length - opInfo.in + opInfo.out) > 1024) {
-      return done(new VmError(ERROR.STACK_OVERFLOW))
-    }
-
     async.series([
       runStepHook,
       runOp
@@ -153,6 +139,20 @@ module.exports = function (opts, cb) {
     }
 
     function runOp (cb) {
+      // check for invalid opcode
+      if (opName === 'INVALID') {
+        return cb(new VmError(ERROR.INVALID_OPCODE))
+      }
+
+      // check for stack underflows
+      if (runState.stack.length < opInfo.in) {
+        return cb(new VmError(ERROR.STACK_UNDERFLOW))
+      }
+
+      if ((runState.stack.length - opInfo.in + opInfo.out) > 1024) {
+        return cb(new VmError(ERROR.STACK_OVERFLOW))
+      }
+
       // calculate gas
       var fee = new BN(opInfo.fee)
       // TODO: move to a shared funtion; subGas in opFuns


### PR DESCRIPTION
To ensure those conditions still generate a valid step for `runStepHook` handler.

The initial checks otherwise prevent certain situations from generating steps (e.g. for trace output)