### PR TITLE
Fix longer output than return length in call opcode

### DIFF
--- a/lib/vm/opFns.js
+++ b/lib/vm/opFns.js
@@ -1047,9 +1047,12 @@ function makeCall (runState, callOptions, localOpts, cb) {
     // save results to memory
     if (results.vm.return && (!results.vm.exceptionError || results.vm.exceptionError.error === ERROR.REVERT)) {
       if (results.vm.return.length > 0) {
-        const data = getDataSlice(results.vm.return, new BN(0), localOpts.outLength)
         const memOffset = localOpts.outOffset.toNumber()
-        const dataLength = localOpts.outLength.toNumber()
+        let dataLength = localOpts.outLength.toNumber()
+        if (results.vm.return.length < dataLength) {
+          dataLength = results.vm.return.length
+        }
+        const data = getDataSlice(results.vm.return, new BN(0), new BN(dataLength))
         runState.memory.extend(memOffset, dataLength)
         runState.memory.write(memOffset, dataLength, data)
       }

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -9,7 +9,6 @@ const {
 } = require('./util')
 // tests which should be fixed
 const skipBroken = [
-  'CallIdentity_6_inputShorterThanOutput', // temporary till fixed (2018-11-14)
   'ecmul_0-3_5616_28000_96', // temporary till fixed (2018-09-20)
   'dynamicAccountOverwriteEmpty' // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
 ]


### PR DESCRIPTION
Fixes the case where `outLength` in `CALL` is longer than the actual data returned, which resulted in the difference being overwritten with zeros. This fixes the `CallIdentity_6_inputShorterThanOutput` test case.