### PR TITLE
hooked - add instantiators as Vm class members

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,3 +96,10 @@ VM.prototype.loadCompiled = function (address, src, cb) {
 VM.prototype.populateCache = function (addresses, cb) {
   this.stateManager.warmCache(addresses, cb)
 }
+
+/**
+ * Specialized VM instantiators
+ */
+
+VM.createHookedVm = require('./hooked.js')
+VM.fromWeb3Provider = require('./hooked.js').fromWeb3Provider


### PR DESCRIPTION
At some point the module deploy process changed, and the source files are no longer distributed. In order to access the hookedVm instantiators, I added them onto the Class as methods.