### PR TITLE
Fix mixed sync/async funcs in cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -47,7 +47,7 @@ Cache.prototype.getOrLoad = function (key, cb) {
   var self = this
   var account = this.lookup(key)
   if (account) {
-    cb(null, account)
+    async.nextTick(cb, null, account)
   } else {
     self._lookupAccount(key, function (err, account) {
       if (err) return cb(err)
@@ -102,7 +102,7 @@ Cache.prototype.flush = function (cb) {
     } else {
       next = it.hasNext
       it.next()
-      done()
+      async.nextTick(done)
     }
   }, cb)
 }


### PR DESCRIPTION
Uses `async.nextTick` to defer calling the callback in two `cache` async functions. Tested manually, but wasn't sure how best to write tests for such an issue. Happy to add tests if anyone has an idea.

Fixes #421.