### PR TITLE
[WIP] Use BN reduction context in modexp precompile

### DIFF
--- a/lib/precompiled/05-modexp.js
+++ b/lib/precompiled/05-modexp.js
@@ -56,14 +56,14 @@ function getAdjustedExponentLength (data) {
   return adjustedExpLen
 }
 
-// Taken from https://stackoverflow.com/a/1503019
 function expmod (B, E, M) {
   if (E.isZero()) return new BN(1).mod(M)
-  var BM = B.mod(M)
-  var R = expmod(BM, E.divn(2), M)
-  R = (R.mul(R)).mod(M)
-  if (E.mod(new BN(2)).isZero()) return R
-  return (R.mul(BM)).mod(M)
+  // Red asserts M > 1
+  if (M.lten(1)) return new BN(0)
+  const red = BN.red(M)
+  const redB = B.toRed(red)
+  const res = redB.redPow(E)
+  return res.fromRed()
 }
 
 function getOOGResults (opts, results) {


### PR DESCRIPTION
This PR attempts to fix #214. I tried to use `BN.mont` explicitly, but got some weird result:

`new BN(1).toRed(BN.mont(new BN('64', 16))).fromRed()` which I thought should return `0x1`, actually returns `0x18`! Not sure if this is a bug or intended?

Should I do benchmarks to make sure this is actually more performant?

~~Update: It's running out of heap memory on `modexp_37120_37111_1_1000000`~~