### PR TITLE
Complete switch to Petersburg on tests | Fix coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "testStateConstantinople": "npm run build:dist && node ./tests/tester -s --fork='Constantinople' --dist",
     "testStatePetersburg": "npm run build:dist && node ./tests/tester -s --fork='Petersburg' --dist",
     "testBuildIntegrity": "npm run build:dist && node ./tests/tester -s --dist --test='stackOverflow'",
-    "testBlockchain": "npm run build:dist && node --stack-size=1500 ./tests/tester -b --fork='Constantinople' --dist --excludeDir='GeneralStateTests'",
+    "testBlockchain": "npm run build:dist && node --stack-size=1500 ./tests/tester -b --fork='Petersburg' --dist --excludeDir='GeneralStateTests'",
     "testBlockchainGeneralStateTests": "npm run build:dist && node --stack-size=1500 ./tests/tester -b --dist --dir='GeneralStateTests'",
     "testAPI": "tape './tests/api/**/*.js'",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -3,7 +3,7 @@
 const argv = require('minimist')(process.argv.slice(2))
 const tape = require('tape')
 const testing = require('ethereumjs-testing')
-const FORK_CONFIG = argv.fork || 'Byzantium'
+const FORK_CONFIG = argv.fork || 'Petersburg'
 const {
   getRequiredForkConfigAlias
 } = require('./util')


### PR DESCRIPTION
Main trigger for this was that ``coverage`` was still running on ``Byzantium`` and so coverage was inaccurate since e.g. the new opcodes were not shown yet as covered.

I also updated the ``testBlockchain`` command to run on ``Petersburg``.