### PR TITLE
Add Gas Refund to Transaction Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Process a transaction.
 - `opts.block` - The block to which the `tx` belongs. If omitted a blank block will be used.
 - `cb` - The callback. It is given two arguments, an `error` string containing an error that may have happened or `null`, and a `results` object with the following properties:
   - `amountSpent` - the amount of ether used by this transaction as a `bignum`
-  - `gasUsed` - the amount of gas used by the transaction
+  - `gasUsed` - the amount of gas as a `bignum` used by the transaction
+  - `gasRefund` - the amount of gas as a `bignum` that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
   - `vm` - contains the results from running the code, if any, as described in [`vm.runCode(params, cb)`](#vmruncodeopts-cb)
 
 --------------------------------------------------------
@@ -107,7 +108,7 @@ Runs EVM code
 - `cb` - The callback. It is given two arguments, an `error` string containing an error that may have happened or `null` and a `results` object with the following properties
   - `gas` - the amount of gas left as a `bignum`
   - `gasUsed` - the amount of gas as a `bignum` the code used to run.
-  - `gasRefund` - a `Bignum` containing the amount of gas to refund from deleting storage values
+  - `gasRefund` - a `bignum` containing the amount of gas to refund from deleting storage values
   - `selfdestruct` - an `Object` with keys for accounts that have selfdestructed and values for balance transfer recipient accounts.
   - `logs` - an `Array` of logs that the contract emitted.
   - `exception` - `0` if the contract encountered an exception, `1` otherwise.

--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -138,10 +138,10 @@ module.exports = function (opts, cb) {
       results.gasUsed = results.gasUsed.add(basefee)
 
       // process any gas refund
-      var gasRefund = results.vm.gasRefund
-      if (gasRefund) {
-        if (gasRefund.lt(results.gasUsed.divn(2))) {
-          results.gasUsed.isub(gasRefund)
+      results.gasRefund = results.vm.gasRefund
+      if (results.gasRefund) {
+        if (results.gasRefund.lt(results.gasUsed.divn(2))) {
+          results.gasUsed.isub(results.gasRefund)
         } else {
           results.gasUsed.isub(results.gasUsed.divn(2))
         }


### PR DESCRIPTION
Fixes #283

Excerpt to #283 that this PR implements:
> I can see why we shouldn't change the reported gasUsed, because it's the amount of net gas that was removed from the sending account. However, ethereumjs-vm should at a minimum report the gasRefund to let callers know that additional gas may be needed to actually execute the transaction. I believe this proposal makes sense, but I'd love to talk alternatives if it's not quite right. I'm going to go ahead open a PR that implements this proposal.