### PR TITLE
Convert Bloom to es6 class

### DIFF
--- a/lib/bloom/index.js
+++ b/lib/bloom/index.js
@@ -25,13 +25,13 @@ module.exports = class Bloom {
    */
   add (e) {
     e = utils.keccak256(e)
-    var mask = 2047 // binary 11111111111
+    const mask = 2047 // binary 11111111111
 
-    for (var i = 0; i < 3; i++) {
-      var first2bytes = e.readUInt16BE(i * 2)
-      var loc = mask & first2bytes
-      var byteLoc = loc >> 3
-      var bitLoc = 1 << loc % 8
+    for (let i = 0; i < 3; i++) {
+      const first2bytes = e.readUInt16BE(i * 2)
+      const loc = mask & first2bytes
+      const byteLoc = loc >> 3
+      const bitLoc = 1 << loc % 8
       this.bitvector[BYTE_SIZE - byteLoc - 1] |= bitLoc
     }
   }
@@ -44,14 +44,14 @@ module.exports = class Bloom {
    */
   check (e) {
     e = utils.keccak256(e)
-    var mask = 2047 // binary 11111111111
-    var match = true
+    const mask = 2047 // binary 11111111111
+    let match = true
 
-    for (var i = 0; i < 3 && match; i++) {
-      var first2bytes = e.readUInt16BE(i * 2)
-      var loc = mask & first2bytes
-      var byteLoc = loc >> 3
-      var bitLoc = 1 << loc % 8
+    for (let i = 0; i < 3 && match; i++) {
+      const first2bytes = e.readUInt16BE(i * 2)
+      const loc = mask & first2bytes
+      const byteLoc = loc >> 3
+      const bitLoc = 1 << loc % 8
       match = (this.bitvector[BYTE_SIZE - byteLoc - 1] & bitLoc)
     }
 
@@ -65,10 +65,7 @@ module.exports = class Bloom {
    * @returns {boolean} Returns {@code true} if every topic is in the bloom
    */
   multiCheck (topics) {
-    var self = this
-    return topics.every(function (t) {
-      return self.check(t)
-    })
+    return topics.every((t) => this.check(t))
   }
 
   /**
@@ -78,7 +75,7 @@ module.exports = class Bloom {
    */
   or (bloom) {
     if (bloom) {
-      for (var i = 0; i <= BYTE_SIZE; i++) {
+      for (let i = 0; i <= BYTE_SIZE; i++) {
         this.bitvector[i] = this.bitvector[i] | bloom.bitvector[i]
       }
     }

--- a/lib/bloom/index.js
+++ b/lib/bloom/index.js
@@ -2,82 +2,84 @@ const assert = require('assert')
 const utils = require('ethereumjs-util')
 const byteSize = 256
 
-/**
- * Represents a Bloom
- * @constructor
- * @param {Buffer} bitvector
- */
-var Bloom = module.exports = function (bitvector) {
-  if (!bitvector) {
-    this.bitvector = utils.zeros(byteSize)
-  } else {
-    assert(bitvector.length === byteSize, 'bitvectors must be 2048 bits long')
-    this.bitvector = bitvector
-  }
-}
-
-/**
- * adds an element to a bit vector of a 64 byte bloom filter
- * @method add
- * @param {Buffer} e the element to add
- */
-Bloom.prototype.add = function (e) {
-  e = utils.keccak256(e)
-  var mask = 2047 // binary 11111111111
-
-  for (var i = 0; i < 3; i++) {
-    var first2bytes = e.readUInt16BE(i * 2)
-    var loc = mask & first2bytes
-    var byteLoc = loc >> 3
-    var bitLoc = 1 << loc % 8
-    this.bitvector[byteSize - byteLoc - 1] |= bitLoc
-  }
-}
-
-/**
- * checks if an element is in the bloom
- * @method check
- * @param {Buffer} e the element to check
- * @returns {boolean} Returns {@code true} if the element is in the bloom
- */
-Bloom.prototype.check = function (e) {
-  e = utils.keccak256(e)
-  var mask = 2047 // binary 11111111111
-  var match = true
-
-  for (var i = 0; i < 3 && match; i++) {
-    var first2bytes = e.readUInt16BE(i * 2)
-    var loc = mask & first2bytes
-    var byteLoc = loc >> 3
-    var bitLoc = 1 << loc % 8
-    match = (this.bitvector[byteSize - byteLoc - 1] & bitLoc)
+module.exports = class Bloom {
+  /**
+   * Represents a Bloom
+   * @constructor
+   * @param {Buffer} bitvector
+   */
+  constructor (bitvector) {
+    if (!bitvector) {
+      this.bitvector = utils.zeros(byteSize)
+    } else {
+      assert(bitvector.length === byteSize, 'bitvectors must be 2048 bits long')
+      this.bitvector = bitvector
+    }
   }
 
-  return Boolean(match)
-}
+  /**
+   * adds an element to a bit vector of a 64 byte bloom filter
+   * @method add
+   * @param {Buffer} e the element to add
+   */
+  add (e) {
+    e = utils.keccak256(e)
+    var mask = 2047 // binary 11111111111
 
-/**
- * checks if multiple topics are in a bloom
- * @method multiCheck
- * @param {Buffer} topics
- * @returns {boolean} Returns {@code true} if every topic is in the bloom
- */
-Bloom.prototype.multiCheck = function (topics) {
-  var self = this
-  return topics.every(function (t) {
-    return self.check(t)
-  })
-}
+    for (var i = 0; i < 3; i++) {
+      var first2bytes = e.readUInt16BE(i * 2)
+      var loc = mask & first2bytes
+      var byteLoc = loc >> 3
+      var bitLoc = 1 << loc % 8
+      this.bitvector[byteSize - byteLoc - 1] |= bitLoc
+    }
+  }
 
-/**
- * bitwise or blooms together
- * @method or
- * @param {Bloom} bloom
- */
-Bloom.prototype.or = function (bloom) {
-  if (bloom) {
-    for (var i = 0; i <= byteSize; i++) {
-      this.bitvector[i] = this.bitvector[i] | bloom.bitvector[i]
+  /**
+   * checks if an element is in the bloom
+   * @method check
+   * @param {Buffer} e the element to check
+   * @returns {boolean} Returns {@code true} if the element is in the bloom
+   */
+  check (e) {
+    e = utils.keccak256(e)
+    var mask = 2047 // binary 11111111111
+    var match = true
+
+    for (var i = 0; i < 3 && match; i++) {
+      var first2bytes = e.readUInt16BE(i * 2)
+      var loc = mask & first2bytes
+      var byteLoc = loc >> 3
+      var bitLoc = 1 << loc % 8
+      match = (this.bitvector[byteSize - byteLoc - 1] & bitLoc)
+    }
+
+    return Boolean(match)
+  }
+
+  /**
+   * checks if multiple topics are in a bloom
+   * @method multiCheck
+   * @param {Buffer} topics
+   * @returns {boolean} Returns {@code true} if every topic is in the bloom
+   */
+  multiCheck (topics) {
+    var self = this
+    return topics.every(function (t) {
+      return self.check(t)
+    })
+  }
+
+  /**
+   * bitwise or blooms together
+   * @method or
+   * @param {Bloom} bloom
+   */
+  or (bloom) {
+    if (bloom) {
+      for (var i = 0; i <= byteSize; i++) {
+        this.bitvector[i] = this.bitvector[i] | bloom.bitvector[i]
+      }
     }
   }
 }

--- a/lib/bloom/index.js
+++ b/lib/bloom/index.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const utils = require('ethereumjs-util')
-const byteSize = 256
+
+const BYTE_SIZE = 256
 
 module.exports = class Bloom {
   /**
@@ -10,9 +11,9 @@ module.exports = class Bloom {
    */
   constructor (bitvector) {
     if (!bitvector) {
-      this.bitvector = utils.zeros(byteSize)
+      this.bitvector = utils.zeros(BYTE_SIZE)
     } else {
-      assert(bitvector.length === byteSize, 'bitvectors must be 2048 bits long')
+      assert(bitvector.length === BYTE_SIZE, 'bitvectors must be 2048 bits long')
       this.bitvector = bitvector
     }
   }
@@ -31,7 +32,7 @@ module.exports = class Bloom {
       var loc = mask & first2bytes
       var byteLoc = loc >> 3
       var bitLoc = 1 << loc % 8
-      this.bitvector[byteSize - byteLoc - 1] |= bitLoc
+      this.bitvector[BYTE_SIZE - byteLoc - 1] |= bitLoc
     }
   }
 
@@ -51,7 +52,7 @@ module.exports = class Bloom {
       var loc = mask & first2bytes
       var byteLoc = loc >> 3
       var bitLoc = 1 << loc % 8
-      match = (this.bitvector[byteSize - byteLoc - 1] & bitLoc)
+      match = (this.bitvector[BYTE_SIZE - byteLoc - 1] & bitLoc)
     }
 
     return Boolean(match)
@@ -77,7 +78,7 @@ module.exports = class Bloom {
    */
   or (bloom) {
     if (bloom) {
-      for (var i = 0; i <= byteSize; i++) {
+      for (var i = 0; i <= BYTE_SIZE; i++) {
         this.bitvector[i] = this.bitvector[i] | bloom.bitvector[i]
       }
     }


### PR DESCRIPTION
Converts Bloom to an es6 class, and moves it to a directory to have it as a separate module.

My thinking is to structure the VM as multiple modules which contain most of the code, and in the root directory (`lib/`) have code that connects these individual modules together. This should also ease our way into a monorepo (if we decided to go for it). Bloom was a low-hanging fruit, I'll create an issue to discuss how to structure the rest of the code.

Bloom is used only internally, and is not exposed, so this shouldn't be a breaking change.