### PR TITLE
API Tests for runJit and fakeBlockchain

### DIFF
--- a/tests/api/fakeBlockChain.js
+++ b/tests/api/fakeBlockChain.js
@@ -1,0 +1,36 @@
+const tape = require('tape')
+const fakeBlockchain = require('../../lib/fakeBlockChain')
+
+tape('fakeBlockChain', (t) => {
+  const blockchain = fakeBlockchain
+
+  t.test('should fail to get block by invalid type', (st) => {
+    blockchain.getBlock(null, (err, block) => {
+      st.ok(err, 'should return error')
+      st.notOk(block)
+      st.end()
+    })
+  })
+
+  t.test('should get block hash by number', (st) => {
+    blockchain.getBlock(1, isValidBlock(st))
+  })
+
+  t.test('should get block hash by buffer', (st) => {
+    blockchain.getBlock(Buffer.from('0x0'), isValidBlock(st))
+  })
+
+  t.test('should "del" block', (st) => {
+    blockchain.delBlock('0x0', (err) => {
+      st.error(err)
+      st.end()
+    })
+  })
+})
+
+const isValidBlock = (st) => (err, block) => {
+  st.notOk(err)
+  st.ok(block, 'should return non-empty value')
+  st.ok(Buffer.isBuffer(block.hash()), 'block hash should of type buffer')
+  st.end()
+}

--- a/tests/api/runJit.js
+++ b/tests/api/runJit.js
@@ -1,0 +1,34 @@
+const tape = require('tape')
+const runJit = require('../../lib/runJit')
+const exceptions = require('../../lib/exceptions.js')
+
+tape('Should run code with func type', (t) => {
+  // TODO: Determine if account is still necessary for runJit
+  // as the callers don't seem to be using results.account
+  const opts = {
+    account: 'account',
+    code: (o) => ({ exceptionError: new exceptions.VmError('Invalid opcode') })
+  }
+
+  runJit(opts, (err, res) => {
+    t.ok(err, 'error should be set')
+    t.equal(err.errorType, 'VmError')
+    t.equal(err, res.exceptionError, 'callback error should be taken from exceptionError')
+    t.equal(res.account, 'account')
+    t.end()
+  })
+})
+
+tape('should run stringy code', (t) => {
+  const opts = {
+    account: 'account',
+    code: `return { exceptionError: null }`
+  }
+
+  runJit(opts, (err, res) => {
+    t.error(err, 'error should be null')
+    t.error(res.exceptionError, 'exceptionError should be null')
+    t.equal(res.account, 'account')
+    t.end()
+  })
+})


### PR DESCRIPTION
This PR contains tests for `runJit` and `fakeBlockchain`. I bundled them together since the changeset was rather small.