### PR TITLE
Run with the latest tests (ethereumjs-testing to v1.2.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-preset-env": "^1.6.1",
     "coveralls": "^3.0.0",
     "ethereumjs-blockchain": "~3.2.1",
-    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.2",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.3",
     "ethereumjs-tx": "1.3.3",
     "level": "^1.4.0",
     "leveldown": "^1.4.6",


### PR DESCRIPTION
Run the VM on the latests tests included in ``ethereumjs-testing`` [v1.2.3](https://github.com/ethereumjs/ethereumjs-testing/releases/tag/v1.2.3).

The new tests should now be on a greater part ready to be used for Constantinople testing, especially new ``SSTORE`` gas price calculations are now included through a complete test refill (consistency/accuracy not confirmed though yet).