### PR TITLE
Fix blockhash opfn

### DIFF
--- a/lib/opFns.js
+++ b/lib/opFns.js
@@ -314,7 +314,7 @@ module.exports = {
       return
     }
 
-    blockchain.getBlock(number.toArrayLike(Buffer, 'be', 32), function (err, block) {
+    blockchain.getBlock(number, function (err, block) {
       if (err) return cb(err)
       var blockHash = block.hash()
       cb(null, new BN(blockHash))


### PR DESCRIPTION
This fixes the `BLOCKHASH` opcode which is essentially broken. Fixes the following blockchain tests:
* randomStatetest218BC
* randomStatetest240BC
* randomStatetest255BC
* randomStatetest331BC
* randomStatetest34BC
* randomStatetest35BC
* randomStatetest403BC
* randomStatetest431BC
* randomStatetest432BC
* randomStatetest598BC
* randomStatetest65BC
* BLOCKHASH_Bounds
* blockhashNonConstArg
* blockhashTests