### PR TITLE
Add runTx API tests

### DIFF
--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -16,12 +16,22 @@ const Block = require('ethereumjs-block')
  * @param cb {Function} - the callback
  */
 module.exports = function (opts, cb) {
+  if (typeof opts === 'function' && cb === undefined) {
+    cb = opts
+    return cb(new Error('invalid input, opts must be provided'))
+  }
+
   var self = this
   var block = opts.block
   var tx = opts.tx
   var gasLimit
   var results
   var basefee
+
+  // tx is required
+  if (!tx) {
+    return cb(new Error('invalid input, tx is required'))
+  }
 
   // create a reasonable default if no block is given
   if (!block) {
@@ -62,16 +72,16 @@ module.exports = function (opts, cb) {
    * populates the cache with the 'to' and 'from' of the tx
    */
   function populateCache (cb) {
+    if (opts.populateCache === false) {
+      return cb()
+    }
+
     var accounts = new Set()
     accounts.add(tx.from.toString('hex'))
     accounts.add(block.header.coinbase.toString('hex'))
 
     if (tx.to.toString('hex') !== '') {
       accounts.add(tx.to.toString('hex'))
-    }
-
-    if (opts.populateCache === false) {
-      return cb()
     }
 
     self.stateManager.warmCache(accounts, cb)

--- a/tests/api/runBlockchain.js
+++ b/tests/api/runBlockchain.js
@@ -7,6 +7,7 @@ const Block = require('ethereumjs-block')
 const util = require('ethereumjs-util')
 const runBlockchain = require('../../lib/runBlockchain')
 const StateManager = require('../../lib/stateManager')
+const { createGenesis } = require('./utils')
 
 tape('runBlockchain', (t) => {
   const blockchainDB = new Levelup('', { db: Memdown })
@@ -78,12 +79,6 @@ tape('runBlockchain', (t) => {
     }
   })
 })
-
-function createGenesis () {
-  const genesis = new Block()
-  genesis.setGenesisParams()
-  return genesis
-}
 
 function createBlock (parent = null, n = 0) {
   if (parent === null) {

--- a/tests/api/runTx.js
+++ b/tests/api/runTx.js
@@ -1,0 +1,138 @@
+const { promisify } = require('util')
+const tape = require('tape')
+const Transaction = require('ethereumjs-tx')
+const runTx = require('../../lib/runTx')
+const StateManager = require('../../lib/stateManager')
+const VM = require('../../lib/index')
+const { createAccount } = require('./utils')
+
+function setup (vm = null) {
+  if (vm === null) {
+    vm = {
+      stateManager: new StateManager({ }),
+      emit: (e, val, cb) => { cb() },
+      runCall: (opts, cb) => cb(new Error('test'))
+    }
+  }
+
+  return {
+    vm,
+    runTx: promisify(runTx.bind(vm)),
+    putAccount: promisify(vm.stateManager.putAccount.bind(vm.stateManager)),
+    cacheFlush: promisify(vm.stateManager.cache.flush.bind(vm.stateManager.cache))
+  }
+}
+
+tape('runTx', (t) => {
+  const suite = setup()
+
+  t.test('should fail to run without opts', async (st) => {
+    shouldFail(st, suite.runTx(),
+      (e) => st.ok(e.message.includes('invalid input'), 'should fail with appropriate error')
+    )
+    st.end()
+  })
+
+  t.test('should fail to run without tx', async (st) => {
+    shouldFail(st, suite.runTx({}),
+      (e) => st.ok(e.message.includes('invalid input'), 'should fail with appropriate error')
+    )
+    st.end()
+  })
+
+  t.test('should fail to run without signature', async (st) => {
+    const tx = getTransaction()
+    shouldFail(st, suite.runTx({ tx }),
+      (e) => st.ok(e.message.toLowerCase().includes('signature'), 'should fail with appropriate error')
+    )
+    st.end()
+  })
+
+  t.test('should fail without sufficient funds', async (st) => {
+    const tx = getTransaction(true, true)
+    shouldFail(st, suite.runTx({ tx }),
+      (e) => st.ok(e.message.toLowerCase().includes('enough funds'), 'error should include "enough funds"')
+    )
+    st.end()
+  })
+})
+
+tape('should fail when runCall fails', async (t) => {
+  const suite = setup()
+
+  const tx = getTransaction(true, true)
+  const acc = createAccount()
+  await suite.putAccount(tx.from.toString('hex'), acc)
+  await suite.cacheFlush()
+
+  shouldFail(t,
+    suite.runTx({ tx, populateCache: true }),
+    (e) => t.equal(e.message, 'test', 'error should be equal to what the mock runCall returns')
+  )
+
+  t.end()
+})
+
+tape('should run simple tx without errors', async (t) => {
+  let vm = new VM()
+  const suite = setup(vm)
+
+  const tx = getTransaction(true, true)
+  const acc = createAccount()
+  await suite.putAccount(tx.from.toString('hex'), acc)
+  await suite.cacheFlush()
+
+  let res = await suite.runTx({ tx, populateCache: true })
+  t.true(res.gasUsed.gt(0), 'should have used some gas')
+
+  t.end()
+})
+
+// The following test tries to verify that running a tx
+// would work, even when stateManager is not using a cache.
+// It fails at the moment, and has been therefore commented.
+// Please refer to https://github.com/ethereumjs/ethereumjs-vm/issues/353
+/* tape('should behave the same when not using cache', async (t) => {
+  const suite = setup()
+
+  const tx = getTransaction(true, true)
+  const acc = createAccount()
+  await suite.putAccount(tx.from.toString('hex'), acc)
+  await suite.cacheFlush()
+  suite.vm.stateManager.cache.clear()
+
+  shouldFail(t,
+    suite.runTx({ tx, populateCache: false }),
+    (e) => t.equal(e.message, 'test', 'error should be equal to what the mock runCall returns')
+  )
+
+  t.end()
+}) */
+
+function shouldFail (st, p, onErr) {
+  p.then(() => st.fail('runTx didnt return any errors')).catch(onErr)
+}
+
+function getTransaction (sign = false, calculageGas = false) {
+  const privateKey = Buffer.from('e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109', 'hex')
+  const txParams = {
+    nonce: '0x00',
+    gasPrice: 100,
+    gasLimit: 1000,
+    to: '0x0000000000000000000000000000000000000000',
+    value: '0x00',
+    data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
+    chainId: 3
+  }
+
+  const tx = new Transaction(txParams)
+  if (sign) {
+    tx.sign(privateKey)
+  }
+
+  if (calculageGas) {
+    tx.gas = tx.getUpfrontCost()
+  }
+
+  return tx
+}

--- a/tests/api/utils.js
+++ b/tests/api/utils.js
@@ -1,0 +1,23 @@
+const Block = require('ethereumjs-block')
+const Account = require('ethereumjs-account')
+
+function createGenesis () {
+  const genesis = new Block()
+  genesis.setGenesisParams()
+
+  return genesis
+}
+
+function createAccount () {
+  const raw = {
+    nonce: '0x00',
+    balance: '0xfff384'
+  }
+  const acc = new Account(raw)
+  return acc
+}
+
+module.exports = {
+  createGenesis,
+  createAccount
+}


### PR DESCRIPTION
This PR is part of the [series](https://github.com/ethereumjs/ethereumjs-vm/pull/315) for adding API test coverage. It:

- Adds tests for `runTx.js`
- Modifies `lib/runTx.js` to add two validation checks. Furthermore it moves the check for `populateCache` flag to the beginning of function.
- A test Related to `populateCache` fails. I'm not sure if the test case makes sense. I assumed `runTx` should run even when `populateCache` is false, the difference being that no cache is utilized. However, `runTx` fails because it tries to use cache nevertheless.
- Moves `createGenesis` utility to `utils.js` file.