### PR TITLE
Fix ecmul_0-3_5616_28000_96

### DIFF
--- a/tests/tester.js
+++ b/tests/tester.js
@@ -9,7 +9,6 @@ const {
 } = require('./util')
 // tests which should be fixed
 const skipBroken = [
-  'ecmul_0-3_5616_28000_96', // temporary till fixed (2018-09-20)
   'dynamicAccountOverwriteEmpty' // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
 ]
 // tests skipped due to system specifics / design considerations


### PR DESCRIPTION
This PR fixes the failing `ecmul_0-3_5616_28000_96` test case. You might notice that the fix is not done in code, but in the test suite. I noticed that the tx is not being executed at all, because the tx sender doesn't have enough balance, but I was puzzled why then this invalid test is failing. I found an explanation in https://github.com/PegaSysEng/pantheon/pull/106. Here's a summary:

A requirement of the test harness is that if a test is invalid and the coinbase account is empty, it should be dropped from the state. This is mainly for state tests, as in blockchain tests, an invalid tx is simply rejected.

It might be a good idea to verify this nevertheless.