### PR TITLE
Accept a Common object when constructing the VM and pass it when copying it

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -138,9 +138,13 @@ export default class VM extends AsyncEventEmitter {
    * Returns a copy of the [[VM]] instance.
    */
   copy(): VM {
+    const hardfork = this._common.hardfork()
+
     return new VM({
       stateManager: this.stateManager.copy(),
       blockchain: this.blockchain,
+      chain: this._common.chainName(),
+      hardfork: hardfork !== null ? hardfork : undefined,
     })
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,6 +45,7 @@ export interface VMOpts {
    * Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed
    */
   allowUnlimitedContractSize?: boolean
+  common?: Common
 }
 
 /**
@@ -71,10 +72,21 @@ export default class VM extends AsyncEventEmitter {
 
     this.opts = opts
 
-    const chain = opts.chain ? opts.chain : 'mainnet'
-    const hardfork = opts.hardfork ? opts.hardfork : 'petersburg'
-    const supportedHardforks = ['byzantium', 'constantinople', 'petersburg']
-    this._common = new Common(chain, hardfork, supportedHardforks)
+    if (opts.common) {
+      if (opts.chain || opts.hardfork) {
+        throw new Error(
+          'You can only instantiate the VM class with one of: opts.common, or opts.chain and opts.hardfork',
+        )
+      }
+
+      this._common = opts.common
+    } else {
+      const chain = opts.chain ? opts.chain : 'mainnet'
+      const hardfork = opts.hardfork ? opts.hardfork : 'petersburg'
+      const supportedHardforks = ['byzantium', 'constantinople', 'petersburg']
+
+      this._common = new Common(chain, hardfork, supportedHardforks)
+    }
 
     if (opts.stateManager) {
       this.stateManager = opts.stateManager

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -153,7 +153,7 @@ export default class VM extends AsyncEventEmitter {
     return new VM({
       stateManager: this.stateManager.copy(),
       blockchain: this.blockchain,
-      common: this._common
+      common: this._common,
     })
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -150,13 +150,10 @@ export default class VM extends AsyncEventEmitter {
    * Returns a copy of the [[VM]] instance.
    */
   copy(): VM {
-    const hardfork = this._common.hardfork()
-
     return new VM({
       stateManager: this.stateManager.copy(),
       blockchain: this.blockchain,
-      chain: this._common.chainName(),
-      hardfork: hardfork !== null ? hardfork : undefined,
+      common: this._common
     })
   }
 

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -2,6 +2,7 @@ const promisify = require('util.promisify')
 const tape = require('tape')
 const util = require('ethereumjs-util')
 const Block = require('ethereumjs-block')
+const Common = require('ethereumjs-common').default
 const Trie = require('merkle-patricia-tree/secure')
 const VM = require('../../dist/index').default
 const { setupVM } = require('./utils')
@@ -28,6 +29,25 @@ tape('VM with default blockchain', (t) => {
     let vm = new VM({ state: trie, activatePrecompiles: true })
     st.notEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.ok(vm.stateManager._trie.isTestTrie, 'it works on trie provided')
+    st.end()
+  })
+
+  t.test('should only accept common or chain and fork', (st) => {
+    const common = new Common('mainnet');
+
+    st.throws(() => new VM({ chain: 'a', common }))
+    st.throws(() => new VM({ hardfork: 'a', common }))
+    st.throws(() => new VM({ chain: 'a', hardfork: 'a', common }))
+
+    st.end()
+  })
+
+  t.test('should accept a common object as option', (st) => {
+    const common = new Common('mainnet')
+
+    const vm = new VM({ common })
+    st.equal(vm._common, common)
+
     st.end()
   })
 

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -115,6 +115,18 @@ tape('VM with blockchain', (t) => {
 
     st.end()
   })
+
+  t.test('should pass the correct Common object when copying the VM', st => {
+    const vm = setupVM({ chain: 'goerli', hardfork: 'byzantium' })
+    st.equal(vm._common.chainName(), 'goerli')
+    st.equal(vm._common.hardfork(), 'byzantium')
+
+    const copiedVM = vm.copy()
+    st.equal(copiedVM._common.chainName(), 'goerli')
+    st.equal(copiedVM._common.hardfork(), 'byzantium')
+
+    st.end()
+  })
 })
 
 const runBlockchainP = (vm) => promisify(vm.runBlockchain.bind(vm))()


### PR DESCRIPTION
Previous to this PR copying a VM always returned one with a `Common` object set to `mainnet` and `Petersburg`. It now passes the chain and hardfork info when copying it.