### PR TITLE
Fix error handling in fakeBlockChain

### DIFF
--- a/lib/fakeBlockChain.js
+++ b/lib/fakeBlockChain.js
@@ -10,7 +10,7 @@ module.exports = {
     } else if (Number.isInteger(blockTag)) {
       hash = utils.sha3('0x' + utils.toBuffer(blockTag).toString('hex'))
     } else {
-      cb(new Error('Unknown blockTag type'))
+      return cb(new Error('Unknown blockTag type'))
     }
 
     var block = {


### PR DESCRIPTION
If `blockTag` is of an invalid type, call callback, and return, so as not to execute the rest of instructions in the function.