### PR TITLE
Fix incorrect references to trie in tests

### DIFF
--- a/tests/cacheTest.js
+++ b/tests/cacheTest.js
@@ -44,10 +44,10 @@ tape('test the cache api', function (t) {
       runCode,
       runTx,
       function (cb) {
-        vm.trie.get(account2.address, function (err, val) {
+        vm.stateManager.trie.get(account2.address, function (err, val) {
           t.assert(!err)
           var a = new Account(val)
-          a.getCode(vm.trie, function (err, v) {
+          a.getCode(vm.stateManager.trie, function (err, v) {
             t.assert(!err)
             t.assert(v.toString('hex') === '60606040526008565b00')
             cb()
@@ -62,7 +62,7 @@ tape('test the cache api', function (t) {
     function createAccount (cb) {
       var account = new Account()
       account.balance = '0xf00000000000000001'
-      vm.trie.put(Buffer.from(account1.address, 'hex'), account.serialize(), cb)
+      vm.stateManager.trie.put(Buffer.from(account1.address, 'hex'), account.serialize(), cb)
     }
 
     function runCode (cb) {
@@ -77,9 +77,9 @@ tape('test the cache api', function (t) {
         caller: account1.address
       }, function (err, result) {
         if (err) return cb(err)
-        account.setCode(vm.trie, result.return, function (err) {
+        account.setCode(vm.stateManager.trie, result.return, function (err) {
           if (err) cb(err)
-          else vm.trie.put(account2.address, account.serialize(), cb)
+          else vm.stateManager.trie.put(account2.address, account.serialize(), cb)
         })
       })
     }

--- a/tests/genesishashes.js
+++ b/tests/genesishashes.js
@@ -7,7 +7,7 @@ var vm = new VM()
 tape('[Common]: genesis hashes tests', function (t) {
   t.test('should generate the genesis state correctly', function (st) {
     vm.stateManager.generateCanonicalGenesis(function () {
-      st.equal(vm.trie.root.toString('hex'), genesisData.genesis_state_root)
+      st.equal(vm.stateManager.trie.root.toString('hex'), genesisData.genesis_state_root)
       st.end()
     })
   })


### PR DESCRIPTION
In the current master, `npm test` raises the following error:
```
TAP version 13
# test the cache api
# should have the correct value in the cache
/Users/kn/repos/ethereumjs-vm/tests/cacheTest.js:65
      vm.trie.put(Buffer.from(account1.address, 'hex'), account.serialize(), cb)
              ^

TypeError: Cannot read property 'put' of undefined
```

This PR fixes it by correcting references to `trie`.