### PR TITLE
Stop adding account to cache when checking if it is empty.

### DIFF
--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -40,6 +40,22 @@ proto.getAccount = function (address, cb) {
   this.cache.getOrLoad(address, cb)
 }
 
+proto.getAccountPure = function (address, cb) {
+  const self = this
+  const cachedAccount = this.cache.get(address)
+
+  if (cachedAccount) {
+    cb(null, cachedAccount)
+  } else {
+    self.trie.get(address, function (err, account) {
+      if (err) {
+        return cb(err)
+      }
+      cb(null, account)
+    })
+  }
+}
+
 // saves the account
 proto.putAccount = function (address, account, cb) {
   var self = this
@@ -285,9 +301,16 @@ proto.generateGenesis = function (initState, cb) {
   }, cb)
 }
 
-proto.accountIsEmpty = function (address, cb) {
+proto.accountIsEmpty = function (address, getAccountWithoutLoad, cb) {
+  if (cb === undefined) {
+    cb = getAccountWithoutLoad
+    getAccountWithoutLoad = null
+  }
+
   var self = this
-  self.getAccount(address, function (err, account) {
+  var getAccountCall = getAccountWithoutLoad ? self.getAccountPure : self.getAccount
+
+  getAccountCall.bind(this)(address, function (err, account) {
     if (err) {
       return cb(err)
     }
@@ -301,7 +324,7 @@ proto.cleanupTouchedAccounts = function (cb) {
   var touchedArray = Array.from(self._touched)
   async.forEach(touchedArray, function (addressHex, next) {
     var address = Buffer.from(addressHex, 'hex')
-    self.accountIsEmpty(address, function (err, empty) {
+    self.accountIsEmpty(address, true, function (err, empty) {
       if (err) {
         next(err)
         return

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -40,7 +40,7 @@ proto.getAccount = function (address, cb) {
   this.cache.getOrLoad(address, cb)
 }
 
-proto.getAccountPure = function (address, cb) {
+proto._getAccountPure = function (address, cb) {
   const self = this
   const cachedAccount = this.cache.get(address)
 
@@ -308,7 +308,7 @@ proto.accountIsEmpty = function (address, getAccountWithoutLoad, cb) {
   }
 
   var self = this
-  var getAccountCall = getAccountWithoutLoad ? self.getAccountPure : self.getAccount
+  var getAccountCall = getAccountWithoutLoad ? self._getAccountPure : self.getAccount
 
   getAccountCall.bind(this)(address, function (err, account) {
     if (err) {

--- a/tests/api/stateManager.js
+++ b/tests/api/stateManager.js
@@ -4,7 +4,7 @@ const util = require('ethereumjs-util')
 const StateManager = require('../../lib/stateManager')
 const { createAccount } = require('./utils')
 
-tape.only('StateManager', (t) => {
+tape('StateManager', (t) => {
   t.test('should instantiate', (st) => {
     const stateManager = new StateManager()
 
@@ -53,7 +53,7 @@ tape.only('StateManager', (t) => {
       account
     )
 
-    let res = await promisify(stateManager.getAccountPure.bind(stateManager))(
+    let res = await promisify(stateManager._getAccountPure.bind(stateManager))(
       'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
     )
 
@@ -61,7 +61,7 @@ tape.only('StateManager', (t) => {
 
     stateManager.cache.clear()
 
-    res = await promisify(stateManager.getAccountPure.bind(stateManager))(
+    res = await promisify(stateManager._getAccountPure.bind(stateManager))(
       'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
     )
 

--- a/tests/api/stateManager.js
+++ b/tests/api/stateManager.js
@@ -4,7 +4,7 @@ const util = require('ethereumjs-util')
 const StateManager = require('../../lib/stateManager')
 const { createAccount } = require('./utils')
 
-tape('StateManager', (t) => {
+tape.only('StateManager', (t) => {
   t.test('should instantiate', (st) => {
     const stateManager = new StateManager()
 
@@ -18,7 +18,7 @@ tape('StateManager', (t) => {
     st.end()
   })
 
-  t.test('should put and get account', async (st) => {
+  t.test('should put and get account, and add to the underlying cache if the account is not found', async (st) => {
     const stateManager = new StateManager()
     const account = createAccount()
 
@@ -32,6 +32,79 @@ tape('StateManager', (t) => {
     )
 
     st.equal(res.balance.toString('hex'), 'fff384')
+
+    stateManager.cache.clear()
+
+    res = await promisify(stateManager.getAccount.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    )
+
+    st.equal(stateManager.cache._cache.keys[0], 'a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+
+    st.end()
+  })
+
+  t.test('should retrieve a cached account, without adding to the underlying cache if the account is not found', async (st) => {
+    const stateManager = new StateManager()
+    const account = createAccount()
+
+    await promisify(stateManager.putAccount.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+      account
+    )
+
+    let res = await promisify(stateManager.getAccountPure.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    )
+
+    st.equal(res.balance.toString('hex'), 'fff384')
+
+    stateManager.cache.clear()
+
+    res = await promisify(stateManager.getAccountPure.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
+    )
+
+    st.notOk(stateManager.cache._cache.keys[0])
+
+    st.end()
+  })
+
+  t.test('should call the callback with a boolean representing emptiness, and not cache the account if passed correct params', async (st) => {
+    const stateManager = new StateManager()
+
+    const promisifiedAccountIsEmpty = promisify(stateManager.accountIsEmpty.bind(stateManager), function (err, result) {
+      return err || result
+    })
+    let res = await promisifiedAccountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', true)
+
+    st.ok(res)
+    st.notOk(stateManager.cache._cache.keys[0])
+
+    let res2 = await promisifiedAccountIsEmpty('0x095e7baea6a6c7c4c2dfeb977efac326af552d87')
+
+    st.ok(res2)
+    st.equal(stateManager.cache._cache.keys[0], '0x095e7baea6a6c7c4c2dfeb977efac326af552d87')
+
+    st.end()
+  })
+
+  t.test('should call the callback with a false boolean representing emptiness when the account is empty', async (st) => {
+    const stateManager = new StateManager()
+    const account = createAccount('0x1', '0x1')
+
+    await promisify(stateManager.putAccount.bind(stateManager))(
+      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+      account
+    )
+
+    const promisifiedAccountIsEmpty = promisify(stateManager.accountIsEmpty.bind(stateManager), function (err, result) {
+      return err || result
+    })
+    let res = await promisifiedAccountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', true)
+
+    st.notOk(res)
+
     st.end()
   })
 })

--- a/tests/api/utils.js
+++ b/tests/api/utils.js
@@ -11,10 +11,10 @@ function createGenesis () {
   return genesis
 }
 
-function createAccount () {
+function createAccount (nonce, balance) {
   const raw = {
-    nonce: '0x00',
-    balance: '0xfff384'
+    nonce: nonce || '0x00',
+    balance: balance || '0xfff384'
   }
   const acc = new Account(raw)
   return acc


### PR DESCRIPTION
This PR fixes three currently failing blockchain tests:
- "OOGStateCopyContainingDeletedContract",
- "suicideCoinbase",
- "RecallSuicidedContractInOneBlock"

These started failing with https://github.com/ethereumjs/ethereumjs-vm/pull/147

The PR implements changes that are required for [EIP-158](https://github.com/ethereum/eips/issues/158). EIP-158 requires that accounts evaluated as empty be deleted.

With #147, we started checking if accounts were empty, in `runTx.js` by calling `stateManager.accountIsEmpty`. This in turn calls `stateManager.getAccount` which calls `cache.getOrLoad`.

The call to `cache.getOrLoad` is problematic because if it cannot find an account in the cache, it will add one to the cache. (Either the one it finds in the merkle tree / `cache.trie` or a new one.) However, this runs contrary to the original intention of the `stateManager.accountIsEmpty` call in `runTx.js` which deletes the account from the cache if it is found to be empty (thereby meeting some of the requirements of EIP158).

The result is that the expected state root hash from the state manager does not match what is expected given the header and is caught as an error after flushing the cache in `parseBlockResults()` of `runBlock.js`. (In between, the `stateManager.cache.flush` causes the account unintentionally added to the cache to be added to the trie, thereby changing its state root.)

The solution in this PR is to create a new method in stateManager which is to be called if you want to get an account without the side effect of adding it to the cache if it does not exist.

This also exposes another improvement that can be made (for which I will create an issue): refactoring existing calls of `stateManager.getAccount` so that we only call the `cache.getOrLoad` method when the side effect of loading a new account into the cache is desired.