### PR TITLE
Fix failing blockchain test GasLimitHigherThan2p63m1

### DIFF
--- a/lib/runBlock.js
+++ b/lib/runBlock.js
@@ -55,6 +55,7 @@ module.exports = function (opts, cb) {
   // run everything
   async.series([
     beforeBlock,
+    validateBlock,
     processTransactions,
     payOmmersAndMiner
   ], parseBlockResults)
@@ -79,6 +80,14 @@ module.exports = function (opts, cb) {
      * @property {Object} result emits the results of processing a block
      */
     self.emit('afterBlock', result, cb)
+  }
+
+  function validateBlock (cb) {
+    if (new BN(block.header.gasLimit).gte(new BN('8000000000000000', 16))) {
+      cb(new Error('Invalid block with gas limit greater than (2^63 - 1)'))
+    } else {
+      cb()
+    }
   }
 
   /**

--- a/tests/api/runBlock.js
+++ b/tests/api/runBlock.js
@@ -69,6 +69,23 @@ tape('runBlock', async (t) => {
   })
 })
 
+tape('should fail when block gas limit higher than 2^63-1', async (t) => {
+  const suite = setup()
+
+  const genesis = createGenesis()
+  const block = new Block({
+    header: {
+      ...suite.data.blocks[0].header,
+      gasLimit: Buffer.from('8000000000000000', 16)
+    }
+  })
+  suite.p.runBlock({ block, root: genesis.header.stateRoot })
+    .then(() => t.fail('should have returned error'))
+    .catch((e) => t.ok(e.message.includes('Invalid block')))
+
+  t.end()
+})
+
 tape('should fail when tx gas limit higher than block gas limit', async (t) => {
   const suite = setup()
 


### PR DESCRIPTION
This fixes the test GasLimitHigherThan2p63m1. `runBlock` should fail when the supplied block has a gas limit higher than `2^63 - 1` but currently this validation doesn't occur.

I ran into one of the failing blockchain tests from #338 whilst doing work on #376. The above test now passes but what I find odd is I can't find a reference to this in an EIP or in the yellow paper. I can see this exact logic present in `cpp-ethereum` and `go-ethereum` though so I thought I'd throw this out there. It might be the constant is better in `ethereumjs-common` but I left it in here for now; quite happy to update this if desired.