### PR TITLE
Add emitFreeLogs option - Used for debugging/coverage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ VM Class, `new VM(opts)` creates a new VM object
     -   `opts.hardfork` **[String][32]** hardfork rules to be used [default: 'byzantium', supported: 'byzantium' (will throw on unsupported)]
     -   `opts.activatePrecompiles` **[Boolean][34]** create entries in the state tree for the precompiled contracts
     -   `opts.allowUnlimitedContractSize` **[Boolean][34]** allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170][35]) is bypassed. (default: `false`; ONLY set to `true` during debugging)
+    -   `opts.emitFreeLogs` **[Boolean][34]** Changes the behavior of the LOG opcode, the gas cost of the opcode becomes zero and calling it using STATICCALL won't throw. (default: `false`; ONLY set to `true` during debugging)
 
 ## vm.runBlock
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,7 @@ VM.deps = {
  * @param {String} opts.hardfork hardfork rules to be used [default: 'byzantium', supported: 'byzantium' (will throw on unsupported)]
  * @param {Boolean} opts.activatePrecompiles create entries in the state tree for the precompiled contracts
  * @param {Boolean} opts.allowUnlimitedContractSize allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. (default: `false`; ONLY set to `true` during debugging)
+ * @param {Boolean} opts.emitFreeLogs Changes the behavior of the LOG opcode, the gas cost of the opcode becomes zero and calling it using STATICCALL won't throw. (default: `false`; ONLY set to `true` during debugging)
  */
 function VM (opts = {}) {
   this.opts = opts
@@ -63,6 +64,7 @@ function VM (opts = {}) {
   this.blockchain = opts.blockchain || fakeBlockchain
 
   this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
+  this.emitFreeLogs = opts.emitFreeLogs === undefined ? false : opts.emitFreeLogs
 
   // precompiled contracts
   this._precompiled = {}

--- a/lib/opcodes.js
+++ b/lib/opcodes.js
@@ -160,7 +160,7 @@ const codes = {
   0xff: ['SELFDESTRUCT', 5000, 1, 0, false, true]
 }
 
-module.exports = function (op, full) {
+module.exports = function (op, full, freeLogs) {
   var code = codes[op] ? codes[op] : ['INVALID', 0, 0, 0, false, false]
   var opcode = code[0]
 
@@ -179,6 +179,12 @@ module.exports = function (op, full) {
 
     if (opcode === 'SWAP') {
       opcode += op - 0x8f
+    }
+  }
+
+  if (freeLogs) {
+    if (opcode === 'LOG') {
+      code[1] = 0
     }
   }
 

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -127,7 +127,7 @@ module.exports = function (opts, cb) {
 
   function iterateVm (done) {
     var opCode = runState.code[runState.programCounter]
-    var opInfo = lookupOpInfo(opCode)
+    var opInfo = lookupOpInfo(opCode, false, self.emitFreeLogs)
     var opName = opInfo.name
     var opFn = opFns[opName]
 
@@ -145,7 +145,7 @@ module.exports = function (opts, cb) {
       var eventObj = {
         pc: runState.programCounter,
         gasLeft: runState.gasLeft,
-        opcode: lookupOpInfo(opCode, true),
+        opcode: lookupOpInfo(opCode, true, self.emitFreeLogs),
         stack: runState.stack,
         depth: runState.depth,
         address: runState.address,
@@ -230,6 +230,12 @@ module.exports = function (opts, cb) {
         })
       }
 
+      // if opcode is log and emitFreeLogs is enabled, remove static context
+      let prevStatic = runState.static
+      if (self.emitFreeLogs && opName === 'LOG') {
+        runState.static = false
+      }
+
       try {
         // run the opcode
         var result = opFn.apply(null, args)
@@ -241,6 +247,9 @@ module.exports = function (opts, cb) {
           throw e
         }
       }
+
+      // restore previous static context
+      runState.static = prevStatic
 
       // save result to the stack
       if (result !== undefined) {

--- a/tests/api/freeLogs.js
+++ b/tests/api/freeLogs.js
@@ -1,0 +1,52 @@
+const tape = require('tape')
+const VM = require('../../lib/index')
+
+/*
+contract Contract1 {
+    event Event();
+    function() external {
+        emit Event();
+    }
+}
+*/
+
+const code = Buffer.from('6080604052348015600f57600080fd5b506040517f57050ab73f6b9ebdd9f76b8d4997793f48cf956e965ee070551b9ca0bb71584e90600090a10000a165627a7a72305820f80265dc41ca5376abe548a02070b68b91119b77dc54c76563b9c19a758cf26f0029', 'hex')
+
+tape('VM with free logs', async (t) => {
+  t.test('should run code without charging for log opcode', async (st) => {
+    const vm = new VM({ emitFreeLogs: true })
+    vm.runCode({
+      code: code,
+      gasLimit: 810
+    }, function (err, val) {
+      st.notOk(err)
+      st.ok(val.runState.gasLeft >= 0x177, 'should expend less gas')
+      st.ok(val.logs.length === 1, 'should emit event')
+      st.end()
+    })
+  })
+  t.test('should emit event on static context', async (st) => {
+    const vm = new VM({ emitFreeLogs: true })
+    vm.runCode({
+      code: code,
+      gasLimit: 24000,
+      static: true
+    }, function (err, val) {
+      st.notOk(err)
+      st.ok(val.logs.length === 1, 'should emit event')
+      st.end()
+    })
+  })
+  t.test('should not emit event on static context if flag is not set', async (st) => {
+    const vm = new VM()
+    vm.runCode({
+      code: code,
+      gasLimit: 24000,
+      static: true
+    }, function (err, val) {
+      st.ok(err)
+      st.ok(val.logs.length === 0, 'should emit zero events')
+      st.end()
+    })
+  })
+})


### PR DESCRIPTION
Some tools for debugging and creating coverage reports of contracts relay on adding events before compiling and testing, this is approach was proven to work on the solidity-coverage project https://github.com/sc-forks/solidity-coverage

By doing this, they elevate the cost of all the calls, and they can't cover views and pure functions, because the EVM will throw when those functions try to emit an event.

This _emitFreeLogs_ option allows instantiating an EVM instance without this limitation, enabling any contract to emit an unlimited quantity of events without modifying the block gas limit, and also to emit events during STATICCALLS.

**Note:**
Like _allowUnlimitedContractSize_, this (emitFreeLogs) option should only be used when debugging, any transaction calling the LOG opcode when this is enabled will behave differently than in the real EVM used on Ethereum mainnet and testnet.

Related: 
https://github.com/sc-forks/solidity-coverage/issues/234
https://github.com/OpenZeppelin/openzeppelin-solidity/pull/876#issuecomment-379621933