### PR TITLE
Created contract accounts should have nonce 1 and storage empty

### DIFF
--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -70,11 +70,16 @@ module.exports = function (opts, cb) {
       txData = undefined
       var newNonce = new BN(account.nonce).subn(1)
       createdAddress = toAddress = ethUtil.generateAddress(caller, newNonce.toArray())
-      stateManager.getAccount(createdAddress, function (err, account) {
-        toAccount = account
-        const NONCE_OFFSET = 1
-        toAccount.nonce = new BN(toAccount.nonce).addn(NONCE_OFFSET).toArrayLike(Buffer)
-        done(err)
+      stateManager.clearContractStorage(createdAddress, function (err) {
+        if (err) {
+          done(err)
+        }
+
+        stateManager.getAccount(createdAddress, function (err, account) {
+          toAccount = account
+          toAccount.nonce = new BN(1).toArrayLike(Buffer)
+          done(err)
+        })
       })
     } else {
       // else load the `to` account

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -160,21 +160,14 @@ proto.getContractStorage = function (address, key, cb) {
   })
 }
 
-proto.putContractStorage = function (address, key, value, cb) {
+proto._modifyContractStorage = function (address, modifyTrie, cb) {
   var self = this
   self._getStorageTrie(address, function (err, storageTrie) {
     if (err) {
       return cb(err)
     }
 
-    if (value && value.length) {
-      // format input
-      var encodedValue = rlp.encode(value)
-      storageTrie.put(key, encodedValue, finalize)
-    } else {
-      // deleting a value
-      storageTrie.del(key, finalize)
-    }
+    modifyTrie(storageTrie, finalize)
 
     function finalize (err) {
       if (err) return cb(err)
@@ -187,6 +180,28 @@ proto.putContractStorage = function (address, key, value, cb) {
       self._touched.add(address.toString('hex'))
     }
   })
+}
+
+proto.putContractStorage = function (address, key, value, cb) {
+  var self = this
+  self._modifyContractStorage(address, function (storageTrie, done) {
+    if (value && value.length) {
+      // format input
+      var encodedValue = rlp.encode(value)
+      storageTrie.put(key, encodedValue, done)
+    } else {
+      // deleting a value
+      storageTrie.del(key, done)
+    }
+  }, cb)
+}
+
+proto.clearContractStorage = function (address, cb) {
+  var self = this
+  self._modifyContractStorage(address, function (storageTrie, done) {
+    storageTrie.root = storageTrie.EMPTY_TRIE_ROOT
+    done()
+  }, cb)
 }
 
 proto.commitContracts = function (cb) {


### PR DESCRIPTION
Fixes test RevertInCreateInInit for #272 as per eq. 79 of the yellow paper. I wasn't entirely sure if any explicit cleanup of the storage trie was required but the tests do indeed all pass now 🎉  

I've done the cleanup in `stateManager` to ensure all storage tries and the cache are maintained correctly. This makes the change a bit more verbose but hopefully a little bit more stable. I've also refactoring the common elements of `stateManager.putContractStorage()` and the new method `stateManager.clearContractStorage()` into a private method `_modifyContractStorage`.