### PR TITLE
Easier triggering of BlockchainTests test runs on CircleCI

### DIFF
--- a/.circleci/config-blockchain-tests.yml
+++ b/.circleci/config-blockchain-tests.yml
@@ -1,0 +1,61 @@
+version: 2
+
+defaults: &defaults
+  working_directory: ~/project/ethereumjs-vm
+  docker:
+    - image: circleci/node:8
+restore_node_modules: &restore_node_modules
+  restore_cache:
+    name: Restore node_modules cache
+    keys:
+      - v1-node-{{ .Branch }}-{{ checksum "package.json" }}
+      - v1-node-{{ .Branch }}-
+      - v1-node-
+jobs:
+  install:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_node_modules
+      - run:
+          name: npm install
+          command: npm install
+      - save_cache:
+          name: Save node_modules cache
+          key: v1-node-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - node_modules/
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - ethereumjs-vm/
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - *restore_node_modules
+      - run:
+          name: Lint
+          command: npm run lint
+  run_blockchain_tests:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - *restore_node_modules
+      - run:
+          name: testBlockchain
+          command: npm run testBlockchain
+workflows:
+  version: 2
+  install-lint-test:
+    jobs:
+      - install
+      - lint:
+          requires:
+            - install
+      - run_blockchain_tests:
+          requires:
+            - install
+

--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ It is also possible to only run the tests from the skip lists:
 
 `node tests/tester -s --runSkipped=SLOW`
 
+### CI Test Integration
+
+Tests are run on ``CircleCI`` on every PR, configuration can be found in ``.circleci/config.yml``.
+
+Since ``BlockchainTests`` take too much time to run on every PR, only a selected set
+of blockchain tests is triggered on a normal PR test run.
+
+For a complete test run, create a new branch named ``run-blockchain-tests``, rename
+``.circleci/config.yml`` -> ``.circleci/config-save.yml`` and ``.circleci/config-blockchain-tests.yml``
+-> ``.circleci/config.yml`` and submit a PR with an additional ``[DO-NOT-MERGE]`` note. This will trigger a blockchain test run.
+
 ### Debugging
 
 #### Local Debugging


### PR DESCRIPTION
Solution is a bit more elegant than proposed in: https://github.com/ethereumjs/ethereumjs-vm/issues/337

This PR introduces a new CircleCI job ``run_blockchain_tests``. This job is ignored on regular PRs and only triggered (then skipping all the other test executing jobs) on a branch named ``run-blockchain-tests. Have only added this to the README docs.

Like this we can easily trigger test runs on Circle (we have to see once how long this will take though), we might even just keep a permanent ``run-blockchain-tests`` PR where tests are retriggered every now-and-then by rebasing.

Will also submit another PR named differently for a negative-test.