### PR TITLE
Exclude tests directory for nyc coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
     "url": "https://github.com/ethereumjs/ethereumjs-vm/issues"
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-vm",
+  "nyc": {
+    "exclude": [
+      "tests"
+    ]
+  },
   "standard": {
     "ignore": [
       "dist/**",


### PR DESCRIPTION
Switching from ``istanbul`` to ``nyc`` somehow resulted in the ``tests`` folder being included in the coverage report, which reduced coverage below the threshold value, see https://github.com/ethereumjs/ethereumjs-vm/pull/334.

This PR should fix this by explicitly excluding the ``tests`` directory.