### PR TITLE
Fix casting genesis state addresses to buffer

### DIFF
--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -498,7 +498,7 @@ proto.generateGenesis = function (initState, cb) {
   async.eachSeries(addresses, function (address, done) {
     var account = new Account()
     account.balance = new BN(initState[address]).toArrayLike(Buffer)
-    address = Buffer.from(address, 'hex')
+    address = utils.toBuffer(address)
     self._trie.put(address, account.serialize(), done)
   }, cb)
 }


### PR DESCRIPTION
StateManager used `Buffer.from(address, 'hex')` to cast genesis state addresses to buffer, which returns empty after addresses were padded with `0x` in https://github.com/ethereumjs/ethereumjs-common/pull/33, resulting in some of the `runBlock` API tests failing.