### PR TITLE
[v4] Add promisified wrapper for stateManager

### DIFF
--- a/lib/state/promisified.js
+++ b/lib/state/promisified.js
@@ -1,0 +1,83 @@
+const { promisify } = require('util')
+
+module.exports = class PStateManager {
+  constructor (wrapped) {
+    this._wrapped = wrapped
+  }
+
+  copy () {
+    return new PStateManager(this._wrapped.copy())
+  }
+
+  getAccount (addr) {
+    return promisify(this._wrapped.getAccount.bind(this._wrapped))(addr)
+  }
+
+  putAccount (addr, account) {
+    return promisify(this._wrapped.putAccount.bind(this._wrapped))(addr, account)
+  }
+
+  putContractCode (addr, code) {
+    return promisify(this._wrapped.putContractCode.bind(this._wrapped))(addr, code)
+  }
+
+  getContractCode (addr) {
+    return promisify(this._wrapped.getContractCode.bind(this._wrapped))(addr)
+  }
+
+  getContractStorage (addr, key) {
+    return promisify(this._wrapped.getContractStorage.bind(this._wrapped))(addr, key)
+  }
+
+  putContractStorage (addr, key, value) {
+    return promisify(this._wrapped.putContractStorage.bind(this._wrapped))(addr, key, value)
+  }
+
+  clearContractStorage (addr) {
+    return promisify(this._wrapped.clearContractStorage.bind(this._wrapped))(addr)
+  }
+
+  checkpoint () {
+    return promisify(this._wrapped.checkpoint.bind(this._wrapped))()
+  }
+
+  commit () {
+    return promisify(this._wrapped.commit.bind(this._wrapped))()
+  }
+
+  revert () {
+    return promisify(this._wrapped.revert.bind(this._wrapped))()
+  }
+
+  getStateRoot () {
+    return promisify(this._wrapped.getStateRoot.bind(this._wrapped))()
+  }
+
+  setStateRoot (root) {
+    return promisify(this._wrapped.setStateRoot.bind(this._wrapped))(root)
+  }
+
+  dumpStorage (address) {
+    return promisify(this._wrapped.dumpStorage.bind(this._wrapped))(address)
+  }
+
+  hasGenesisState () {
+    return promisify(this._wrapped.hasGenesisState.bind(this._wrapped))()
+  }
+
+  generateCanonicalGenesis () {
+    return promisify(this._wrapped.generateCanonicalGenesis.bind(this._wrapped))()
+  }
+
+  generateGenesis (initState) {
+    return promisify(this._wrapped.generateGenesis.bind(this._wrapped))(initState)
+  }
+
+  accountIsEmpty (address) {
+    return promisify(this._wrapped.accountIsEmpty.bind(this._wrapped))(address)
+  }
+
+  cleanupTouchedAccounts () {
+    return promisify(this._wrapped.cleanupTouchedAccounts.bind(this._wrapped))()
+  }
+}


### PR DESCRIPTION
One of the main sources of asynchrony in VM is the state manager. This wrapper allows us to slowly shift towards promises without having to modify the whole codebase at once. E.g. a new part that's being modernized could wrap its `stateManager` like this:

```javascript
const state = new StateManager()

const pstate = new PStateManager(state)
await pstate.getAccount(addr)
```

This is a temporary class and will have to be deleted when the whole codebase has transitioned to promises.

(Will be merged into #479)