### PR TITLE
Add option to emit 'newContract' events

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ To build for standalone use in the browser, install `browserify` and check [run-
     - [`vm.runCode(opts, cb)`](#vmruncodeopts-cb)
     - [`vm.generateCanonicalGenesis(cb)`](#vmgeneratecanonicalgenesiscb)
     - [`vm.generateGenesis(cb)`](#vmgenerategenesiscb)
-  - [`VM` debugging hooks](#vm-debugging-hooks)
-    - [`vm.onStep`](#vmonstep)
-    - [`newContract` event](#newcontract)
+  - [`VM` Events](#events)
+    - [`step`](#step)
+    - [`newContract`](#newcontract)
+    - [`beforeBlock`](#beforeblock)
+    - [`afterBlock`](#afterblock)
+    - [`beforeTx`](#beforetx)
+    - [`afterTx`](#aftertx)
 
 ### `new VM([opts])`
 Creates a new VM object
@@ -141,7 +145,7 @@ vm.generateGenesis(genesisData, function(){
 ```
 
 ### `events`
-All events are instances of [async-eventemmiter](https://www.npmjs.com/package/async-eventemitter). If an event handler has an arity of 2 the VM will pause until the callback is called
+All events are instances of [async-eventemmiter](https://www.npmjs.com/package/async-eventemitter). If an event handler has an arity of 2 the VM will pause until the callback is called, otherwise the VM will treat the event handler as a synchronous function.
 
 #### `step`
 The `step` event is given an `Object` and callback. The `Object` has the following properties.
@@ -160,7 +164,6 @@ The `step` event is given an `Object` and callback. The `Object` has the followi
 The `newContract` event is given an `Object` and callback. The `Object` has the following properties.
 - `address`: The created address for the new contract (type `Buffer | Uint8Array`)
 - `code`: The deployment bytecode for reference (type `Buffer | Uint8Array`)
-If a listener is added for the `newContract` event with the callback function (e.g. `evm.on('newContract', function(data, callback))`), `ethereumjs-vm` will not continue until the callback function is called. If the callback function is omitted (e.g. `evm.on('newContract', function(data))`), `ethereumjs-vm` will treat the function as a synchronous one and continue after it finishes.
 
 #### `beforeBlock`
 Emits the block that is about to be processed.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To build for standalone use in the browser, install `browserify` and check [run-
     - [`vm.generateGenesis(cb)`](#vmgenerategenesiscb)
   - [`VM` debugging hooks](#vm-debugging-hooks)
     - [`vm.onStep`](#vmonstep)
+    - [`newContract` event](#newcontract)
 
 ### `new VM([opts])`
 Creates a new VM object
@@ -61,12 +62,6 @@ Creates a new VM object
   - `blockchain` - A blockchain object for storing/retrieving blocks (ignored if `stateManager` is passed)
   - `activatePrecompiles` - Create entries in the state tree for the precompiled contracts
   - `allowUnlimitedContractSize` - Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 2KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. (default: `false`; **ONLY** set to `true` during debugging).
-  - `emitNewContractEvents` - Emits a `newContract` event after a new contract address is created, but before the contract deployment code (and constructor) is executed. This allows for libraries to handle the new address prior to the code being executed. (default: `false`).
-    - The `newContract` event will have the following parameters:
-      - `object`
-        - `address`: The created address for the new contract (type `Buffer | Uint8Array`)
-        - `code`: The deployment bytecode for reference (type `Buffer | Uint8Array`)
-      - `Function`: A callback function to notify the VM that it may continue on with executing the deployment code. The VM **will wait** for this callback to be called, so be sure to call it if you set `emitNewContractEvents` to true
 
 ### `VM` methods
 
@@ -160,6 +155,12 @@ The `step` event is given an `Object` and callback. The `Object` has the followi
 - `depth` - the current number of calls deep the contract is
 - `memory` - the memory of the VM as a `buffer`
 - `cache` - The account cache. Contains all the accounts loaded from the trie. It is an instance of [functional red black tree](https://www.npmjs.com/package/functional-red-black-tree)
+
+#### `newContract`
+The `newContract` event is given an `Object` and callback. The `Object` has the following properties.
+- `address`: The created address for the new contract (type `Buffer | Uint8Array`)
+- `code`: The deployment bytecode for reference (type `Buffer | Uint8Array`)
+If a listener is added for the `newContract` event with the callback function (e.g. `evm.on('newContract', function(data, callback))`), `ethereumjs-vm` will not continue until the callback function is called. If the callback function is omitted (e.g. `evm.on('newContract', function(data))`), `ethereumjs-vm` will treat the function as a synchronous one and continue after it finishes.
 
 #### `beforeBlock`
 Emits the block that is about to be processed.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Creates a new VM object
   - `blockchain` - A blockchain object for storing/retrieving blocks (ignored if `stateManager` is passed)
   - `activatePrecompiles` - Create entries in the state tree for the precompiled contracts
   - `allowUnlimitedContractSize` - Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 2KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. (default: `false`; **ONLY** set to `true` during debugging).
+  - `emitNewContractEvents` - Emits a `newContract` event after a new contract address is created, but before the contract deployment code (and constructor) is executed. This allows for libraries to handle the new address prior to the code being executed. (default: `false`).
+    - The `newContract` event will have the following parameters:
+      - `object`
+        - `address`: The created address for the new contract (type `Buffer | Uint8Array`)
+        - `code`: The deployment bytecode for reference (type `Buffer | Uint8Array`)
+      - `Function`: A callback function to notify the VM that it may continue on with executing the deployment code. The VM **will wait** for this callback to be called, so be sure to call it if you set `emitNewContractEvents` to true
 
 ### `VM` methods
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ VM.deps = {
  * @param {Blockchain} [opts.blockchain] A blockchain object for storing/retrieving blocks (ignored if stateManager is passed)
  * @param {Boolean} [opts.activatePrecompiles] Create entries in the state tree for the precompiled contracts
  * @param {Boolean} [opts.allowUnlimitedContractSize] Allows unlimited contract sizes while debugging (default: false; ONLY use during debugging)
+ * @param {Boolean} [opts.emitNewContractEvents] Emits a `newContract` event with a callback and waits for a response before proceeding. (default: false)
  */
 function VM (opts = {}) {
   this.opts = opts
@@ -47,6 +48,7 @@ function VM (opts = {}) {
   }
 
   this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
+  this.emitNewContractEvents = opts.emitNewContractEvents === undefined ? false : opts.emitNewContractEvents
 
   // temporary
   // this is here for a gradual transition to StateManager

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,6 @@ VM.deps = {
  * @param {Blockchain} [opts.blockchain] A blockchain object for storing/retrieving blocks (ignored if stateManager is passed)
  * @param {Boolean} [opts.activatePrecompiles] Create entries in the state tree for the precompiled contracts
  * @param {Boolean} [opts.allowUnlimitedContractSize] Allows unlimited contract sizes while debugging (default: false; ONLY use during debugging)
- * @param {Boolean} [opts.emitNewContractEvents] Emits a `newContract` event with a callback and waits for a response before proceeding. (default: false)
  */
 function VM (opts = {}) {
   this.opts = opts
@@ -48,7 +47,6 @@ function VM (opts = {}) {
   }
 
   this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
-  this.emitNewContractEvents = opts.emitNewContractEvents === undefined ? false : opts.emitNewContractEvents
 
   // temporary
   // this is here for a gradual transition to StateManager

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -75,11 +75,31 @@ module.exports = function (opts, cb) {
           done(err)
         }
 
-        stateManager.getAccount(createdAddress, function (err, account) {
-          toAccount = account
-          toAccount.nonce = new BN(1).toArrayLike(Buffer)
-          done(err)
-        })
+        async.series([
+          newContractEvent,
+          getAccount
+        ], done)
+
+        function newContractEvent (callback) {
+          if (self.emitNewContractEvents) {
+            self.emit('newContract', {
+              address: createdAddress,
+              code: code
+            }, callback)
+          }
+          else {
+            callback()
+          }
+        }
+
+        function getAccount (callback) {
+          stateManager.getAccount(createdAddress, function (err, account) {
+            toAccount = account
+            const NONCE_OFFSET = 1
+            toAccount.nonce = new BN(toAccount.nonce).addn(NONCE_OFFSET).toArrayLike(Buffer)
+            callback(err)
+          })
+        }
       })
     } else {
       // else load the `to` account

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -81,14 +81,10 @@ module.exports = function (opts, cb) {
         ], done)
 
         function newContractEvent (callback) {
-          if (self.emitNewContractEvents) {
-            self.emit('newContract', {
-              address: createdAddress,
-              code: code
-            }, callback)
-          } else {
-            callback()
-          }
+          self.emit('newContract', {
+            address: createdAddress,
+            code: code
+          }, callback)
         }
 
         function getAccount (callback) {

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -86,8 +86,7 @@ module.exports = function (opts, cb) {
               address: createdAddress,
               code: code
             }, callback)
-          }
-          else {
+          } else {
             callback()
           }
         }


### PR DESCRIPTION
This PR is in support of the new/upcoming [Velma Solidity Debugger](https://github.com/SeesePlusPlus/velma), which is a real-time (rather than trace analyzer) Solidity debugger with supported [VS Code extension](https://github.com/SeesePlusPlus/vscode-velma-debug).

This PR introduces an option to the `new VM()` API called `emitNewContractEvents` (I am flexible with the name) which will emit an event named `newContract` (also open for name change) which provides a new contract's created address and it's deployment/creation bytecode (for reference/identification of the contract).

This event occurs immediately after the address is created for the new contract instance; this allows 3rd party libraries to know about the address before the constructor is executed. For example, this allows `Velma` to stop on breakpoints that are inside the constructor of a contract.

I am open for discussion about how this is to be implemented, but being able to know about the address prior to contract instance creation is necessary for `Velma` debugging (specifically for debugging constructors).

Let me know if you have any questions or comments! Thanks for the support!!