### PR TITLE
Avoid generating genesis state in blockchain test runner

### DIFF
--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -100,6 +100,14 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
         done()
       })
     },
+    function setGenesisStateRoot (done) {
+      // This is a trick to avoid generating the canonical genesis
+      // state. Generating the genesis state is not needed because
+      // blockchain tests come with their own `pre` world state.
+      // TODO: Add option to `runBlockchain` not to generate genesis state.
+      vm._common.genesis().stateRoot = state.root
+      done()
+    },
     function runBlockchain (done) {
       vm.runBlockchain(function () {
         done()


### PR DESCRIPTION
blockchain tests don't need to generate the gensis state as they come with their own `pre` world state. Avoiding this extra generation resulted in the duration of `npm run testBlockchain` going from 17m down to 2m on my local machine :grin: 

This is done via a trick: `runBlockchain` generates the genesis state when current state root doesn't match with the genesis state's root. So I manually manipulate `vm._common.genesis().stateRoot` to avoid generating the state.

I checked the source code, and this shouldn't have a side-effect (`common.genesis().stateRoot` doesn't seem to be used elsewhere). But still this is a trick and ideally `runBlockchain` would accept an option to disable generating genesis state (which would be a breaking change because it changes the parameter ordering, so I didn't go for it).