### PR TITLE
Replace usages of sha3 with keccak256

### DIFF
--- a/tests/cacheTest.js
+++ b/tests/cacheTest.js
@@ -10,7 +10,7 @@ tape('test the cache api', function (t) {
   t.test('should have the correct value in the cache ', function (st) {
     var account1 = {
       address: Buffer.from('cd2a3d9f938e13cd947ec05abc7fe734df8dd826', 'hex'),
-      key: ethUtil.sha3('cow')
+      key: ethUtil.keccak256('cow')
     }
 
     /*

--- a/tests/util.js
+++ b/tests/util.js
@@ -118,7 +118,7 @@ exports.verifyPostConditions = function (state, testData, t, cb) {
   var keyMap = {}
 
   for (var key in testData) {
-    var hash = utils.sha3(Buffer.from(utils.stripHexPrefix(key), 'hex')).toString('hex')
+    var hash = utils.keccak256(Buffer.from(utils.stripHexPrefix(key), 'hex')).toString('hex')
     hashedAccounts[hash] = testData[key]
     keyMap[hash] = key
   }
@@ -182,7 +182,7 @@ exports.verifyAccountPostConditions = function (state, address, account, acctDat
 
   var hashedStorage = {}
   for (var key in acctData.storage) {
-    hashedStorage[utils.sha3(utils.setLength(Buffer.from(key.slice(2), 'hex'), 32)).toString('hex')] = acctData.storage[key]
+    hashedStorage[utils.keccak256(utils.setLength(Buffer.from(key.slice(2), 'hex'), 32)).toString('hex')] = acctData.storage[key]
   }
 
   if (storageKeys.length > 0) {
@@ -286,12 +286,12 @@ exports.fromAddress = function (hexString) {
 }
 
 /**
- * toCodeHash - applies sha3 to hexCode
+ * toCodeHash - applies keccak256 to hexCode
  * @param {String} hexCode string from tests repo
  * @returns {Buffer}
  */
 exports.toCodeHash = function (hexCode) {
-  return utils.sha3(Buffer.from(hexCode.slice(2), 'hex'))
+  return utils.keccak256(Buffer.from(hexCode.slice(2), 'hex'))
 }
 
 exports.makeBlockHeader = function (data) {


### PR DESCRIPTION
Follow-up to #319

This replaces usages of `sha3` missed in the `tests/` directory with the correct `keccak256`.