### PR TITLE
Fix freeLogs, don't modify codes constant

### DIFF
--- a/lib/opcodes.js
+++ b/lib/opcodes.js
@@ -182,11 +182,13 @@ module.exports = function (op, full, freeLogs) {
     }
   }
 
+  var fee = code[1]
+
   if (freeLogs) {
     if (opcode === 'LOG') {
-      code[1] = 0
+      fee = 0
     }
   }
 
-  return {name: opcode, opcode: op, fee: code[1], in: code[2], out: code[3], dynamic: code[4], async: code[5]}
+  return {name: opcode, opcode: op, fee: fee, in: code[2], out: code[3], dynamic: code[4], async: code[5]}
 }

--- a/tests/api/freeLogs.js
+++ b/tests/api/freeLogs.js
@@ -17,10 +17,22 @@ tape('VM with free logs', async (t) => {
     const vm = new VM({ emitFreeLogs: true })
     vm.runCode({
       code: code,
-      gasLimit: 810
+      gasLimit: 1000
     }, function (err, val) {
       st.notOk(err)
-      st.ok(val.runState.gasLeft >= 0x177, 'should expend less gas')
+      st.ok(val.runState.gasLeft >= 0x8e, 'should expend less gas')
+      st.ok(val.logs.length === 1, 'should emit event')
+      st.end()
+    })
+  })
+  t.test('should charge normal gas if flag is not set', async (st) => {
+    const vm = new VM()
+    vm.runCode({
+      code: code,
+      gasLimit: 1000
+    }, function (err, val) {
+      st.notOk(err)
+      st.ok(val.runState.gasLeft < 0x8e, 'should expend normal gas')
       st.ok(val.logs.length === 1, 'should emit event')
       st.end()
     })

--- a/tests/api/freeLogs.js
+++ b/tests/api/freeLogs.js
@@ -20,7 +20,7 @@ tape('VM with free logs', async (t) => {
       gasLimit: 1000
     }, function (err, val) {
       st.notOk(err)
-      st.ok(val.runState.gasLeft >= 0x8e, 'should expend less gas')
+      st.ok(val.runState.gasLeft >= 0x235, 'should expend less gas')
       st.ok(val.logs.length === 1, 'should emit event')
       st.end()
     })
@@ -32,7 +32,7 @@ tape('VM with free logs', async (t) => {
       gasLimit: 1000
     }, function (err, val) {
       st.notOk(err)
-      st.ok(val.runState.gasLeft < 0x8e, 'should expend normal gas')
+      st.ok(val.runState.gasLeft < 0x235, 'should expend normal gas')
       st.ok(val.logs.length === 1, 'should emit event')
       st.end()
     })


### PR DESCRIPTION
Error originated in #378 

Behavior:
Once the codes constant changed, the flag persisted until the VM was re-imported.

Desired:
New instances should always have false by default.

Added test case, should charge normal gas if flag is not set