### PR TITLE
Remove blockchain from stateManager

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const StateManager = require('./stateManager.js')
 const Common = require('ethereumjs-common')
 const Account = require('ethereumjs-account')
 const AsyncEventEmitter = require('async-eventemitter')
+const fakeBlockchain = require('./fakeBlockChain.js')
 const BN = ethUtil.BN
 
 // require the percomiled contracts
@@ -58,6 +59,8 @@ function VM (opts = {}) {
     })
   }
 
+  this.blockchain = opts.blockchain || fakeBlockchain
+
   this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
 
   // precompiled contracts
@@ -90,7 +93,7 @@ VM.prototype.runCall = require('./runCall.js')
 VM.prototype.runBlockchain = require('./runBlockchain.js')
 
 VM.prototype.copy = function () {
-  return new VM({ stateManager: this.stateManager.copy() })
+  return new VM({ stateManager: this.stateManager.copy(), blockchain: this.blockchain })
 }
 
 /**

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -305,7 +305,7 @@ module.exports = {
   },
   // '0x40' range - block operations
   BLOCKHASH: function (number, runState, cb) {
-    var stateManager = runState.stateManager
+    var blockchain = runState.blockchain
     var diff = new BN(runState.block.header.number).sub(number)
 
     // block lookups must be within the past 256 blocks
@@ -314,8 +314,9 @@ module.exports = {
       return
     }
 
-    stateManager.getBlockHash(number.toArrayLike(Buffer, 'be', 32), function (err, blockHash) {
+    blockchain.getBlock(number.toArrayLike(Buffer, 'be', 32), function (err, block) {
       if (err) return cb(err)
+      var blockHash = block.hash()
       cb(null, new BN(blockHash))
     })
   },

--- a/lib/runBlockchain.js
+++ b/lib/runBlockchain.js
@@ -15,7 +15,7 @@ module.exports = function (blockchain, cb) {
     blockchain = undefined
   }
 
-  blockchain = blockchain || self.stateManager.blockchain
+  blockchain = blockchain || self.blockchain
 
   // setup blockchain iterator
   blockchain.iterator('vm', processBlock, cb)

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -46,6 +46,7 @@ module.exports = function (opts, cb) {
 
   // VM internal state
   var runState = {
+    blockchain: self.blockchain,
     stateManager: stateManager,
     returnValue: false,
     stopped: false,

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -4,7 +4,6 @@ const Common = require('ethereumjs-common')
 const genesisStates = require('ethereumjs-common/genesisStates')
 const async = require('async')
 const Account = require('ethereumjs-account')
-const fakeBlockchain = require('./fakeBlockChain.js')
 const Cache = require('./cache.js')
 const utils = require('ethereumjs-util')
 const BN = utils.BN
@@ -15,7 +14,6 @@ module.exports = StateManager
 function StateManager (opts = {}) {
   var self = this
 
-  self.blockchain = opts.blockchain || fakeBlockchain
   self.trie = opts.trie || new Trie()
 
   var common = opts.common
@@ -32,7 +30,7 @@ function StateManager (opts = {}) {
 var proto = StateManager.prototype
 
 proto.copy = function () {
-  return new StateManager({ trie: this.trie.copy(), blockchain: this.blockchain })
+  return new StateManager({ trie: this.trie.copy() })
 }
 
 // gets the account from the cache, or triggers a lookup and stores
@@ -221,20 +219,6 @@ proto.revertContracts = function () {
   var self = this
   self._storageTries = {}
   self._touched.clear()
-}
-
-//
-// blockchain
-//
-proto.getBlockHash = function (number, cb) {
-  var self = this
-  self.blockchain.getBlock(number, function (err, block) {
-    if (err) {
-      return cb(err)
-    }
-    var blockHash = block.hash()
-    cb(null, blockHash)
-  })
 }
 
 //

--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -88,7 +88,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
       })
     },
     function getHead (done) {
-      vm.stateManager.blockchain.getHead(function (err, block) {
+      vm.blockchain.getHead(function (err, block) {
         if (testData.lastblockhash.substr(0, 2) === '0x') {
           // fix for BlockchainTests/GeneralStateTests/stRandom/*
           testData.lastblockhash = testData.lastblockhash.substr(2)


### PR DESCRIPTION
This is part of the broader discussion in #268 and #309 so readers should probably start there.

The basic premise is that `getBlockHash` should not be on `stateManager`. This is the only block property that is present on `stateManager` and it doesn't really fit. Removing this also means the ctor doesn't need to take a blockchain which simplifies the interface as per #268. 