### PR TITLE
Update of ethereumjs-util to v6.0.0

### DIFF
--- a/lib/hooked.js
+++ b/lib/hooked.js
@@ -59,7 +59,7 @@ function createHookedVm (opts, hooks) {
       results._exists = results.nonce !== '0x0' || results.balance !== '0x0' || results._code !== '0x'
         // console.log('fetch account results:', results)
       var account = new Account(results)
-        // not used but needs to be anything but the default (ethUtil.SHA3_NULL)
+        // not used but needs to be anything but the default (ethUtil.KECCAK256_NULL)
         // code lookups are handled by `codeStore`
       account.codeHash = ZERO_BUFFER.slice()
       cb(null, account)

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -296,7 +296,7 @@ proto.accountIsEmpty = function (address, cb) {
       return cb(err)
     }
 
-    cb(null, account.nonce.toString('hex') === '' && account.balance.toString('hex') === '' && account.codeHash.toString('hex') === utils.SHA3_NULL_S)
+    cb(null, account.nonce.toString('hex') === '' && account.balance.toString('hex') === '' && account.codeHash.toString('hex') === utils.KECCAK256_NULL_S)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ethereumjs-account": "^2.0.3",
     "ethereumjs-block": "~2.0.1",
     "ethereumjs-common": "~0.4.0",
-    "ethereumjs-util": "^5.2.0",
+    "ethereumjs-util": "^6.0.0",
     "fake-merkle-patricia-tree": "^1.0.1",
     "functional-red-black-tree": "^1.0.1",
     "merkle-patricia-tree": "^2.1.2",

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -11,7 +11,7 @@ tape('VM with fake blockchain', (t) => {
   t.test('should insantiate without params', (st) => {
     const vm = new VM()
     st.ok(vm.stateManager)
-    st.equal(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has default trie')
+    st.deepEqual(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has default trie')
     st.ok(vm.blockchain.fake, 'it has fake blockchain by default')
     st.end()
   })
@@ -47,7 +47,7 @@ tape('VM with fake blockchain', (t) => {
 tape('VM with blockchain', (t) => {
   t.test('should instantiate', (st) => {
     const vm = setupVM()
-    st.equal(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has default trie')
+    st.deepEqual(vm.stateManager.trie.root, util.KECCAK256_RLP, 'it has default trie')
     st.notOk(vm.stateManager.fake, 'it doesn\'t have fake blockchain')
     st.end()
   })

--- a/tests/api/stateManager.js
+++ b/tests/api/stateManager.js
@@ -8,10 +8,10 @@ tape('StateManager', (t) => {
   t.test('should instantiate', (st) => {
     const stateManager = new StateManager()
 
-    st.equal(stateManager.trie.root, util.KECCAK256_RLP, 'it has default root')
+    st.deepEqual(stateManager.trie.root, util.KECCAK256_RLP, 'it has default root')
     stateManager.getStateRoot((err, res) => {
       st.error(err, 'getStateRoot returns no error')
-      st.equal(res, util.KECCAK256_RLP, 'it has default root')
+      st.deepEqual(res, util.KECCAK256_RLP, 'it has default root')
     })
 
     st.equal(stateManager._common.hardfork(), 'byzantium', 'it has default hardfork')


### PR DESCRIPTION
``ethereumjs-util`` update to ``v6.0.0`` as preparation for https://github.com/ethereumjs/ethereumjs-vm/pull/329.