### PR TITLE
Throw original error and terminate execution on programmatic errors

### DIFF
--- a/lib/exceptions.js
+++ b/lib/exceptions.js
@@ -11,6 +11,7 @@ const ERROR = {
 
 function VmError (error) {
   this.error = error
+  this.errorType = 'VmError'
 }
 
 module.exports = {

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -200,8 +200,12 @@ module.exports = function (opts, cb) {
         // run the opcode
         var result = opFn.apply(null, args)
       } catch (e) {
-        cb(e)
-        return
+        if (e.errorType && e.errorType === 'VmError') {
+          cb(e)
+          return
+        } else {
+          throw e
+        }
       }
 
       // save result to the stack


### PR DESCRIPTION
This solves https://github.com/ethereumjs/ethereumjs-vm/issues/191 by throwing all programmatic errors not being internal errors of the VM (like ``OUT_OF_GAS``).

Behaviour can be tested by introducing a JS runtime error in ``opFn.js``, e.g. by adding:

```javascript
var test = toast - tee
```

as a first line in the ``ADD`` opcode and then run a state test encompassing this opcode in the stack:

```shell
node tests/tester.js -s --test='add11'
```

Behaviour before:

```shell
$ node tests/tester.js -s --test='add11'
TAP version 13
# GeneralStateTests
# file: add11 test: add11
not ok 1 the state roots should match
  ---
    operator: equal
    expected: |-
      '17454a767e5f04461256f3812ffca930443c04a47d05ce3f38940c4a14b8c479'
    actual: |-
      '3d0b7c83da4ae1c5eb6964cbfb1ffb248498ce6560113458ce7d963fff8cb449'
    at: replenish (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:1011:17)
  ...

1..1
# tests 1
# pass  0
# fail  1
```

-> Runtime error is implicitly handled, the differing state roots suggest some VM internal error.

Behaviour with PR:

```shell
$ node tests/tester.js -s --test='add11'
TAP version 13
# GeneralStateTests
# file: add11 test: add11
/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/lib/runCode.js:207
          throw e
          ^

ReferenceError: toast is not defined
    at ADD (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/lib/opFns.js:33:22)
    at runOp (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/lib/runCode.js:201:27)
    at /Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:3880:24
    at replenish (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:1011:17)
    at /Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:1016:9
    at eachOfLimit (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:1041:24)
    at /Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:1046:16
    at _parallel (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:3879:5)
    at Object.series (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:4735:5)
    at iterateVm (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/lib/runCode.js:119:11)
    at next (/Users/hdrewes/Documents/DEV/EthereumJS/ethereumjs-vm/node_modules/async/dist/async.js:5223:28)
    at runCallback (timers.js:781:20)
    at tryOnImmediate (timers.js:743:5)
    at processImmediate [as _immediateCallback] (timers.js:714:5)
```

-> Original JS runtime error is thrown, indicating an error in the code