### PR TITLE
fix typo: stateManager._cache

### DIFF
--- a/lib/hooked.js
+++ b/lib/hooked.js
@@ -32,7 +32,7 @@ function createHookedVm (opts, hooks) {
 
   var vm = new VM(opts)
   vm.stateManager._lookupStorageTrie = createAccountStorageTrie
-  vm.stateManager.cache._lookupAccount = loadAccount
+  vm.stateManager._cache._lookupAccount = loadAccount
   vm.stateManager.getContractCode = codeStore.get.bind(codeStore)
   vm.stateManager.setContractCode = codeStore.set.bind(codeStore)
 


### PR DESCRIPTION
There is no field "cache" in stateManager, it is called "_cache"