### PR TITLE
Test to fix temporary broken dependency on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - *restore_node_modules
       - run:
           name: npm install
-          command: npm install
+          command: npm install highlight.js@9.14.2 && npm install
       - save_cache:
           name: Save node_modules cache
           key: v1-node-{{ .Branch }}-{{ checksum "package.json" }}


### PR DESCRIPTION
This is a manual test to see if this is a way to temporary fix CircleCI builds on acute dependency brokenness cases, see discussion here: https://github.com/ethereumjs/ethereumjs-vm/pull/451 (e.g.)

DO NOT MERGE.