### PR TITLE
Rewrite runBlock internals with async/await

### DIFF
--- a/lib/runBlock.js
+++ b/lib/runBlock.js
@@ -1,10 +1,10 @@
-const Buffer = require('safe-buffer').Buffer
-const async = require('async')
+const promisify = require('util.promisify')
 const ethUtil = require('ethereumjs-util')
 const Bloom = require('./bloom')
 const rlp = ethUtil.rlp
 const Trie = require('merkle-patricia-tree')
 const BN = ethUtil.BN
+const PStateManager = require('./state/promisified')
 
 /**
  * Processes the `block` running all of the transactions it contains and updating the miner's account
@@ -32,237 +32,187 @@ module.exports = function (opts, cb) {
     return cb(new Error('invalid input, block must be provided'))
   }
 
-  const self = this
+  _runBlock.bind(this)(opts)
+    .then((results) => cb(null, results))
+    .catch(cb)
+}
 
-  // parse options
+async function _runBlock (opts) {
+  const state = new PStateManager(this.stateManager)
   const block = opts.block
-  const skipBlockValidation = opts.skipBlockValidation || false
   const generateStateRoot = !!opts.generate
-  const validateStateRoot = !generateStateRoot
-  const bloom = new Bloom()
-  const receiptTrie = new Trie()
-  // the total amount of gas used processing this block
-  var gasUsed = new BN(0)
-  var checkpointedState = false
-  var receipts = []
-  var txResults = []
-  var result
 
-  // run everything
-  async.series([
-    beforeBlock,
-    validateBlock,
-    setStateRoot,
-    checkpointState,
-    processTransactions,
-    payOmmersAndMiner
-  ], parseBlockResults)
+  /**
+   * The `beforeBlock` event
+   *
+   * @event Event: beforeBlock
+   * @type {Object}
+   * @property {Block} block emits the block that is about to be processed
+   */
+  await this._emit('beforeBlock', opts.block)
 
