### PR TITLE
Update API doc types for Bloom filter methods 

### DIFF
--- a/lib/bloom/index.js
+++ b/lib/bloom/index.js
@@ -21,7 +21,7 @@ module.exports = class Bloom {
   /**
    * adds an element to a bit vector of a 64 byte bloom filter
    * @method add
-   * @param {Buffer} e the element to add
+   * @param {Buffer|Array|String|Number} e the element to add
    */
   add (e) {
     e = utils.keccak256(e)
@@ -39,7 +39,7 @@ module.exports = class Bloom {
   /**
    * checks if an element is in the bloom
    * @method check
-   * @param {Buffer} e the element to check
+   * @param {Buffer|Array|String|Number} e the element to check
    * @returns {boolean} Returns {@code true} if the element is in the bloom
    */
   check (e) {
@@ -61,7 +61,7 @@ module.exports = class Bloom {
   /**
    * checks if multiple topics are in a bloom
    * @method multiCheck
-   * @param {Buffer} topics
+   * @param {Buffer[]|Array[]|String[]|Number[]} topics
    * @returns {boolean} Returns {@code true} if every topic is in the bloom
    */
   multiCheck (topics) {


### PR DESCRIPTION
Fixes #332 

Using the types that are expected in `utils.keccak256`, which is what `add` and `check` uses to process to params