### PR TITLE
Reactivated fixed tests from skipped broken tests list

### DIFF
--- a/tests/tester.js
+++ b/tests/tester.js
@@ -7,14 +7,6 @@ const testing = require('ethereumjs-testing')
 const FORK_CONFIG = argv.fork || 'Byzantium'
 // tests which should be fixed
 const skipBroken = [
-  'CreateHashCollision', // impossible hash collision on generating address
-  'RecursiveCreateContracts',
-  'createJS_ExampleContract', // creates an account that already exsists
-  'CreateCollisionToEmpty', // temporary till fixed (2017-09-21)
-  'TransactionCollisionToEmptyButCode', // temporary till fixed (2017-09-21)
-  'TransactionCollisionToEmptyButNonce', // temporary till fixed (2017-09-21)
-  'RevertDepthCreateAddressCollision', // test case is wrong
-  'randomStatetest642', // BROKEN, rustbn.js error
   'ecmul_0-3_5616_28000_96' // temporary till fixed (2018-09-20)
 ]
 // tests skipped due to system specifics / design considerations


### PR DESCRIPTION
Just tested the tests marked as broken in the skipped tests list in ``tester.js``.

The following tests are passing now and can be reactivated:

```
  'CreateHashCollision', // impossible hash collision on generating address
  'RecursiveCreateContracts',
  'createJS_ExampleContract', // creates an account that already exsists
  'CreateCollisionToEmpty', // temporary till fixed (2017-09-21)
  'TransactionCollisionToEmptyButCode', // temporary till fixed (2017-09-21)
  'TransactionCollisionToEmptyButNonce', // temporary till fixed (2017-09-21)
  'RevertDepthCreateAddressCollision', // test case is wrong
  'randomStatetest642', // BROKEN, rustbn.js error
```

Last test still failing is one test from ``ecmul_0-3_5616_28000_96``.