### PR TITLE
Convert VM to es6 class

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const Buffer = require('safe-buffer').Buffer
-const util = require('util')
 const ethUtil = require('ethereumjs-util')
 const { StateManager } = require('./state')
 const Common = require('ethereumjs-common').default
@@ -19,15 +18,6 @@ const num06 = require('./precompiled/06-ecadd.js')
 const num07 = require('./precompiled/07-ecmul.js')
 const num08 = require('./precompiled/08-ecpairing.js')
 
-module.exports = VM
-
-VM.deps = {
-  ethUtil: ethUtil,
-  Account: require('ethereumjs-account'),
-  Trie: require('merkle-patricia-tree'),
-  rlp: require('ethereumjs-util').rlp
-}
-
 /**
  * VM Class, `new VM(opts)` creates a new VM object
  * @method VM
@@ -41,58 +31,58 @@ VM.deps = {
  * @param {Boolean} opts.allowUnlimitedContractSize allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed. (default: `false`; ONLY set to `true` during debugging)
  * @param {Boolean} opts.emitFreeLogs Changes the behavior of the LOG opcode, the gas cost of the opcode becomes zero and calling it using STATICCALL won't throw. (default: `false`; ONLY set to `true` during debugging)
  */
-function VM (opts = {}) {
-  this.opts = opts
+module.exports = class VM extends AsyncEventEmitter {
+  constructor (opts = {}) {
+    super()
 
-  let chain = opts.chain ? opts.chain : 'mainnet'
-  let hardfork = opts.hardfork ? opts.hardfork : 'byzantium'
-  let supportedHardforks = [
-    'byzantium',
-    'constantinople',
-    'petersburg'
-  ]
-  this._common = new Common(chain, hardfork, supportedHardforks)
+    this.opts = opts
 
-  if (opts.stateManager) {
-    this.stateManager = opts.stateManager
-  } else {
-    var trie = opts.state || new Trie()
-    if (opts.activatePrecompiles) {
-      for (var i = 1; i <= 8; i++) {
-        trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
+    let chain = opts.chain ? opts.chain : 'mainnet'
+    let hardfork = opts.hardfork ? opts.hardfork : 'byzantium'
+    let supportedHardforks = [
+      'byzantium',
+      'constantinople',
+      'petersburg'
+    ]
+    this._common = new Common(chain, hardfork, supportedHardforks)
+
+    if (opts.stateManager) {
+      this.stateManager = opts.stateManager
+    } else {
+      var trie = opts.state || new Trie()
+      if (opts.activatePrecompiles) {
+        for (var i = 1; i <= 8; i++) {
+          trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
+        }
       }
+      this.stateManager = new StateManager({ trie, common: this._common })
     }
-    this.stateManager = new StateManager({ trie, common: this._common })
+
+    this.blockchain = opts.blockchain || fakeBlockchain
+
+    this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
+    this.emitFreeLogs = opts.emitFreeLogs === undefined ? false : opts.emitFreeLogs
+
+    // precompiled contracts
+    this._precompiled = {}
+    this._precompiled['0000000000000000000000000000000000000001'] = num01
+    this._precompiled['0000000000000000000000000000000000000002'] = num02
+    this._precompiled['0000000000000000000000000000000000000003'] = num03
+    this._precompiled['0000000000000000000000000000000000000004'] = num04
+    this._precompiled['0000000000000000000000000000000000000005'] = num05
+    this._precompiled['0000000000000000000000000000000000000006'] = num06
+    this._precompiled['0000000000000000000000000000000000000007'] = num07
+    this._precompiled['0000000000000000000000000000000000000008'] = num08
+
+    this.runCode = require('./runCode.js').bind(this)
+    this.runJIT = require('./runJit.js').bind(this)
+    this.runBlock = require('./runBlock.js').bind(this)
+    this.runTx = require('./runTx.js').bind(this)
+    this.runCall = require('./runCall.js').bind(this)
+    this.runBlockchain = require('./runBlockchain.js').bind(this)
   }
 
-  this.blockchain = opts.blockchain || fakeBlockchain
-
-  this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
-  this.emitFreeLogs = opts.emitFreeLogs === undefined ? false : opts.emitFreeLogs
-
-  // precompiled contracts
-  this._precompiled = {}
-  this._precompiled['0000000000000000000000000000000000000001'] = num01
-  this._precompiled['0000000000000000000000000000000000000002'] = num02
-  this._precompiled['0000000000000000000000000000000000000003'] = num03
-  this._precompiled['0000000000000000000000000000000000000004'] = num04
-  this._precompiled['0000000000000000000000000000000000000005'] = num05
-  this._precompiled['0000000000000000000000000000000000000006'] = num06
-  this._precompiled['0000000000000000000000000000000000000007'] = num07
-  this._precompiled['0000000000000000000000000000000000000008'] = num08
-
-  AsyncEventEmitter.call(this)
-}
-
-util.inherits(VM, AsyncEventEmitter)
-
-VM.prototype.runCode = require('./runCode.js')
-VM.prototype.runJIT = require('./runJit.js')
-VM.prototype.runBlock = require('./runBlock.js')
-VM.prototype.runTx = require('./runTx.js')
-VM.prototype.runCall = require('./runCall.js')
-VM.prototype.runBlockchain = require('./runBlockchain.js')
-
-VM.prototype.copy = function () {
-  return new VM({ stateManager: this.stateManager.copy(), blockchain: this.blockchain })
+  copy () {
+    return new VM({ stateManager: this.stateManager.copy(), blockchain: this.blockchain })
+  }
 }


### PR DESCRIPTION
This PR converts VM to a es6 style class. I also dropped `VM.deps`, as I wasn't sure what purpose it's serving, and why users can't require the libraries themselves. If there's a good reason why it's there let me know so I can add it back in.