### PR TITLE
Add option to ignore EIP 170 for debugging purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Creates a new VM object
   - `state` - A merkle-patricia-tree instance for the state tree (ignored if `stateManager` is passed)
   - `blockchain` - A blockchain object for storing/retrieving blocks (ignored if `stateManager` is passed)
   - `activatePrecompiles` - Create entries in the state tree for the precompiled contracts
+  - `allowUnlimitedContractSize` - Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 2KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. (default: `false`; **ONLY** set to `true` during debugging).
 
 ### `VM` methods
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ VM.deps = {
  * @param {Trie} [opts.state] A merkle-patricia-tree instance for the state tree (ignored if stateManager is passed)
  * @param {Blockchain} [opts.blockchain] A blockchain object for storing/retrieving blocks (ignored if stateManager is passed)
  * @param {Boolean} [opts.activatePrecompiles] Create entries in the state tree for the precompiled contracts
+ * @param {Boolean} [opts.allowUnlimitedContractSize] Allows unlimited contract sizes while debugging (default: false; ONLY use during debugging)
  */
 function VM (opts = {}) {
   this.opts = opts
@@ -44,6 +45,8 @@ function VM (opts = {}) {
       blockchain: opts.blockchain
     })
   }
+
+  this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
 
   // temporary
   // this is here for a gradual transition to StateManager

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -164,7 +164,7 @@ module.exports = function (opts, cb) {
           totalGas = totalGas.add(returnFee)
         }
         // if not enough gas
-        if (totalGas.lte(gasLimit) && results.return.length <= 24576) {
+        if (totalGas.lte(gasLimit) && (self.allowUnlimitedContractSize || results.return.length <= 24576)) {
           results.gasUsed = totalGas
         } else {
           results.return = Buffer.alloc(0)


### PR DESCRIPTION
I'm creating a real-time Solidity debugger runtime for an [Augur bounty](https://github.com/augurProject/augur-bounties#-bounty-2-portable-solidity-debugger).

To do this sanely, compiler optimization needs to be turned off for the developer to be follow a logical stepping process; otherwise it's possible for the compiler to optimize things away and cause unexpected behavior from a debugging perspective.

Unfortunately, turning off optimization can mean very large compiled contracts. [EIP 170](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md) prevents contracts with more than `0x6000` bytes (or 24KB) from being created. The rationale for EIP 170 (as I interpreted it) was really to address scaling from a global perspective, however I can see it acceptable to allow users to ignore EIP 170, specifically for debugging purposes.

This PR adds the option for ignoring EIP 170.