### PR TITLE
Change stateManager.trie to stateManager._trie in GeneralStateTestsRunner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+### IDE ###
+.idea
 
 ### Node ###
 # Logs

--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -91,6 +91,9 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
             cb(err)
           })
         } catch (err) {
+          if (err) {
+            console.log(err)
+          }
           cb()
         }
       }, function () {

--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -92,7 +92,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
           })
         } catch (err) {
           if (err) {
-            console.log(err)
+            t.fail(err)
           }
           cb()
         }

--- a/tests/GeneralStateTestsRunner.js
+++ b/tests/GeneralStateTestsRunner.js
@@ -100,9 +100,6 @@ function runTestCase (options, testData, t, cb) {
           tx: tx,
           block: block
         }, function (err, r) {
-          if (err) {
-            t.fail(err)
-          }
           err = null
           done()
         })

--- a/tests/GeneralStateTestsRunner.js
+++ b/tests/GeneralStateTestsRunner.js
@@ -101,7 +101,7 @@ function runTestCase (options, testData, t, cb) {
           block: block
         }, function (err, r) {
           if (err) {
-            console.log(err)
+            t.fail(err)
           }
           err = null
           done()

--- a/tests/GeneralStateTestsRunner.js
+++ b/tests/GeneralStateTestsRunner.js
@@ -91,7 +91,7 @@ function runTestCase (options, testData, t, cb) {
           })
           vm.on('afterTx', function (results) {
             let stateRoot = {
-              'stateRoot': results.vm.runState.stateManager.trie.root.toString('hex')
+              'stateRoot': results.vm.runState.stateManager._trie.root.toString('hex')
             }
             t.comment(JSON.stringify(stateRoot))
           })
@@ -100,6 +100,9 @@ function runTestCase (options, testData, t, cb) {
           tx: tx,
           block: block
         }, function (err, r) {
+          if (err) {
+            console.log(err)
+          }
           err = null
           done()
         })


### PR DESCRIPTION
Fix #390 

`stateManager.trie` should be `stateManager._trie` instead. I have also included a change to surface error message in test, as the testrunner was swallowing the error message, making it difficult to debug failing test.