### PR TITLE
Replace Object.assign calls and fix type errors

### DIFF
--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -467,7 +467,7 @@ export default class EEI {
   }
 
   async _baseCall(msg: Message): Promise<BN> {
-    const selfdestruct = Object.assign({}, this._result.selfdestruct)
+    const selfdestruct = { ...this._result.selfdestruct }
     msg.selfdestruct = selfdestruct
 
     // empty the return data buffer
@@ -520,7 +520,7 @@ export default class EEI {
    * @param {Buffer} data
    */
   async create(gasLimit: BN, value: BN, data: Buffer, salt: Buffer | null = null): Promise<BN> {
-    const selfdestruct = Object.assign({}, this._result.selfdestruct)
+    const selfdestruct = { ...this._result.selfdestruct }
     const msg = new Message({
       caller: this._env.address,
       gasLimit: gasLimit,

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -288,7 +288,7 @@ export default class Interpreter {
     return {
       ...result,
       runState: {
-        ...loopRes.runState,
+        ...loopRes.runState!,
         ...result,
         ...eei._env,
       },

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -231,7 +231,7 @@ export default class Interpreter {
     ) {
       result.gasUsed = totalGas
     } else {
-      Object.assign(result, OOGResult(message.gasLimit))
+      result = { ...result, ...OOGResult(message.gasLimit) }
     }
 
     // Save code if a new contract was created
@@ -276,22 +276,28 @@ export default class Interpreter {
         gasUsed = message.gasLimit
       }
 
-      // remove any logs on error
-      result = Object.assign({}, result, {
+      // Clear the result on error
+      result = {
+        ...result,
         logs: [],
-        gasRefund: null,
-        selfdestruct: null,
-      })
+        gasRefund: new BN(0),
+        selfdestruct: {},
+      }
     }
 
-    return Object.assign({}, result, {
-      runState: Object.assign({}, loopRes.runState, result, eei._env),
+    return {
+      ...result,
+      runState: {
+        ...loopRes.runState,
+        ...result,
+        ...eei._env,
+      },
       exception: loopRes.exception,
       exceptionError: loopRes.exceptionError,
       gas: eei._gasLeft,
       gasUsed,
       return: result.returnValue ? result.returnValue : Buffer.alloc(0),
-    })
+    }
   }
 
   /**

--- a/lib/evm/loop.ts
+++ b/lib/evm/loop.ts
@@ -30,7 +30,7 @@ export interface RunState {
 }
 
 export interface LoopResult {
-  runState?: RunState
+  runState: RunState
   exception: IsException
   exceptionError?: VmError | ERROR
 }
@@ -62,11 +62,9 @@ export default class Loop {
   }
 
   async run(code: Buffer, opts: RunOpts = {}): Promise<LoopResult> {
-    Object.assign(this._runState, {
-      code: code,
-      programCounter: opts.pc || this._runState.programCounter,
-      validJumps: this._getValidJumpDests(code),
-    })
+    this._runState.code = code
+    this._runState.programCounter = opts.pc || this._runState.programCounter
+    this._runState.validJumps = this._getValidJumpDests(code)
 
     // Check that the programCounter is in range
     const pc = this._runState.programCounter

--- a/lib/evm/loop.ts
+++ b/lib/evm/loop.ts
@@ -30,7 +30,7 @@ export interface RunState {
 }
 
 export interface LoopResult {
-  runState: RunState
+  runState?: RunState
   exception: IsException
   exceptionError?: VmError | ERROR
 }

--- a/tests/GeneralStateTestsRunner.js
+++ b/tests/GeneralStateTestsRunner.js
@@ -11,7 +11,7 @@ function parseTestCases (forkConfig, testData, data, gasLimit, value) {
   if (testData['post'][forkConfig]) {
     testCases = testData['post'][forkConfig].map(testCase => {
       let testIndexes = testCase['indexes']
-      let tx = Object.assign({}, testData.transaction)
+      let tx = { ...testData.transaction }
       if (data !== undefined && testIndexes['data'] !== data) {
         return null
       }


### PR DESCRIPTION
While reviewing the codebase some calls to `Object.assign` caught my attention, as I suspected that they may be hiding some type errors. 

I replaced them with object literals using the spread operator (i.e. `{ ...obj }`) and normal field assignments to check if that was the case.

My suspicion turned out to be right, and I found two type errors in `Interpreter#runLoop`:

1. If `Loop#run` returned an exception, `null` was set as the result's `gasRefund` and `selfdestruct` fields.
2. The result's `runState` didn't type.

I tried to fix them, but I'm not familiar enough with the codebase as to be sure that my changes are correct.

For 1, I replaced the `null`s with the default values used to initialize those fields.

For 2, I made  `LoopResult#runState` non-optional, as I didn't find any instance of it being `undefined`.