### PR TITLE
[WIP] Run with the latest tests (ethereumjs-testing v1.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-preset-env": "^1.6.1",
     "coveralls": "^3.0.0",
     "ethereumjs-blockchain": "~3.2.1",
-    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.1.1",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.1",
     "ethereumjs-tx": "1.3.3",
     "level": "^1.4.0",
     "leveldown": "^1.4.6",

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -14,7 +14,8 @@ const skipBroken = [
   'TransactionCollisionToEmptyButCode', // temporary till fixed (2017-09-21)
   'TransactionCollisionToEmptyButNonce', // temporary till fixed (2017-09-21)
   'RevertDepthCreateAddressCollision', // test case is wrong
-  'randomStatetest642' // BROKEN, rustbn.js error
+  'randomStatetest642', // BROKEN, rustbn.js error
+  'ecmul_0-3_5616_28000_96' // temporary till fixed (2018-09-20)
 ]
 // tests skipped due to system specifics / design considerations
 const skipPermanent = [


### PR DESCRIPTION
This PR runs the VM on the latests tests, I've done a new ``ethereumjs-testing`` [v1.2.1]() release, also added some CHANGELOG entry on the updates on the testing repository.

I will close https://github.com/ethereumjs/ethereumjs-vm/pull/305, since this brings not enough value with minimal changes and three commits to rebase this and bring this in order.

We can nevertheless reference this here for going back to the notes already done on some test results.