### PR TITLE
Make fakeBlockChain return blocks with the right hash

### DIFF
--- a/lib/fakeBlockChain.js
+++ b/lib/fakeBlockChain.js
@@ -1,5 +1,4 @@
 const Buffer = require('safe-buffer').Buffer
-const utils = require('ethereumjs-util')
 
 module.exports = {
   fake: true,
@@ -7,9 +6,9 @@ module.exports = {
     var hash
 
     if (Buffer.isBuffer(blockTag)) {
-      hash = utils.keccak256(blockTag)
+      hash = blockTag
     } else if (Number.isInteger(blockTag)) {
-      hash = utils.keccak256('0x' + utils.toBuffer(blockTag).toString('hex'))
+      return cb(new Error('fakeBlockChain can\'t return blocks by number'))
     } else {
       return cb(new Error('Unknown blockTag type'))
     }

--- a/tests/api/fakeBlockChain.js
+++ b/tests/api/fakeBlockChain.js
@@ -5,19 +5,16 @@ tape('fakeBlockChain', (t) => {
   const blockchain = fakeBlockchain
 
   t.test('should fail to get block by invalid type', (st) => {
-    blockchain.getBlock(null, (err, block) => {
-      st.ok(err, 'should return error')
-      st.notOk(block)
-      st.end()
-    })
+    blockchain.getBlock(null, isError(st, 'Unknown blockTag type'))
   })
 
-  t.test('should get block hash by number', (st) => {
-    blockchain.getBlock(1, isValidBlock(st))
+  t.test('should not get block hash by number', (st) => {
+    blockchain.getBlock(1, isError(st, 'fakeBlockChain can\'t return blocks by number'))
   })
 
-  t.test('should get block hash by buffer', (st) => {
-    blockchain.getBlock(Buffer.from('0x0'), isValidBlock(st))
+  t.test('should get block by hash', (st) => {
+    const hash = Buffer.from('d71b71b0860adfe1ebd703eb8025d1d312925aa3e759e0542967ff1915f7b991', 'hex')
+    blockchain.getBlock(hash, isValidBlock(st, hash))
   })
 
   t.test('should "del" block', (st) => {
@@ -28,9 +25,23 @@ tape('fakeBlockChain', (t) => {
   })
 })
 
-const isValidBlock = (st) => (err, block) => {
+const isValidBlock = (st, expectedHash) => (err, block) => {
   st.notOk(err)
   st.ok(block, 'should return non-empty value')
   st.ok(Buffer.isBuffer(block.hash()), 'block hash should of type buffer')
+
+  if (expectedHash) {
+    st.ok(
+      expectedHash.compare(block.hash()) === 0,
+      'block should have hash ' + expectedHash.toString('hex')
+    )
+  }
+  st.end()
+}
+
+const isError = (st, errorMessage) => (err, block) => {
+  st.ok(err, 'should return error')
+  st.ok(err.message === errorMessage, 'should return error')
+  st.notOk(block)
   st.end()
 }


### PR DESCRIPTION
This PR fixes #446. 

This changes make `fakeBlockChain` return "blocks" with the hash that was requested. It also makes it throw if the `blockTag` is a number, as there's no way to return a block with the right hash in that case.