### PR TITLE
Remove vm accesses to stateManager trie and cache

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,9 @@
     -   [Parameters][6]
 -   [runBlock~callback][7]
     -   [Parameters][8]
--   [vm.runTx][9]
+-   [runTx~callback][9]
     -   [Parameters][10]
--   [runTx~callback][11]
+-   [vm.runTx][11]
     -   [Parameters][12]
 -   [vm.runCode][13]
     -   [Parameters][14]
@@ -20,9 +20,9 @@
     -   [Parameters][16]
 -   [Event: beforeBlock][17]
     -   [Properties][18]
--   [Event: beforeTx][19]
+-   [Event: afterBlock][19]
     -   [Properties][20]
--   [Event: afterBlock][21]
+-   [Event: beforeTx][21]
     -   [Properties][22]
 -   [Event: afterTx][23]
     -   [Properties][24]
@@ -80,19 +80,6 @@ Type: [Function][30]
     -   `results.receipts` **[Array][39]** the receipts from the transactions in the block
     -   `results.results` **[Array][39]** 
 
-## vm.runTx
-
-Process a transaction. Run the vm. Transfers eth. Checks balances.
-
-### Parameters
-
--   `opts`  
-    -   `opts.tx` **Transaction** a [`Transaction`][40] to run
-    -   `opts.skipNonce` **[Boolean][34]** skips the nonce check
-    -   `opts.skipBalance` **[Boolean][34]** skips the balance check
-    -   `opts.block` **Block** the block to which the `tx` belongs, if no block is given a default one is created
--   `cb` **[runTx~callback][41]** the callback
-
 ## runTx~callback
 
 Callback for `runTx` method
@@ -106,7 +93,20 @@ Type: [Function][30]
     -   `results.amountSpent` **BN** the amount of ether used by this transaction as a `bignum`
     -   `results.gasUsed` **BN** the amount of gas as a `bignum` used by the transaction
     -   `results.gasRefund` **BN** the amount of gas as a `bignum` that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
--   `vm` **[VM][42]** contains the results from running the code, if any, as described in `vm.runCode(params, cb)`
+-   `vm` **[VM][40]** contains the results from running the code, if any, as described in `vm.runCode(params, cb)`
+
+## vm.runTx
+
+Process a transaction. Run the vm. Transfers eth. Checks balances.
+
+### Parameters
+
+-   `opts`  
+    -   `opts.tx` **Transaction** a [`Transaction`][41] to run
+    -   `opts.skipNonce` **[Boolean][34]** skips the nonce check
+    -   `opts.skipBalance` **[Boolean][34]** skips the balance check
+    -   `opts.block` **Block** the block to which the `tx` belongs, if no block is given a default one is created
+-   `cb` **[runTx~callback][42]** the callback
 
 ## vm.runCode
 
@@ -155,16 +155,6 @@ Type: [Object][31]
 
 -   `block` **Block** emits the block that is about to be processed
 
-## Event: beforeTx
-
-The `beforeTx` event
-
-Type: [Object][31]
-
-### Properties
-
--   `tx` **Transaction** emits the Transaction that is about to be processed
-
 ## Event: afterBlock
 
 The `afterBlock` event
@@ -174,6 +164,16 @@ Type: [Object][31]
 ### Properties
 
 -   `result` **[Object][31]** emits the results of processing a block
+
+## Event: beforeTx
+
+The `beforeTx` event
+
+Type: [Object][31]
+
+### Properties
+
+-   `tx` **Transaction** emits the Transaction that is about to be processed
 
 ## Event: afterTx
 
@@ -208,12 +208,11 @@ Type: [Object][31]
 -   `opcode` **[String][32]** the next opcode to be ran
 -   `gasLeft` **BN** amount of gasLeft
 -   `stack` **[Array][39]** an `Array` of `Buffers` containing the stack
--   `storageTrie` **Trie** the storage [trie][46] for the account
--   `account` **Account** the [`Account`][47] which owns the code running
+-   `account` **Account** the [`Account`][46] which owns the code running
 -   `address` **[Buffer][44]** the address of the `account`
 -   `depth` **[Number][33]** the current number of calls deep the contract is
 -   `memory` **[Buffer][44]** the memory of the VM as a `buffer`
