### PR TITLE
runCode: Add `memoryWordCount` to the `step` event object.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -199,6 +199,7 @@ Type: [Object][29]
 -   `address` **[Buffer][42]** the address of the `account`
 -   `depth` **[Number][32]** the current number of calls deep the contract is
 -   `memory` **[Buffer][42]** the memory of the VM as a `buffer`
+-   `memoryWordCount` **BN** current size of memory in words
 -   `stateManager` **StateManager** a [`StateManager`][30] instance (Beta API)
 
 [1]: #vmrunblockchain

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -152,7 +152,8 @@ module.exports = function (opts, cb) {
         address: runState.address,
         account: runState.contract,
         stateManager: runState.stateManager,
-        memory: runState.memory
+        memory: runState.memory,
+        memoryWordCount: runState.memoryWordCount
       }
       /**
        * The `step` event for trace output
@@ -167,6 +168,7 @@ module.exports = function (opts, cb) {
        * @property {Buffer} address the address of the `account`
        * @property {Number} depth the current number of calls deep the contract is
        * @property {Buffer} memory the memory of the VM as a `buffer`
+       * @property {BN} memoryWordCount current size of memory in words
        * @property {StateManager} stateManager a [`StateManager`](stateManager.md) instance (Beta API)
        */
       self.emit('step', eventObj, cb)


### PR DESCRIPTION
If a user modifies memory like shrinking and growing,
he also needs access to this property to reflect memory size changes.

~~This is needed to properly inject/modify the memory in the `step` event.
In my special case, I need to modify the `memoryWordCount` to properly
reflect changes.~~

~~Also, for other scenarios in the future, it might be necessary to have
the ability to have full access to the `runState` object.~~