### PR TITLE
Pass the Common object when copying a StateManager

### DIFF
--- a/lib/state/stateManager.ts
+++ b/lib/state/stateManager.ts
@@ -58,7 +58,7 @@ export default class StateManager {
    * @method copy
    */
   copy(): StateManager {
-    return new StateManager({ trie: this._trie.copy() })
+    return new StateManager({ trie: this._trie.copy(), common: this._common })
   }
 
   /**

--- a/tests/api/state/stateManager.js
+++ b/tests/api/state/stateManager.js
@@ -1,6 +1,7 @@
 const promisify = require('util.promisify')
 const tape = require('tape')
 const util = require('ethereumjs-util')
+const Common = require('ethereumjs-common').default
 const { StateManager } = require('../../../dist/state')
 const { createAccount } = require('../utils')
 
@@ -159,5 +160,20 @@ tape('StateManager', (t) => {
 
       st.end()
     })
+  })
+
+  t.test('should pass Common object when copying the state manager', st => {
+    const stateManager = new StateManager({
+      common: new Common('goerli', 'byzantium')
+    })
+
+    st.equal(stateManager._common.chainName(), 'goerli')
+    st.equal(stateManager._common.hardfork(), 'byzantium')
+
+    const stateManagerCopy = stateManager.copy()
+    st.equal(stateManagerCopy._common.chainName(), 'goerli')
+    st.equal(stateManagerCopy._common.hardfork(), 'byzantium')
+
+    st.end()
   })
 })


### PR DESCRIPTION
Previous to this PR copying a `StateManager` always returned one with a `Common` object set to `mainnet` and `byzantium` (see #524). Now the `Common` object is passed when copying a `StateManager`.