--   `cache` **FunctionalRedBlackTree** the account cache. Contains all the accounts loaded from the trie. It is an instance of [functional red black tree][48]
+-   `storageManager` **StateManager** a state manager instance (EXPERIMENTAL - unstable API)
 
 [1]: #vmrunblockchain
 
@@ -231,11 +230,11 @@ Type: [Object][31]
 
 [8]: #parameters-3
 
-[9]: #vmruntx
+[9]: #runtxcallback
 
 [10]: #parameters-4
 
-[11]: #runtxcallback
+[11]: #vmruntx
 
 [12]: #parameters-5
 
@@ -251,11 +250,11 @@ Type: [Object][31]
 
 [18]: #properties
 
-[19]: #event-beforetx
+[19]: #event-afterblock
 
 [20]: #properties-1
 
-[21]: #event-afterblock
+[21]: #event-beforetx
 
 [22]: #properties-2
 
@@ -293,11 +292,11 @@ Type: [Object][31]
 
 [39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[40]: https://github.com/ethereum/ethereumjs-tx
+[40]: #vm
 
-[41]: #runtxcallback
+[41]: https://github.com/ethereum/ethereumjs-tx
 
-[42]: #vm
+[42]: #runtxcallback
 
 [43]: https://github.com/ethereumjs/ethereumjs-account
 
@@ -305,8 +304,4 @@ Type: [Object][31]
 
 [45]: #runcodecallback
 
-[46]: https://github.com/wanderer/merkle-patricia-tree
-
-[47]: https://github.com/ethereum/ethereumjs-account
-
-[48]: https://www.npmjs.com/package/functional-red-black-tree
+[46]: https://github.com/ethereum/ethereumjs-account

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,13 +6,12 @@ const async = require('async')
 var Cache = module.exports = function (trie) {
   this._cache = Tree()
   this._checkpoints = []
-  this._deletes = []
   this._trie = trie
 }
 
 Cache.prototype.put = function (key, val, fromTrie) {
   var modified = !fromTrie
-  this._update(key, val, modified, true)
+  this._update(key, val, modified, false)
 }
 
 // returns the queried account or an empty account
@@ -52,7 +51,7 @@ Cache.prototype.getOrLoad = function (key, cb) {
   } else {
     self._lookupAccount(key, function (err, account) {
       if (err) return cb(err)
-      self._update(key, account, false)
+      self._update(key, account, false, false)
       cb(null, account)
     })
   }
@@ -70,7 +69,7 @@ Cache.prototype.warm = function (addresses, cb) {
     var address = Buffer.from(addressHex, 'hex')
     self._lookupAccount(address, function (err, account) {
       if (err) return done(err)
-      self._update(address, account, false)
+      self._update(address, account, false, false)
       done()
     })
   }, cb)
@@ -91,19 +90,21 @@ Cache.prototype.flush = function (cb) {
         it.next()
         done()
       })
+    } else if (it.value && it.value.deleted) {
+      it.value.modified = false
+      it.value.deleted = false
+      it.value.val = (new Account()).serialize()
+      self._trie.del(Buffer.from(it.key, 'hex'), function () {
+        next = it.hasNext
+        it.next()
+        done()
+      })
     } else {
       next = it.hasNext
       it.next()
       done()
     }
