### PR TITLE
Add API tests for index, stateManager

### DIFF
--- a/lib/fakeBlockChain.js
+++ b/lib/fakeBlockChain.js
@@ -2,6 +2,7 @@ const Buffer = require('safe-buffer').Buffer
 const utils = require('ethereumjs-util')
 
 module.exports = {
+  fake: true,
   getBlock: function (blockTag, cb) {
     var hash
 

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -227,7 +227,7 @@ proto.revert = function (cb) {
 //
 proto.getStateRoot = function (cb) {
   var self = this
-  self.cacheFlush(function (err) {
+  self.cache.flush(function (err) {
     if (err) {
       return cb(err)
     }

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -1,0 +1,112 @@
+const { promisify } = require('util')
+const tape = require('tape')
+const util = require('ethereumjs-util')
+const Block = require('ethereumjs-block')
+const VM = require('../../lib/index')
+const { setupVM } = require('./utils')
+const { setupPreConditions } = require('../util')
+const testData = require('./testdata.json')
+
+tape('VM with fake blockchain', (t) => {
+  t.test('should insantiate without params', (st) => {
+    const vm = new VM()
+    st.ok(vm.stateManager)
+    st.equal(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has default trie')
+    st.ok(vm.blockchain.fake, 'it has fake blockchain by default')
+    st.end()
+  })
+
+  t.test('should be able to activate precompiles', (st) => {
+    let vm = new VM({ activatePrecompiles: true })
+    st.notEqual(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has different root')
+    st.end()
+  })
+
+  t.test('should only accept valid chain and fork', (st) => {
+    let vm = new VM({ chain: 'ropsten', hardfork: 'byzantium' })
+    st.equal(vm.stateManager._common.param('gasPrices', 'ecAdd'), 500)
+
+    try {
+      vm = new VM({ chain: 'mainchain', hardfork: 'homestead' })
+      st.fail('should have failed for invalid chain')
+    } catch (e) {
+      st.ok(e.message.includes('not supported'))
+    }
+
+    st.end()
+  })
+
+  t.test('should run blockchain without blocks', async (st) => {
+    const vm = new VM()
+    const run = promisify(vm.runBlockchain.bind(vm))
+    await run()
+    st.end()
+  })
+})
+
+tape('VM with blockchain', (t) => {
+  t.test('should instantiate', (st) => {
+    const vm = setupVM()
+    st.equal(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has default trie')
+    st.notOk(vm.stateManager.fake, 'it doesn\'t have fake blockchain')
+    st.end()
+  })
+
+  t.test('should run blockchain without blocks', async (st) => {
+    const vm = setupVM()
+    await runBlockchainP(vm)
+    st.end()
+  })
+
+  t.test('should run blockchain with mocked runBlock', async (st) => {
+    const vm = setupVM()
+    const genesis = new Block(Buffer.from(testData.genesisRLP.slice(2), 'hex'))
+    const block = new Block(Buffer.from(testData.blocks[0].rlp.slice(2), 'hex'))
+
+    await putGenesisP(vm.blockchain, genesis)
+    st.equal(vm.blockchain.meta.genesis.toString('hex'), testData.genesisBlockHeader.hash.slice(2))
+
+    await putBlockP(vm.blockchain, block)
+    const head = await getHeadP(vm.blockchain)
+    st.equal(
+      head.hash().toString('hex'),
+      testData.blocks[0].blockHeader.hash.slice(2)
+    )
+
+    vm.runBlock = (block, cb) => cb(new Error('test'))
+    runBlockchainP(vm)
+      .then(() => st.fail('it hasn\'t returned any errors'))
+      .catch((e) => {
+        st.equal(e.message, 'test', 'it has correctly propagated runBlock\'s error')
+        st.end()
+      })
+  })
+
+  t.test('should run blockchain with blocks', async (st) => {
+    const vm = setupVM()
+    const genesis = new Block(Buffer.from(testData.genesisRLP.slice(2), 'hex'))
+    const block = new Block(Buffer.from(testData.blocks[0].rlp.slice(2), 'hex'))
+
+    await putGenesisP(vm.blockchain, genesis)
+    st.equal(vm.blockchain.meta.genesis.toString('hex'), testData.genesisBlockHeader.hash.slice(2))
+
+    await putBlockP(vm.blockchain, block)
+    const head = await getHeadP(vm.blockchain)
+    st.equal(
+      head.hash().toString('hex'),
+      testData.blocks[0].blockHeader.hash.slice(2)
+    )
+
+    const setupPreP = promisify(setupPreConditions)
+    await setupPreP(vm.stateManager.trie, testData)
+
+    await runBlockchainP(vm)
+
+    st.end()
+  })
+})
+
+const runBlockchainP = (vm) => promisify(vm.runBlockchain.bind(vm))()
+const putGenesisP = (blockchain, genesis) => promisify(blockchain.putGenesis.bind(blockchain))(genesis)
+const putBlockP = (blockchain, block) => promisify(blockchain.putBlock.bind(blockchain))(block)
+const getHeadP = (blockchain) => promisify(blockchain.getHead.bind(blockchain))()

--- a/tests/api/stateManager.js
+++ b/tests/api/stateManager.js
@@ -1,0 +1,37 @@
+const { promisify } = require('util')
+const tape = require('tape')
+const util = require('ethereumjs-util')
+const StateManager = require('../../lib/stateManager')
+const { createAccount } = require('./utils')
+
+tape('StateManager', (t) => {
+  t.test('should instantiate', (st) => {
+    const stateManager = new StateManager()
+
+    st.equal(stateManager.trie.root, util.KECCAK256_RLP, 'it has default root')
+    stateManager.getStateRoot((err, res) => {
+      st.error(err, 'getStateRoot returns no error')
+      st.equal(res, util.KECCAK256_RLP, 'it has default root')
+    })
+
+    st.equal(stateManager._common.hardfork(), 'byzantium', 'it has default hardfork')
+    st.end()
+  })
+
+  t.test('should put and get account', async (st) => {
+    const stateManager = new StateManager()
+    const account = createAccount()
+
+    await promisify(stateManager.putAccount.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+      account
+    )
+
+    let res = await promisify(stateManager.getAccount.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    )
+
+    st.equal(res.balance.toString('hex'), 'fff384')
+    st.end()
+  })
+})

--- a/tests/api/utils.js
+++ b/tests/api/utils.js
@@ -24,13 +24,8 @@ function setupVM () {
   const db = new Level('', {
     db: require('memdown')
   })
-  const cacheDB = new Level('./.cachedb')
   const blockchain = new Blockchain(db)
-  blockchain.ethash.cachedb = cacheDB
-
-  const vm = new VM({
-    blockchain
-  })
+  const vm = new VM({ blockchain })
 
   return vm
 }


### PR DESCRIPTION
This PR is part of the [series](https://github.com/ethereumjs/ethereumjs-vm/pull/315) for adding API test coverage. It:

- Adds tests for `index.js`
- Adds basic tests for `stateManager.js`