-  function beforeBlock (cb) {
-    /**
-     * The `beforeBlock` event
-     *
-     * @event Event: beforeBlock
-     * @type {Object}
-     * @property {Block} block emits the block that is about to be processed
-     */
-    self.emit('beforeBlock', opts.block, cb)
+  // Set state root if provided
+  if (opts.root) {
+    await state.setStateRoot(opts.root)
   }
 
-  function afterBlock (cb) {
-    /**
-     * The `afterBlock` event
-     *
-     * @event Event: afterBlock
-     * @type {Object}
-     * @property {Object} result emits the results of processing a block
-     */
-    self.emit('afterBlock', result, cb)
+  // Checkpoint state
+  await state.checkpoint()
+  let result
+  try {
+    result = await applyBlock.bind(this)(block, opts.skipBlockValidation)
+  } catch (err) {
+    await state.revert()
+    throw err
   }
 
-  function validateBlock (cb) {
-    if (skipBlockValidation) {
-      cb()
-    } else {
-      if (new BN(block.header.gasLimit).gte(new BN('8000000000000000', 16))) {
-        cb(new Error('Invalid block with gas limit greater than (2^63 - 1)'))
-      } else {
-        block.validate(self.blockchain, cb)
-      }
+  // Persist state
+  await state.commit()
+  const stateRoot = await state.getStateRoot()
+
+  // Given the generate option, either set resulting header
+  // values to the current block, or validate the resulting
+  // header values against the current block.
+  if (generateStateRoot) {
+    block.header.stateRoot = stateRoot
+    block.header.bloom = result.bloom.bitvector
+  } else {
+    if (result.receiptRoot && result.receiptRoot.toString('hex') !== block.header.receiptTrie.toString('hex')) {
+      throw new Error('invalid receiptTrie ')
     }
-  }
-
-  function setStateRoot (cb) {
-    if (opts.root) {
-      self.stateManager.setStateRoot(opts.root, cb)
-    } else {
-      cb(null)
+    if (result.bloom.bitvector.toString('hex') !== block.header.bloom.toString('hex')) {
+      throw new Error('invalid bloom ')
     }
-  }
-
-  function checkpointState (cb) {
-    checkpointedState = true
-    self.stateManager.checkpoint(cb)
+    if (ethUtil.bufferToInt(block.header.gasUsed) !== Number(result.gasUsed)) {
+      throw new Error('invalid gasUsed ')
+    }
+    if (stateRoot.toString('hex') !== block.header.stateRoot.toString('hex')) {
+      throw new Error('invalid block stateRoot ')
+    }
   }
 
   /**
-   * Processes all of the transaction in the block
-   * @method processTransaction
-   * @private
-   * @param {Function} cb the callback is given error if there are any
+   * The `afterBlock` event
+   *
+   * @event Event: afterBlock
+   * @type {Object}
+   * @property {Object} result emits the results of processing a block
    */
-  function processTransactions (cb) {
-    var validReceiptCount = 0
+  await this._emit('afterBlock', { receipts: result.receipts, results: result.results })
 
-    async.eachSeries(block.transactions, processTx, cb)
+  return result
+}
 
-    function processTx (tx, cb) {
-      var gasLimitIsHigherThanBlock = new BN(block.header.gasLimit).lt(new BN(tx.gasLimit).add(gasUsed))
-      if (gasLimitIsHigherThanBlock) {
-        cb(new Error('tx has a higher gas limit than the block'))
-        return
-      }
-
-      // run the tx through the VM
-      self.runTx({
-        tx: tx,
-        block: block
-      }, parseTxResult)
-
-      function parseTxResult (err, result) {
-        txResults.push(result)
-        // var receiptResult = new BN(1)
-
-        // abort if error
-        if (err) {
-          receipts.push(null)
-          cb(err)
-          return
-        }
-
-        gasUsed = gasUsed.add(result.gasUsed)
-        // combine blooms via bitwise OR
-        bloom.or(result.bloom)
-
-        if (generateStateRoot) {
-          block.header.bloom = bloom.bitvector
-        }
-
-        var txLogs = result.vm.logs || []
-
-        var rawTxReceipt = [
-          result.vm.exception ? 1 : 0, // result.vm.exception is 0 when an exception occurs, and 1 when it doesn't.  TODO make this the opposite
-          gasUsed.toArrayLike(Buffer),
-          result.bloom.bitvector,
-          txLogs
-        ]
-        var txReceipt = {
-          status: rawTxReceipt[0],
-          gasUsed: rawTxReceipt[1],
-          bitvector: rawTxReceipt[2],
-          logs: rawTxReceipt[3]
-        }
-
-        receipts.push(txReceipt)
-        receiptTrie.put(rlp.encode(validReceiptCount), rlp.encode(rawTxReceipt), function () {
-          validReceiptCount++
-          cb()
-        })
-      }
+/**
+ * Validates and applies a block, computing the results of
+ * applying its transactions. This method doesn't modify the
+ * block itself. It computes the block rewards and puts
+ * them on state (but doesn't persist the changes).
+ * @param {Block} block
+ * @param {Boolean} [skipBlockValidation=false]
+ */
+async function applyBlock (block, skipBlockValidation = false) {
+  const state = new PStateManager(this.stateManager)
+  // Validate block
+  if (!skipBlockValidation) {
+    if (new BN(block.header.gasLimit).gte(new BN('8000000000000000', 16))) {
+      throw new Error('Invalid block with gas limit greater than (2^63 - 1)')
+    } else {
+      await promisify(block.validate).bind(block)(this.blockchain)
     }
   }
+  // Apply transactions
+  const txResults = await applyTransactions.bind(this)(block, state)
+  // Pay ommers and miners
+  await assignBlockRewards.bind(this)(block)
+  return txResults
+}
 
-  // credit all block rewards
-  function payOmmersAndMiner (cb) {
-    var ommers = block.uncleHeaders
+/**
+ * Applies the transactions in a block, computing the receipts
+ * as well as gas usage and some relevant data. This method is
+ * side-effect free (it doesn't modify the block nor the state).
+ * @param {Block} block
+ */
+async function applyTransactions (block) {
+  const bloom = new Bloom()
+  // the total amount of gas used processing these transactions
+  let gasUsed = new BN(0)
+  const receiptTrie = new Trie()
+  const receipts = []
+  const txResults = []
 
-    // pay each ommer
-    async.series([
-      rewardOmmers,
-      rewardMiner
-    ], cb)
-
-    function rewardOmmers (done) {
-      async.each(block.uncleHeaders, function (ommer, next) {
-        // calculate reward
-        var minerReward = new BN(self._common.param('pow', 'minerReward'))
-        var heightDiff = new BN(block.header.number).sub(new BN(ommer.number))
-        var reward = ((new BN(8)).sub(heightDiff)).mul(minerReward.divn(8))
-
-        if (reward.ltn(0)) {
-          reward = new BN(0)
-        }
-
-        rewardAccount(ommer.coinbase, reward, next)
-      }, done)
+  /*
+   * Process transactions
+   */
+  for (let txIdx = 0; txIdx < block.transactions.length; txIdx++) {
+    const tx = block.transactions[txIdx]
+    const gasLimitIsHigherThanBlock = new BN(block.header.gasLimit).lt(new BN(tx.gasLimit).add(gasUsed))
+    if (gasLimitIsHigherThanBlock) {
+      throw new Error('tx has a higher gas limit than the block')
     }
 
-    function rewardMiner (done) {
-      // calculate nibling reward
-      var minerReward = new BN(self._common.param('pow', 'minerReward'))
-      var niblingReward = minerReward.divn(32)
-      var totalNiblingReward = niblingReward.muln(ommers.length)
-      var reward = minerReward.add(totalNiblingReward)
-      rewardAccount(block.header.coinbase, reward, done)
-    }
+    // Run the tx through the VM
+    let txRes = await promisify(this.runTx).bind(this)({ tx: tx, block: block })
+    txResults.push(txRes)
 
-    function rewardAccount (address, reward, done) {
-      self.stateManager.getAccount(address, function (err, account) {
-        if (err) return done(err)
-        // give miner the block reward
-        account.balance = new BN(account.balance).add(reward)
-        self.stateManager.putAccount(address, account, done)
-      })
+    // Add to total block gas usage
+    gasUsed = gasUsed.add(txRes.gasUsed)
+    // Combine blooms via bitwise OR
+    bloom.or(txRes.bloom)
+
+    const txReceipt = {
+      status: txRes.vm.exception ? 1 : 0, // result.vm.exception is 0 when an exception occurs, and 1 when it doesn't.  TODO make this the opposite
+      gasUsed: gasUsed.toArrayLike(Buffer),
+      bitvector: txRes.bloom.bitvector,
+      logs: txRes.vm.logs || []
     }
+    receipts.push(txReceipt)
+
+    // Add receipt to trie to later calculate receipt root
+    await promisify(receiptTrie.put).bind(receiptTrie)(rlp.encode(txIdx), rlp.encode(Object.values(txReceipt)))
   }
 
-  // handle results or error from block run
-  function parseBlockResults (err) {
-    if (err) {
-      if (checkpointedState) {
-        self.stateManager.revert(function () {
-          cb(err)
-        })
-      } else {
-        cb(err)
-      }
-      return
-    }
+  return { bloom, gasUsed, receiptRoot: receiptTrie.root, receipts, results: txResults }
+}
 
-    self.stateManager.commit(function (err) {
-      if (err) return cb(err)
-
-      self.stateManager.getStateRoot(function (err, stateRoot) {
-        if (err) return cb(err)
-
-        // credit all block rewards
-        if (generateStateRoot) {
-          block.header.stateRoot = stateRoot
-        }
-
-        if (validateStateRoot) {
-          if (receiptTrie.root && receiptTrie.root.toString('hex') !== block.header.receiptTrie.toString('hex')) {
-            err = new Error((err || '') + 'invalid receiptTrie ')
-          }
-          if (bloom.bitvector.toString('hex') !== block.header.bloom.toString('hex')) {
-            err = new Error((err || '') + 'invalid bloom ')
-          }
-          if (ethUtil.bufferToInt(block.header.gasUsed) !== Number(gasUsed)) {
-            err = new Error((err || '') + 'invalid gasUsed ')
-          }
-          if (stateRoot.toString('hex') !== block.header.stateRoot.toString('hex')) {
-            err = new Error((err || '') + 'invalid block stateRoot ')
-          }
-        }
-
-        result = {
-          receipts: receipts,
-          results: txResults,
-          error: err
-        }
-
-        afterBlock(cb.bind(this, err, result))
-      })
-    })
+/**
+ * Calculates block rewards for miner and ommers and puts
+ * the updated balances of their accounts to state.
+ */
+async function assignBlockRewards (block) {
+  const state = new PStateManager(this.stateManager)
+  const minerReward = new BN(this._common.param('pow', 'minerReward'))
+  const ommers = block.uncleHeaders
+  // Reward ommers
+  for (let ommer of ommers) {
+    const reward = calculateOmmerReward(ommer, block.header.number, minerReward)
+    await rewardAccount(state, ommer.coinbase, reward)
   }
+  // Reward miner
+  const reward = calculateMinerReward(minerReward, ommers)
+  await rewardAccount(state, block.header.coinbase, reward)
+}
+
+function calculateOmmerReward (ommer, blockNumber, minerReward) {
+  const heightDiff = new BN(blockNumber).sub(new BN(ommer.number))
+  let reward = ((new BN(8)).sub(heightDiff)).mul(minerReward.divn(8))
+  if (reward.ltn(0)) {
+    reward = new BN(0)
+  }
+  return reward
+}
+
+function calculateMinerReward (minerReward, ommers) {
+  // calculate nibling reward
+  const niblingReward = minerReward.divn(32)
+  const totalNiblingReward = niblingReward.muln(ommers.length)
+  const reward = minerReward.add(totalNiblingReward)
+  return reward
+}
+
+async function rewardAccount (state, address, reward, done) {
+  const account = await state.getAccount(address)
+  account.balance = new BN(account.balance).add(reward)
+  await state.putAccount(address, account)
 }


### PR DESCRIPTION
This PR:

- Rewrites `runBlock` internals with promises and async/await syntax
- It re-structures the code somewhat and breaks it into different methods
- One of my goals has been to reduce shared global state, and rather have methods that explicitly get some parameters and return results, and to reduce the region where side-effects happen. As such, most of the methods don't have side-effects (don't modify the block or state).
- I've also re-ordered some parts of the code where it doesn't change the logic to get closer to the above goals.
- This won't be the final state for `runBlock` and (similar to `runTx`) is the first iteration.

Some side note: Currently the types we have are very heavy and serve multiple purposes. E.g. `ethereumjs-block` contains RLP serialization/deserialization of blocks, db interactions and also validation and other logic. I think we should break them and have separate types for each of these purposes. One type for RLP serialization, one for storing/fetching from db (which uses RLPBlock), one for consensus logic. The same applies to `Blockchain` and `Tx`. Not sure yet about details, but thought I'd ask for feedback on this idea. One other benefit for this separation is that we could then have a base class for the consensus logic part of the type, and have a child class for each fork for that type, e.g. `PetersburgBlock` which contains the logic for blocks after `Petersburg`.

(To be merged into #479)