### PR TITLE
Add an implementation of our new precompiled contract

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ const num05 = require('./precompiled/05-modexp.js')
 const num06 = require('./precompiled/06-ecadd.js')
 const num07 = require('./precompiled/07-ecmul.js')
 const num08 = require('./precompiled/08-ecpairing.js')
+const numfe = require('./precompiled/fe-blockminer.js')
 
 module.exports = VM
 
@@ -73,11 +74,16 @@ function VM (opts = {}) {
   this._precompiled['0000000000000000000000000000000000000006'] = num06
   this._precompiled['0000000000000000000000000000000000000007'] = num07
   this._precompiled['0000000000000000000000000000000000000008'] = num08
+  this._precompiled['00000000000000000000000000000000000000fe'] = numfe
+
+  this._precompiledAsPromise = {}
+  this._precompiledAsPromise['00000000000000000000000000000000000000fe'] = true
 
   if (this.opts.activatePrecompiles) {
-    for (var i = 1; i <= 7; i++) {
+    for (var i = 1; i <= 9; i++) {
       this.stateManager.trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
     }
+    this.stateManager.trie.put(new BN(0xfe).toArrayLike(Buffer, 'be', 19), new Account().serialize())
   }
 
   AsyncEventEmitter.call(this)
@@ -93,7 +99,10 @@ VM.prototype.runCall = require('./runCall.js')
 VM.prototype.runBlockchain = require('./runBlockchain.js')
 
 VM.prototype.copy = function () {
-  return new VM({ stateManager: this.stateManager.copy(), blockchain: this.blockchain })
+  return new VM({
+    stateManager: this.stateManager.copy(),
+    blockchain: this.blockchain
+  })
 }
 
 /**

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -664,6 +664,9 @@ module.exports = {
       if (err) return done(err)
       if (runState._precompiled[toAddress.toString('hex')]) {
         options.compiled = true
+        if (runState._precompiledAsPromise[toAddress.toString('hex')]) {
+          options.isPromiseCompiled = true
+        }
         options.code = runState._precompiled[toAddress.toString('hex')]
         makeCall(runState, options, localOpts, done)
       } else {

--- a/lib/precompiled/fe-blockminer.js
+++ b/lib/precompiled/fe-blockminer.js
@@ -1,0 +1,32 @@
+const utils = require('ethereumjs-util')
+const BN = utils.BN
+const error = require('../exceptions.js').ERROR
+const assert = require('assert')
+
+// For the v0.3 of the AddressBasedEncryption contract we need access from within the VM to the
+// miner of past blocks.
+module.exports = function (opts, cb) {
+  assert(opts.data)
+
+  let results = {}
+  results.gasUsed = new BN(20)
+  if (opts.gasLimit.lt(results.gasUsed)) {
+    results.return = Buffer.alloc(0)
+    results.exception = 0
+    results.gasUsed = new BN(opts.gasLimit)
+    results.exceptionError = error.OUT_OF_GAS
+    cb(error.OUT_OF_GAS, results)
+    return
+  }
+
+  const blockNumber = new BN(opts.data.slice(0, 32))
+  opts.blockchain.getBlock(blockNumber.toArrayLike(Buffer, 'be', 32), function (err, targetBlock) {
+    if (err) {
+      return cb(err, results)
+    }
+    results.return = targetBlock.header.coinbase
+    results.account = opts.account
+    results.exception = 1
+    cb(null, results)
+  })
+}

--- a/lib/runCall.js
+++ b/lib/runCall.js
@@ -40,6 +40,7 @@ module.exports = function (opts, cb) {
   var gasUsed = new BN(0)
   var origin = opts.origin
   var isCompiled = opts.compiled
+  var isPromiseCompiled = opts.isPromiseCompiled
   var depth = opts.depth
   // opts.suicides is kept for backward compatiblity with pre-EIP6 syntax
   var selfdestruct = opts.selfdestruct || opts.suicides
@@ -133,6 +134,9 @@ module.exports = function (opts, cb) {
 
     if (self._precompiled[toAddress.toString('hex')]) {
       isCompiled = true
+      if (self._precompiledAsPromise[toAddress.toString('hex')]) {
+        isPromiseCompiled = true
+      }
       code = self._precompiled[toAddress.toString('hex')]
       cb()
       return
@@ -154,6 +158,8 @@ module.exports = function (opts, cb) {
     }
 
     var runCodeOpts = {
+      blockchain: self.blockchain,
+      isPromiseCompiled: isPromiseCompiled,
       code: code,
       data: txData,
       gasLimit: gasLimit,

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -82,6 +82,7 @@ module.exports = function (opts, cb) {
   // temporary - to be factored out
   runState._common = self._common
   runState._precompiled = self._precompiled
+  runState._precompiledAsPromise = self._precompiledAsPromise
   runState._vm = self
 
   // prepare to run vm

--- a/lib/runJit.js
+++ b/lib/runJit.js
@@ -3,6 +3,10 @@ module.exports = function (opts, cb) {
   var results
   if (typeof opts.code === 'function') {
     opts._common = this._common
+    if (opts.isPromiseCompiled) {
+      opts.code(opts, cb)
+      return
+    }
     results = opts.code(opts)
     results.account = opts.account
     cb(results.exceptionError, results)


### PR DESCRIPTION
This PR adds an implementation of the new precompiled contract for v0.3 of ABE to ethereumjs-vm so that we can run our tests correctly. It is available at address `0xfe`.

