### PR TITLE
Added usage of sealEngine to blockchain tests

### DIFF
--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -13,11 +13,20 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
     db: require('memdown')
   })
   var state = new Trie()
+  var validate = false
+  // Only run with block validation when sealEngine present in test file
+  // and being set to Ethash PoW validation
+  if (testData.sealEngine && testData.sealEngine === 'Ethash') {
+    validate = true
+  }
   var blockchain = new Blockchain({
     db: blockchainDB,
-    hardfork: options.forkConfig.toLowerCase()
+    hardfork: options.forkConfig.toLowerCase(),
+    validate: validate
   })
-  blockchain.ethash.cacheDB = cacheDB
+  if (validate) {
+    blockchain.ethash.cacheDB = cacheDB
+  }
   var VM
   if (options.dist) {
     VM = require('../dist/index.js')


### PR DESCRIPTION
This adds the usage of the new ``sealEngine`` parameter from the new blockchain test format (see this PR https://github.com/ethereum/tests/pull/533 over on the tests repo).

This should both fix currently failing blockchain tests due to not comparing to PoW-related params (``mixHash``, see [this](https://github.com/ethereum/tests/pull/533) comment e.g.) any more and at the same time significantly speed up blockchain test runs (we might be able to directly include these in the normal CI runs now, will do another blockchain test run after merge for getting the execution time).