-  }, function () {
-    async.eachSeries(self._deletes, function (address, done) {
-      self._trie.del(address, done)
-    }, function () {
-      self._deletes = []
-      cb()
-    })
-  })
+  }, cb)
 }
 
 Cache.prototype.checkpoint = function () {
@@ -119,28 +120,27 @@ Cache.prototype.commit = function () {
 }
 
 Cache.prototype.clear = function () {
-  this._deletes = []
   this._cache = Tree()
 }
 
 Cache.prototype.del = function (key) {
-  this._deletes.push(key)
-  key = key.toString('hex')
-  this._cache = this._cache.remove(key)
+  this._update(key, new Account(), false, true)
 }
 
-Cache.prototype._update = function (key, val, modified) {
+Cache.prototype._update = function (key, val, modified, deleted) {
   key = key.toString('hex')
   var it = this._cache.find(key)
   if (it.node) {
     this._cache = it.update({
       val: val,
-      modified: modified
+      modified: modified,
+      deleted: deleted
     })
   } else {
     this._cache = this._cache.insert(key, {
       val: val,
-      modified: modified
+      modified: modified,
+      deleted: deleted
     })
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const StateManager = require('./stateManager.js')
 const Common = require('ethereumjs-common')
 const Account = require('ethereumjs-account')
 const AsyncEventEmitter = require('async-eventemitter')
+const Trie = require('merkle-patricia-tree/secure.js')
 const fakeBlockchain = require('./fakeBlockChain.js')
 const BN = ethUtil.BN
 
@@ -54,11 +55,14 @@ function VM (opts = {}) {
   if (opts.stateManager) {
     this.stateManager = opts.stateManager
   } else {
-    this.stateManager = new StateManager({
-      trie: opts.state,
-      blockchain: opts.blockchain,
-      common: this._common
-    })
+    var trie = opts.state || new Trie()
+    if (opts.activatePrecompiles) {
+      trie = new Trie()
+      for (var i = 1; i <= 8; i++) {
+        trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
+      }
+    }
+    this.stateManager = new StateManager({ trie, common: this._common })
   }
 
   this.blockchain = opts.blockchain || fakeBlockchain
@@ -77,12 +81,6 @@ function VM (opts = {}) {
   this._precompiled['0000000000000000000000000000000000000007'] = num07
   this._precompiled['0000000000000000000000000000000000000008'] = num08
 
-  if (this.opts.activatePrecompiles) {
-    for (var i = 1; i <= 7; i++) {
-      this.stateManager.trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
-    }
-  }
-
   AsyncEventEmitter.call(this)
 }
 
@@ -97,12 +95,4 @@ VM.prototype.runBlockchain = require('./runBlockchain.js')
 
 VM.prototype.copy = function () {
   return new VM({ stateManager: this.stateManager.copy(), blockchain: this.blockchain })
-}
-
-/**
- * Loads precompiled contracts into the state
- * @private
- */
-VM.prototype.loadCompiled = function (address, src, cb) {
-  this.stateManager.trie.db.put(address, src, cb)
 }

--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -987,8 +987,10 @@ function makeCall (runState, callOptions, localOpts, cb) {
       runState.contract.nonce = new BN(runState.contract.nonce).addn(1)
     }
 
-    runState.stateManager.cache.put(runState.address, runState.contract)
-    runState._vm.runCall(callOptions, parseCallResults)
+    runState.stateManager.putAccount(runState.address, runState.contract, function (err) {
+      if (err) return cb(err)
+      runState._vm.runCall(callOptions, parseCallResults)
+    })
   }
 
   function parseCallResults (err, results) {

--- a/lib/runBlock.js
+++ b/lib/runBlock.js
@@ -46,16 +46,13 @@ module.exports = function (opts, cb) {
   var txResults = []
   var result
 
-  if (opts.root) {
-    self.stateManager.trie.root = opts.root
-  }
-
-  self.stateManager.trie.checkpoint()
+  self.stateManager.checkpoint()
 
   // run everything
   async.series([
     beforeBlock,
     validateBlock,
+    setStateRoot,
     processTransactions,
     payOmmersAndMiner
   ], parseBlockResults)
@@ -87,6 +84,14 @@ module.exports = function (opts, cb) {
       cb(new Error('Invalid block with gas limit greater than (2^63 - 1)'))
     } else {
       cb()
+    }
+  }
+
+  function setStateRoot (cb) {
+    if (opts.root) {
+      self.stateManager.setStateRoot(opts.root, cb)
+    } else {
+      cb(null)
     }
   }
 
@@ -157,11 +162,11 @@ module.exports = function (opts, cb) {
     }
   }
 
-    // credit all block rewards
+  // credit all block rewards
   function payOmmersAndMiner (cb) {
     var ommers = block.uncleHeaders
 
-      // pay each ommer
+    // pay each ommer
     async.series([
       rewardOmmers,
       rewardMiner
@@ -169,7 +174,7 @@ module.exports = function (opts, cb) {
 
     function rewardOmmers (done) {
       async.each(block.uncleHeaders, function (ommer, next) {
-          // calculate reward
+        // calculate reward
         var minerReward = new BN(self._common.param('pow', 'minerReward'))
         var heightDiff = new BN(block.header.number).sub(new BN(ommer.number))
         var reward = ((new BN(8)).sub(heightDiff)).mul(minerReward.divn(8))
@@ -183,7 +188,7 @@ module.exports = function (opts, cb) {
     }
 
     function rewardMiner (done) {
-        // calculate nibling reward
+      // calculate nibling reward
       var minerReward = new BN(self._common.param('pow', 'minerReward'))
       var niblingReward = minerReward.divn(32)
       var totalNiblingReward = niblingReward.muln(ommers.length)
@@ -194,7 +199,7 @@ module.exports = function (opts, cb) {
     function rewardAccount (address, reward, done) {
       self.stateManager.getAccount(address, function (err, account) {
         if (err) return done(err)
-          // give miner the block reward
+        // give miner the block reward
         account.balance = new BN(account.balance).add(reward)
         self.stateManager.putAccount(address, account, done)
       })
@@ -204,18 +209,23 @@ module.exports = function (opts, cb) {
   // handle results or error from block run
   function parseBlockResults (err) {
     if (err) {
-      self.stateManager.trie.revert()
-      cb(err)
+      self.stateManager.revert(function () {
+        cb(err)
+      })
       return
     }
 
-    // credit all block rewards
-    if (generateStateRoot) {
-      block.header.stateRoot = self.stateManager.trie.root
-    }
+    self.stateManager.commit(function (err) {
+      if (err) return cb(err)
 
-    self.stateManager.trie.commit(function (err) {
-      self.stateManager.cache.flush(function () {
+      self.stateManager.getStateRoot(function (err, stateRoot) {
+        if (err) return cb(err)
+
+        // credit all block rewards
+        if (generateStateRoot) {
+          block.header.stateRoot = stateRoot
+        }
+
         if (validateStateRoot) {
           if (receiptTrie.root && receiptTrie.root.toString('hex') !== block.header.receiptTrie.toString('hex')) {
             err = new Error((err || '') + 'invalid receiptTrie ')
@@ -226,12 +236,10 @@ module.exports = function (opts, cb) {
           if (ethUtil.bufferToInt(block.header.gasUsed) !== Number(gasUsed)) {
             err = new Error((err || '') + 'invalid gasUsed ')
           }
-          if (self.stateManager.trie.root.toString('hex') !== block.header.stateRoot.toString('hex')) {
+          if (stateRoot.toString('hex') !== block.header.stateRoot.toString('hex')) {
             err = new Error((err || '') + 'invalid block stateRoot ')
           }
         }
-
-        self.stateManager.cache.clear()
 
         result = {
           receipts: receipts,

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -150,7 +150,7 @@ module.exports = function (opts, cb) {
         depth: runState.depth,
         address: runState.address,
         account: runState.contract,
-        cache: runState.stateManager.cache,
+        stateManager: runState.stateManager,
         memory: runState.memory
       }
       /**
@@ -162,12 +162,11 @@ module.exports = function (opts, cb) {
        * @property {String} opcode the next opcode to be ran
        * @property {BN} gasLeft amount of gasLeft
        * @property {Array} stack an `Array` of `Buffers` containing the stack
-       * @property {Trie} storageTrie the storage [trie](https://github.com/wanderer/merkle-patricia-tree) for the account
        * @property {Account} account the [`Account`](https://github.com/ethereum/ethereumjs-account) which owns the code running
        * @property {Buffer} address the address of the `account`
        * @property {Number} depth the current number of calls deep the contract is
        * @property {Buffer} memory the memory of the VM as a `buffer`
-       * @property {FunctionalRedBlackTree} cache the account cache. Contains all the accounts loaded from the trie. It is an instance of [functional red black tree](https://www.npmjs.com/package/functional-red-black-tree)
+       * @property {StateManager} storageManager a state manager instance (EXPERIMENTAL - unstable API)
        */
       self.emit('step', eventObj, cb)
     }

--- a/lib/runTx.js
+++ b/lib/runTx.js
@@ -4,6 +4,7 @@ const utils = require('ethereumjs-util')
 const BN = utils.BN
 const Bloom = require('./bloom.js')
 const Block = require('ethereumjs-block')
+const Account = require('ethereumjs-account')
 
 /**
  * Process a transaction. Run the vm. Transfers eth. Checks balances.
@@ -63,8 +64,15 @@ module.exports = function (opts, cb) {
     runCall,
     runAfterTxHook
   ], function (err) {
-    if (err) self.stateManager.revert(() => cb(err, results))
-    else self.stateManager.commit((err) => cb(err, results))
+    if (err) {
+      self.stateManager.revert(function () {
+        cb(err, results)
+      })
+    } else {
+      self.stateManager.commit(function (err) {
+        cb(err, results)
+      })
+    }
   })
 
   // run the transaction hook
@@ -206,10 +214,10 @@ module.exports = function (opts, cb) {
 
         // save the miner's account
         if (!(new BN(minerAccount.balance).isZero())) {
-          self.stateManager.cache.put(block.header.coinbase, minerAccount)
+          self.stateManager.putAccount(block.header.coinbase, minerAccount, next)
+        } else {
+          next()
         }
-
-        next(null)
       }
 
       function cleanupAccounts (next) {
@@ -219,11 +227,20 @@ module.exports = function (opts, cb) {
 
         var keys = Object.keys(results.vm.selfdestruct)
 
-        keys.forEach(function (s) {
-          self.stateManager.cache.del(Buffer.from(s, 'hex'))
-        })
+        async.series([
+          deleteSelfDestructs,
+          cleanTouched
+        ], next)
 
-        self.stateManager.cleanupTouchedAccounts(next)
+        function deleteSelfDestructs (done) {
+          async.each(keys, function (s, cb) {
+            self.stateManager.putAccount(Buffer.from(s, 'hex'), new Account(), cb)
+          }, done)
+        }
+
+        function cleanTouched (done) {
+          self.stateManager.cleanupTouchedAccounts(done)
+        }
       }
     }
   }

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -26,6 +26,7 @@ function StateManager (opts = {}) {
   self.cache = new Cache(self.trie)
   self._touched = new Set()
   self._touchedStack = []
+  self._checkpointCount = 0
 }
 
 var proto = StateManager.prototype
@@ -38,22 +39,6 @@ proto.copy = function () {
 // the result in the cache
 proto.getAccount = function (address, cb) {
   this.cache.getOrLoad(address, cb)
-}
-
-proto._getAccountPure = function (address, cb) {
-  const self = this
-  const cachedAccount = this.cache.get(address)
-
-  if (cachedAccount) {
-    cb(null, cachedAccount)
-  } else {
-    self.trie.get(address, function (err, account) {
-      if (err) {
-        return cb(err)
-      }
-      cb(null, account)
-    })
-  }
 }
 
 // saves the account
@@ -214,6 +199,7 @@ proto.checkpoint = function () {
   self.trie.checkpoint()
   self.cache.checkpoint()
   self._touchedStack.push(new Set([...self._touched]))
+  self._checkpointCount++
 }
 
 proto.commit = function (cb) {
@@ -223,8 +209,9 @@ proto.commit = function (cb) {
     // setup cache checkpointing
     self.cache.commit()
     self._touchedStack.pop()
+    self._checkpointCount--
 
-    if (self._touchedStack.length === 0) self.cache.flush(cb)
+    if (self._checkpointCount === 0) self.cache.flush(cb)
     else cb()
   })
 }
@@ -237,8 +224,9 @@ proto.revert = function (cb) {
   self.cache.revert()
   self._storageTries = {}
   self._touched = self._touchedStack.pop()
+  self._checkpointCount--
 
-  if (self._touchedStack.length === 0) self.cache.flush(cb)
+  if (self._checkpointCount === 0) self.cache.flush(cb)
   else cb()
 }
 
@@ -253,6 +241,21 @@ proto.getStateRoot = function (cb) {
     }
     var stateRoot = self.trie.root
     cb(null, stateRoot)
+  })
+}
+
+proto.setStateRoot = function (stateRoot, cb) {
+  var self = this
+  self.cache.flush(function (err) {
+    if (err) { return cb(err) }
+    self.trie.checkRoot(stateRoot, function (err, hasRoot) {
+      if (err || !hasRoot) {
+        cb(err || new Error('State trie does not contain state root'))
+      } else {
+        self.trie.root = stateRoot
+        cb()
+      }
+    })
   })
 }
 
@@ -301,16 +304,9 @@ proto.generateGenesis = function (initState, cb) {
   }, cb)
 }
 
-proto.accountIsEmpty = function (address, getAccountWithoutLoad, cb) {
-  if (cb === undefined) {
-    cb = getAccountWithoutLoad
-    getAccountWithoutLoad = null
-  }
-
+proto.accountIsEmpty = function (address, cb) {
   var self = this
-  var getAccountCall = getAccountWithoutLoad ? self._getAccountPure : self.getAccount
-
-  getAccountCall.bind(this)(address, function (err, account) {
+  self.getAccount.bind(this)(address, function (err, account) {
     if (err) {
       return cb(err)
     }
@@ -324,7 +320,7 @@ proto.cleanupTouchedAccounts = function (cb) {
   var touchedArray = Array.from(self._touched)
   async.forEach(touchedArray, function (addressHex, next) {
     var address = Buffer.from(addressHex, 'hex')
-    self.accountIsEmpty(address, true, function (err, empty) {
+    self.accountIsEmpty(address, function (err, empty) {
       if (err) {
         next(err)
         return

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -73,6 +73,9 @@ tape('VM with blockchain', (t) => {
       testData.blocks[0].blockHeader.hash.slice(2)
     )
 
+    const setupPreP = promisify(setupPreConditions)
+    await setupPreP(vm.stateManager.trie, testData)
+
     vm.runBlock = (block, cb) => cb(new Error('test'))
     runBlockchainP(vm)
       .then(() => st.fail('it hasn\'t returned any errors'))

--- a/tests/api/runBlock.js
+++ b/tests/api/runBlock.js
@@ -31,7 +31,8 @@ function setup (vm = null) {
     data: testData,
     p: {
       runBlock: promisify(runBlock.bind(vm)),
-      putAccount: promisify(vm.stateManager.putAccount.bind(vm.stateManager))
+      putAccount: promisify(vm.stateManager.putAccount.bind(vm.stateManager)),
+      generateCanonicalGenesis: promisify(vm.stateManager.generateCanonicalGenesis.bind(vm.stateManager))
     }
   }
 }
@@ -58,6 +59,8 @@ tape('runBlock', async (t) => {
   t.test('should fail when runTx fails', async (st) => {
     const genesis = createGenesis()
     const block = new Block(util.rlp.decode(suite.data.blocks[0].rlp))
+
+    await suite.p.generateCanonicalGenesis()
 
     // The mocked VM uses a mocked runTx
     // which always returns an error.
@@ -92,7 +95,10 @@ tape('should fail when tx gas limit higher than block gas limit', async (t) => {
   const genesis = createGenesis()
   const block = new Block(util.rlp.decode(suite.data.blocks[0].rlp))
   block.transactions[0].gasLimit = Buffer.from('3fefba', 'hex')
-  suite.p.runBlock({ block, root: genesis.header.stateRoot })
+
+  await suite.p.generateCanonicalGenesis()
+
+  await suite.p.runBlock({ block, root: genesis.header.stateRoot })
     .then(() => t.fail('should have returned error'))
     .catch((e) => t.ok(e.message.includes('higher gas limit')))
 
@@ -109,6 +115,8 @@ tape('should fail when runCall fails', async (t) => {
     const acc = createAccount()
     await suite.p.putAccount(tx.from.toString('hex'), acc)
   }
+
+  await suite.p.generateCanonicalGenesis()
 
   // The mocked VM uses a mocked runCall
   // which always returns an error.

--- a/tests/api/runBlockchain.js
+++ b/tests/api/runBlockchain.js
@@ -89,6 +89,7 @@ function createBlock (parent = null, n = 0) {
   b.header.number = util.toBuffer(n)
   b.header.parentHash = parent.hash()
   b.header.difficulty = '0xfffffff'
+  b.header.stateRoot = parent.header.stateRoot
 
   return b
 }

--- a/tests/api/stateManager.js
+++ b/tests/api/stateManager.js
@@ -44,52 +44,20 @@ tape('StateManager', (t) => {
     st.end()
   })
 
-  t.test('should retrieve a cached account, without adding to the underlying cache if the account is not found', async (st) => {
-    const stateManager = new StateManager()
-    const account = createAccount()
-
-    await promisify(stateManager.putAccount.bind(stateManager))(
-      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b',
-      account
-    )
-
-    let res = await promisify(stateManager._getAccountPure.bind(stateManager))(
-      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
-    )
-
-    st.equal(res.balance.toString('hex'), 'fff384')
-
-    stateManager.cache.clear()
-
-    res = await promisify(stateManager._getAccountPure.bind(stateManager))(
-      'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
-    )
-
-    st.notOk(stateManager.cache._cache.keys[0])
-
-    st.end()
-  })
-
-  t.test('should call the callback with a boolean representing emptiness, and not cache the account if passed correct params', async (st) => {
+  t.test('should call the callback with a boolean representing emptiness, when the account is empty', async (st) => {
     const stateManager = new StateManager()
 
     const promisifiedAccountIsEmpty = promisify(stateManager.accountIsEmpty.bind(stateManager), function (err, result) {
       return err || result
     })
-    let res = await promisifiedAccountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', true)
+    let res = await promisifiedAccountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
 
     st.ok(res)
-    st.notOk(stateManager.cache._cache.keys[0])
-
-    let res2 = await promisifiedAccountIsEmpty('0x095e7baea6a6c7c4c2dfeb977efac326af552d87')
-
-    st.ok(res2)
-    st.equal(stateManager.cache._cache.keys[0], '0x095e7baea6a6c7c4c2dfeb977efac326af552d87')
 
     st.end()
   })
 
-  t.test('should call the callback with a false boolean representing emptiness when the account is empty', async (st) => {
+  t.test('should call the callback with a false boolean representing non-emptiness when the account is not empty', async (st) => {
     const stateManager = new StateManager()
     const account = createAccount('0x1', '0x1')
 
@@ -101,7 +69,7 @@ tape('StateManager', (t) => {
     const promisifiedAccountIsEmpty = promisify(stateManager.accountIsEmpty.bind(stateManager), function (err, result) {
       return err || result
     })
-    let res = await promisifiedAccountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', true)
+    let res = await promisifiedAccountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
 
     st.notOk(res)
 

--- a/tests/genesishashes.js
+++ b/tests/genesishashes.js
@@ -7,8 +7,13 @@ var vm = new VM()
 tape('[Common]: genesis hashes tests', function (t) {
   t.test('should generate the genesis state correctly', function (st) {
     vm.stateManager.generateCanonicalGenesis(function () {
-      st.equal(vm.stateManager.trie.root.toString('hex'), genesisData.genesis_state_root)
-      st.end()
+      vm.stateManager.getStateRoot(function (err, stateRoot) {
+        if (err) st.fail(err)
+        else {
+          st.equal(stateRoot.toString('hex'), genesisData.genesis_state_root)
+          st.end()
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
This is part of the broader discussion in #268 and #309 so readers should probably start there.

This PR removes all direct accesses, from the VM functions, to the `cache` and `trie`  properties of `stateManager`. This is essentially done by replacing calls to these properties to the equivalent   `stateManager` functions.

There are potentially two more controversial change here. The first is the removal of the  `loadCompiled` method on the VM. This method is unused internally and undocumented. It is problematic to keep this function as it interferes with checkpoint/commit structure used in `stateManager`. My assumption is that if someone desires this functionality they would interact with the `stateManager` directly prior to instantiating the vm. The second is the change of the `step` event which now exposes the `stateManager` instance rather than the `cache`. This is essentially a breaking change as the event object structure is documented.