### PR TITLE
Refactor memory manipulation in evm

### DIFF
--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -163,7 +163,7 @@ module.exports = function (opts, cb) {
         address: runState.address,
         account: runState.contract,
         stateManager: runState.stateManager,
-        memory: runState.memory,
+        memory: runState.memory._store, // Return underlying array for backwards-compatibility
         memoryWordCount: runState.memoryWordCount
       }
       /**

--- a/lib/runCode.js
+++ b/lib/runCode.js
@@ -17,6 +17,7 @@ const utils = require('ethereumjs-util')
 const Block = require('ethereumjs-block')
 const lookupOpInfo = require('./vm/opcodes.js')
 const opFns = require('./vm/opFns.js')
+const Memory = require('./vm/memory')
 const exceptions = require('./exceptions.js')
 const StorageReader = require('./storageReader')
 const setImmediate = require('timers').setImmediate
@@ -76,7 +77,7 @@ module.exports = function (opts, cb) {
     gasLeft: new BN(opts.gasLimit),
     gasLimit: new BN(opts.gasLimit),
     gasPrice: opts.gasPrice,
-    memory: [],
+    memory: new Memory(),
     memoryWordCount: new BN(0),
     stack: [],
     lastReturned: [],

--- a/lib/vm/memory.js
+++ b/lib/vm/memory.js
@@ -51,13 +51,14 @@ module.exports = class Memory {
 
   /**
    * Reads a slice of memory from `offset` till `offset + size` as a `Buffer`.
+   * It fills up the difference between memory's length and `offset + size` with zeros.
    * @param {Number} offset - Starting position
    * @param {Number} size - How many bytes to read
    * @returns {Buffer}
    */
   read (offset, size) {
     const loaded = this._store.slice(offset, offset + size)
-    // Fill the remaining lenth with zeros
+    // Fill the remaining length with zeros
     for (let i = loaded.length; i < size; i++) {
       loaded[i] = 0
     }

--- a/lib/vm/memory.js
+++ b/lib/vm/memory.js
@@ -1,0 +1,75 @@
+/**
+ * Memory implements a simple memory model
+ * for the ethereum virtual machine.
+ */
+module.exports = class Memory {
+  constructor () {
+    this._store = []
+  }
+
+  /**
+   * Extends the memory given an offset and size. Rounds extended
+   * memory to word-size.
+   * @param {Number} offset
+   * @param {size} size
+   */
+  extend (offset, size) {
+    if (size === 0) {
+      return
+    }
+
+    const newSize = ceil(offset + size, 32)
+    const sizeDiff = newSize - this._store.length
+    if (sizeDiff > 0) {
+      this._store = this._store.concat(new Array(sizeDiff).fill(0))
+    }
+  }
+
+  /**
+   * Writes a byte array with length `size` to memory, starting from `offset`.
+   * @param {Number} offset - Starting position
+   * @param {Number} size - How many bytes to write
+   * @param {Buffer} value - Value
+   */
+  write (offset, size, value) {
+    if (size === 0) {
+      return
+    }
+
+    if (value.length !== size) {
+      throw new Error('Invalid value size')
+    }
+
+    if (offset + size > this._store.length) {
+      throw new Error('Value exceeds memory capacity')
+    }
+
+    for (let i = 0; i < size; i++) {
+      this._store[offset + i] = value[i]
+    }
+  }
+
+  /**
+   * Reads a slice of memory from `offset` till `offset + size` as a `Buffer`.
+   * @param {Number} offset - Starting position
+   * @param {Number} size - How many bytes to read
+   * @returns {Buffer}
+   */
+  read (offset, size) {
+    const loaded = this._store.slice(offset, offset + size)
+    // Fill the remaining lenth with zeros
+    for (let i = loaded.length; i < size; i++) {
+      loaded[i] = 0
+    }
+    return Buffer.from(loaded)
+  }
+}
+
+const ceil = (value, ceiling) => {
+  const r = value % ceiling
+  if (r === 0) {
+    return value
+  } else {
+    return value + ceiling - r
+  }
+}

--- a/lib/vm/opFns.js
+++ b/lib/vm/opFns.js
@@ -259,7 +259,7 @@ module.exports = {
     subMemUsage(runState, memOffset, dataLength)
     subGas(runState, new BN(runState._common.param('gasPrices', 'copy')).imul(dataLength.divCeil(new BN(32))))
 
-    const data = getDataSlice(dataOffset, dataLength, runState.callData)
+    const data = getDataSlice(runState.callData, dataOffset, dataLength)
     memOffset = memOffset.toNumber()
     dataLength = dataLength.toNumber()
     runState.memory.extend(memOffset, dataLength)
@@ -272,7 +272,7 @@ module.exports = {
     subMemUsage(runState, memOffset, length)
     subGas(runState, new BN(runState._common.param('gasPrices', 'copy')).imul(length.divCeil(new BN(32))))
 
-    const data = getDataSlice(codeOffset, length, runState.code)
+    const data = getDataSlice(runState.code, codeOffset, length)
     memOffset = memOffset.toNumber()
     length = length.toNumber()
     runState.memory.extend(memOffset, length)
@@ -297,7 +297,7 @@ module.exports = {
 
     stateManager.getContractCode(address, function (err, code) {
       if (err) return cb(err)
-      const data = getDataSlice(codeOffset, length, code)
+      const data = getDataSlice(code, codeOffset, length)
       memOffset = memOffset.toNumber()
       length = length.toNumber()
       runState.memory.extend(memOffset, length)
@@ -341,7 +341,7 @@ module.exports = {
     subMemUsage(runState, memOffset, length)
     subGas(runState, new BN(runState._common.param('gasPrices', 'copy')).mul(length.divCeil(new BN(32))))
 
-    const data = getDataSlice(returnDataOffset, length, utils.toBuffer(runState.lastReturned))
+    const data = getDataSlice(utils.toBuffer(runState.lastReturned), returnDataOffset, length)
     memOffset = memOffset.toNumber()
     length = length.toNumber()
     runState.memory.extend(memOffset, length)
@@ -948,7 +948,7 @@ function subMemUsage (runState, offset, length) {
  * @param {BN} length
  * @param {Buffer} data
  */
-function getDataSlice (offset, length, data) {
+function getDataSlice (data, offset, length) {
   let len = new BN(data.length)
   if (offset.gt(len)) {
     offset = len
@@ -1041,7 +1041,7 @@ function makeCall (runState, callOptions, localOpts, cb) {
     // save results to memory
     if (results.vm.return && (!results.vm.exceptionError || results.vm.exceptionError.error === ERROR.REVERT)) {
       if (results.vm.return.length > 0) {
-        const data = getDataSlice(new BN(0), localOpts.outLength, results.vm.return)
+        const data = getDataSlice(results.vm.return, new BN(0), localOpts.outLength)
         const memOffset = localOpts.outOffset.toNumber()
         const dataLength = localOpts.outLength.toNumber()
         runState.memory.extend(memOffset, dataLength)

--- a/lib/vm/opFns.js
+++ b/lib/vm/opFns.js
@@ -197,7 +197,11 @@ module.exports = {
   },
   // 0x20 range - crypto
   SHA3: function (offset, length, runState) {
-    var data = memLoad(runState, offset, length)
+    subMemUsage(runState, offset, length)
+    let data = Buffer.alloc(0)
+    if (!length.isZero()) {
+      data = runState.memory.read(offset.toNumber(), length.toNumber())
+    }
     // copy fee
     subGas(runState, new BN(runState._common.param('gasPrices', 'sha3Word')).imul(length.divCeil(new BN(32))))
     return new BN(utils.keccak256(data))
@@ -252,17 +256,27 @@ module.exports = {
     }
   },
   CALLDATACOPY: function (memOffset, dataOffset, dataLength, runState) {
-    memStore(runState, memOffset, runState.callData, dataOffset, dataLength)
-    // sub the COPY fee
+    subMemUsage(runState, memOffset, dataLength)
     subGas(runState, new BN(runState._common.param('gasPrices', 'copy')).imul(dataLength.divCeil(new BN(32))))
+
+    const data = getDataSlice(dataOffset, dataLength, runState.callData)
+    memOffset = memOffset.toNumber()
+    dataLength = dataLength.toNumber()
+    runState.memory.extend(memOffset, dataLength)
+    runState.memory.write(memOffset, dataLength, data)
   },
   CODESIZE: function (runState) {
     return new BN(runState.code.length)
   },
   CODECOPY: function (memOffset, codeOffset, length, runState) {
-    memStore(runState, memOffset, runState.code, codeOffset, length)
-    // sub the COPY fee
+    subMemUsage(runState, memOffset, length)
     subGas(runState, new BN(runState._common.param('gasPrices', 'copy')).imul(length.divCeil(new BN(32))))
+
+    const data = getDataSlice(codeOffset, length, runState.code)
+    memOffset = memOffset.toNumber()
+    length = length.toNumber()
+    runState.memory.extend(memOffset, length)
+    runState.memory.write(memOffset, length, data)
   },
   EXTCODESIZE: function (address, runState, cb) {
     var stateManager = runState.stateManager
@@ -283,7 +297,12 @@ module.exports = {
 
     stateManager.getContractCode(address, function (err, code) {
       if (err) return cb(err)
-      memStore(runState, memOffset, code, codeOffset, length, false)
+      const data = getDataSlice(codeOffset, length, code)
+      memOffset = memOffset.toNumber()
+      length = length.toNumber()
+      runState.memory.extend(memOffset, length)
+      runState.memory.write(memOffset, length, data)
+
       cb(null)
     })
   },
@@ -319,9 +338,14 @@ module.exports = {
       trap(ERROR.OUT_OF_GAS)
     }
 
-    memStore(runState, memOffset, utils.toBuffer(runState.lastReturned), returnDataOffset, length, false)
-    // sub the COPY fee
+    subMemUsage(runState, memOffset, length)
     subGas(runState, new BN(runState._common.param('gasPrices', 'copy')).mul(length.divCeil(new BN(32))))
+
+    const data = getDataSlice(returnDataOffset, length, utils.toBuffer(runState.lastReturned))
+    memOffset = memOffset.toNumber()
+    length = length.toNumber()
+    runState.memory.extend(memOffset, length)
+    runState.memory.write(memOffset, length, data)
   },
   GASPRICE: function (runState) {
     return new BN(runState.gasPrice)
@@ -361,16 +385,24 @@ module.exports = {
   // 0x50 range - 'storage' and execution
   POP: function () {},
   MLOAD: function (pos, runState) {
-    return new BN(memLoad(runState, pos, new BN(32)))
+    subMemUsage(runState, pos, new BN(32))
+    const word = runState.memory.read(pos.toNumber(), 32)
+    return new BN(word)
   },
   MSTORE: function (offset, word, runState) {
     word = word.toArrayLike(Buffer, 'be', 32)
-    memStore(runState, offset, word, new BN(0), new BN(32))
+    subMemUsage(runState, offset, new BN(32))
+    offset = offset.toNumber()
+    runState.memory.extend(offset, 32)
+    runState.memory.write(offset, 32, word)
   },
   MSTORE8: function (offset, byte, runState) {
     // NOTE: we're using a 'trick' here to get the least significant byte
     byte = Buffer.from([ byte.andln(0xff) ])
-    memStore(runState, offset, byte, new BN(0), new BN(1))
+    subMemUsage(runState, offset, new BN(1))
+    offset = offset.toNumber()
+    runState.memory.extend(offset, 1)
+    runState.memory.write(offset, 1, byte)
   },
   SLOAD: function (key, runState, cb) {
     var stateManager = runState.stateManager
@@ -500,7 +532,11 @@ module.exports = {
     })
 
     const numOfTopics = runState.opCode - 0xa0
-    const mem = memLoad(runState, memOffset, memLength)
+    subMemUsage(runState, memOffset, memLength)
+    let mem = Buffer.alloc(0)
+    if (!memLength.isZero()) {
+      mem = runState.memory.read(memOffset.toNumber(), memLength.toNumber())
+    }
     subGas(runState, new BN(runState._common.param('gasPrices', 'logTopic')).imuln(numOfTopics).iadd(memLength.muln(runState._common.param('gasPrices', 'logData'))))
 
     // add address
@@ -518,7 +554,11 @@ module.exports = {
       trap(ERROR.STATIC_STATE_CHANGE)
     }
 
-    var data = memLoad(runState, offset, length)
+    subMemUsage(runState, offset, length)
+    let data = Buffer.alloc(0)
+    if (!length.isZero()) {
+      data = runState.memory.read(offset.toNumber(), length.toNumber())
+    }
 
     // set up config
     var options = {
@@ -546,7 +586,8 @@ module.exports = {
       trap(ERROR.STATIC_STATE_CHANGE)
     }
 
-    var data = memLoad(runState, offset, length)
+    subMemUsage(runState, offset, length)
+    const data = runState.memory.read(offset.toNumber(), length.toNumber())
 
     // set up config
     var options = {
@@ -576,7 +617,8 @@ module.exports = {
       trap(ERROR.STATIC_STATE_CHANGE)
     }
 
-    var data = memLoad(runState, inOffset, inLength)
+    subMemUsage(runState, inOffset, inLength)
+    const data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
 
     var options = {
       gasLimit: gasLimit,
@@ -634,7 +676,11 @@ module.exports = {
     var stateManager = runState.stateManager
     toAddress = addressToBuffer(toAddress)
 
-    var data = memLoad(runState, inOffset, inLength)
+    subMemUsage(runState, inOffset, inLength)
+    let data = Buffer.alloc(0)
+    if (!inLength.isZero()) {
+      data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    }
 
     const options = {
       gasLimit: gas,
@@ -685,7 +731,8 @@ module.exports = {
     var value = runState.callValue
     toAddress = addressToBuffer(toAddress)
 
-    var data = memLoad(runState, inOffset, inLength)
+    subMemUsage(runState, inOffset, inLength)
+    const data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
 
     const options = {
       gasLimit: gas,
@@ -728,7 +775,8 @@ module.exports = {
     var value = new BN(0)
     toAddress = addressToBuffer(toAddress)
 
-    var data = memLoad(runState, inOffset, inLength)
+    subMemUsage(runState, inOffset, inLength)
+    const data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
 
     var options = {
       gasLimit: gasLimit,
@@ -756,11 +804,19 @@ module.exports = {
     makeCall(runState, options, localOpts, done)
   },
   RETURN: function (offset, length, runState) {
-    runState.returnValue = memLoad(runState, offset, length)
+    subMemUsage(runState, offset, length)
+    runState.returnValue = Buffer.alloc(0)
+    if (!length.isZero()) {
+      runState.returnValue = runState.memory.read(offset.toNumber(), length.toNumber())
+    }
   },
   REVERT: function (offset, length, runState) {
     runState.stopped = true
-    runState.returnValue = memLoad(runState, offset, length)
+    subMemUsage(runState, offset, length)
+    runState.returnValue = Buffer.alloc(0)
+    if (!length.isZero()) {
+      runState.returnValue = runState.memory.read(offset.toNumber(), length.toNumber())
+    }
     trap(ERROR.REVERT)
   },
   // '0x70', range - other
@@ -874,92 +930,28 @@ function subMemUsage (runState, offset, length) {
 }
 
 /**
- * Loads bytes from memory and returns them as a buffer. If an error occurs
- * a string is instead returned. The function also subtracts the amount of
- * gas need for memory expansion.
- * @method memLoad
- * @param {Object} runState
- * @param {BN} offset where to start reading from
- * @param {BN} length how far to read
- * @returns {Buffer|String}
+ * Returns an overflow-safe slice of an array. It right-pads
+ * the data with zeros to `length`.
+ * @param {BN} offset
+ * @param {BN} length
+ * @param {Buffer} data
  */
-function memLoad (runState, offset, length) {
-  // check to see if we have enougth gas for the mem read
-  subMemUsage(runState, offset, length)
-
-  // shortcut
-  if (length.isZero()) {
-    return Buffer.alloc(0)
+function getDataSlice (offset, length, data) {
+  let len = new BN(data.length)
+  if (offset.gt(len)) {
+    offset = len
   }
 
-  // NOTE: in theory this could overflow, but unlikely due to OOG above
-  offset = offset.toNumber()
-  length = length.toNumber()
-
-  var loaded = runState.memory.slice(offset, offset + length)
-  // fill the remaining lenth with zeros
-  for (var i = loaded.length; i < length; i++) {
-    loaded[i] = 0
-  }
-  return Buffer.from(loaded)
-}
-
-/**
- * Stores bytes to memory. If an error occurs a string is instead returned.
- * The function also subtracts the amount of gas need for memory expansion.
- * @method memStore
- * @param {Object} runState
- * @param {BN} offset where to start reading from
- * @param {Buffer} val
- * @param {BN} valOffset
- * @param {BN} length how far to read
- * @param {Boolean} skipSubMem
- * @returns {Buffer|String}
- */
-function memStore (runState, offset, val, valOffset, length, skipSubMem) {
-  if (skipSubMem !== false) {
-    subMemUsage(runState, offset, length)
+  let end = offset.add(length)
+  if (end.gt(len)) {
+    end = len
   }
 
-  // shortcut
-  if (length.isZero()) {
-    return
-  }
+  data = data.slice(offset.toNumber(), end.toNumber())
+  // Right-pad with zeros to fill dataLength bytes
+  data = utils.setLengthRight(data, length.toNumber())
 
-  // NOTE: in theory this could overflow, but unlikely due to OOG above
-  offset = offset.toNumber()
-  length = length.toNumber()
-
-  var safeLen = 0
-  if (valOffset.addn(length).gtn(val.length)) {
-    if (valOffset.gten(val.length)) {
-      safeLen = 0
-    } else {
-      valOffset = valOffset.toNumber()
-      safeLen = val.length - valOffset
-    }
-  } else {
-    valOffset = valOffset.toNumber()
-    safeLen = val.length
-  }
-
-  let i = 0
-  if (safeLen > 0) {
-    safeLen = safeLen > length ? length : safeLen
-    for (; i < safeLen; i++) {
-      runState.memory[offset + i] = val[valOffset + i]
-    }
-  }
-
-  /*
-    pad the remaining length with zeros IF AND ONLY IF a value was stored
-    (even if value offset > value length, strange spec...)
-  */
-  if (val.length > 0 && i < length) {
-    for (; i < length; i++) {
-      runState.memory[offset + i] = 0
-    }
-  }
+  return data
 }
 
 // checks if a jump is valid given a destination
@@ -1036,7 +1028,13 @@ function makeCall (runState, callOptions, localOpts, cb) {
 
     // save results to memory
     if (results.vm.return && (!results.vm.exceptionError || results.vm.exceptionError.error === ERROR.REVERT)) {
-      memStore(runState, localOpts.outOffset, results.vm.return, new BN(0), localOpts.outLength, false)
+      if (results.vm.return.length > 0) {
+        const data = getDataSlice(new BN(0), localOpts.outLength, results.vm.return)
+        const memOffset = localOpts.outOffset.toNumber()
+        const dataLength = localOpts.outLength.toNumber()
+        runState.memory.extend(memOffset, dataLength)
+        runState.memory.write(memOffset, dataLength, data)
+      }
 
       if (results.vm.exceptionError && results.vm.exceptionError.error === ERROR.REVERT && isCreateOpCode(runState.opName)) {
         runState.lastReturned = results.vm.return

--- a/lib/vm/opFns.js
+++ b/lib/vm/opFns.js
@@ -587,7 +587,10 @@ module.exports = {
     }
 
     subMemUsage(runState, offset, length)
-    const data = runState.memory.read(offset.toNumber(), length.toNumber())
+    let data = Buffer.alloc(0)
+    if (!length.isZero()) {
+      data = runState.memory.read(offset.toNumber(), length.toNumber())
+    }
 
     // set up config
     var options = {
@@ -618,7 +621,10 @@ module.exports = {
     }
 
     subMemUsage(runState, inOffset, inLength)
-    const data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    let data = Buffer.alloc(0)
+    if (!inLength.isZero()) {
+      data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    }
 
     var options = {
       gasLimit: gasLimit,
@@ -732,7 +738,10 @@ module.exports = {
     toAddress = addressToBuffer(toAddress)
 
     subMemUsage(runState, inOffset, inLength)
-    const data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    let data = Buffer.alloc(0)
+    if (!inLength.isZero()) {
+      data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    }
 
     const options = {
       gasLimit: gas,
@@ -776,7 +785,10 @@ module.exports = {
     toAddress = addressToBuffer(toAddress)
 
     subMemUsage(runState, inOffset, inLength)
-    const data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    let data = Buffer.alloc(0)
+    if (!inLength.isZero()) {
+      data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
+    }
 
     var options = {
       gasLimit: gasLimit,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "testBuildIntegrity": "npm run build:dist && node ./tests/tester -s --dist --test='stackOverflow'",
     "testBlockchain": "npm run build:dist && node --stack-size=1500 ./tests/tester -b --fork='Constantinople' --dist --excludeDir='GeneralStateTests'",
     "testBlockchainGeneralStateTests": "npm run build:dist && node --stack-size=1500 ./tests/tester -b --dist --dir='GeneralStateTests'",
-    "testAPI": "tape ./tests/api/*.js",
+    "testAPI": "tape './tests/api/**/*.js'",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
     "lint": "standard",
     "prepublishOnly": "npm run lint && npm run build:dist && npm run testBuildIntegrity",

--- a/tests/api/vm/memory.js
+++ b/tests/api/vm/memory.js
@@ -1,0 +1,43 @@
+const tape = require('tape')
+const Memory = require('../../../lib/vm/memory')
+
+tape('Memory', t => {
+  const m = new Memory()
+  t.test('should have 0 capacity initially', st => {
+    st.equal(m._store.length, 0)
+    st.throws(() => m.write(0, 3, Buffer.from([1, 2, 3])), /capacity/)
+    st.end()
+  })
+
+  t.test('should return zeros from empty memory', st => {
+    st.deepEqual(m.read(0, 3), Buffer.from([0, 0, 0]))
+    st.end()
+  })
+
+  t.test('should extend capacity to word boundary', st => {
+    m.extend(0, 3)
+    st.equal(m._store.length, 32)
+    st.end()
+  })
+
+  t.test('should return zeros before writing', st => {
+    st.deepEqual(m.read(0, 2), Buffer.from([0, 0]))
+    st.end()
+  })
+
+  t.test('should not write value beyond capacity', st => {
+    st.throws(() => m.write(30, 3, Buffer.from([1, 2, 3])), /capacity/)
+    st.end()
+  })
+
+  t.test('should write value', st => {
+    m.write(29, 3, Buffer.from([1, 2, 3]))
+    st.deepEqual(m.read(29, 5), Buffer.from([1, 2, 3, 0, 0]))
+    st.end()
+  })
+
+  t.test('should fail when value len and size are inconsistent', st => {
+    st.throws(() => m.write(0, 5, Buffer.from([8, 8, 8])), /size/)
+    st.end()
+  })
+})

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -9,10 +9,8 @@ const {
 } = require('./util')
 // tests which should be fixed
 const skipBroken = [
-  'ExtCodeCopyTargetRangeLongerThanCodeTests', // temporary till fixed (2018-11-14)
   'CallIdentity_6_inputShorterThanOutput', // temporary till fixed (2018-11-14)
   'ecmul_0-3_5616_28000_96', // temporary till fixed (2018-09-20)
-  'codeCopyZero', // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
   'dynamicAccountOverwriteEmpty' // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
 ]
 // tests skipped due to system specifics / design considerations


### PR DESCRIPTION
This PR:

- Introduces the `Memory` class used for evm memory manipulation
- Removes `memStore` and `memLoad` and moves the logic to opcode handlers. The goal is to increase verbosity and reduce code hidden in utility functions
- In some opcodes, it reduces copy gas before attempting memory write
- The test cases `ExtCodeCopyTargetRangeLongerThanCodeTests` and `codeCopyZero` which were skipped previously have been fixed and are no longer skipped
- This is part of the same effort as in #424 and #431.

Similar to before, `offset` and `length` are cast from `BN` to normal JS numbers, which means if they're bigger than 53 bits `BN` throws an exception. Gas limit should probably cap how bug `offset` and `length` can become, but it might be better to address this issue somehow in future. The only solution that came to my mind is to use a `Map` instead of a normal array for memory, and to store indices as a `Buffer` which can be arbitrary long. But I imagine this would be less performant.