### PR TITLE
Run with the latest tests (ethereumjs-testing to v1.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-preset-env": "^1.6.1",
     "coveralls": "^3.0.0",
     "ethereumjs-blockchain": "~3.2.1",
-    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.3",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.4",
     "ethereumjs-tx": "1.3.3",
     "level": "^1.4.0",
     "leveldown": "^1.4.6",


### PR DESCRIPTION
Run with the latest tests from ``ethereumjs-testing`` [v1.2.4](https://github.com/ethereumjs/ethereumjs-testing/releases/tag/v1.2.4).

This is fixing various blockchain tests, see release notes for details.