### PR TITLE
Move generateCanonicalGenesis to runBlockchain

### DIFF
--- a/docs/classes/statemanager.md
+++ b/docs/classes/statemanager.md
@@ -57,7 +57,7 @@ Interface for getting and setting data from an underlying state trie.
 
 ⊕ **new StateManager**(opts?: *`any`*): [StateManager](statemanager.md)
 
-*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L29)*
+*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L29)*
 
 Instantiate the StateManager interface.
 
@@ -79,7 +79,7 @@ ___
 
 **● _cache**: *`Cache`*
 
-*Defined in [state/stateManager.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L25)*
+*Defined in [state/stateManager.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L25)*
 
 ___
 <a id="_checkpointcount"></a>
@@ -88,7 +88,7 @@ ___
 
 **● _checkpointCount**: *`number`*
 
-*Defined in [state/stateManager.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L28)*
+*Defined in [state/stateManager.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L28)*
 
 ___
 <a id="_originalstoragecache"></a>
@@ -97,7 +97,7 @@ ___
 
 **● _originalStorageCache**: *`Map`<`string`, `Map`<`string`, `Buffer`>>*
 
-*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L29)*
+*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L29)*
 
 ___
 <a id="_storagetries"></a>
@@ -106,7 +106,7 @@ ___
 
 **● _storageTries**: *`any`*
 
-*Defined in [state/stateManager.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L24)*
+*Defined in [state/stateManager.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L24)*
 
 ___
 <a id="_touched"></a>
@@ -115,7 +115,7 @@ ___
 
 **● _touched**: *`Set`<`string`>*
 
-*Defined in [state/stateManager.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L26)*
+*Defined in [state/stateManager.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L26)*
 
 ___
 <a id="_touchedstack"></a>
@@ -124,7 +124,7 @@ ___
 
 **● _touchedStack**: *`Set`<`string`>[]*
 
-*Defined in [state/stateManager.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L27)*
+*Defined in [state/stateManager.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L27)*
 
 ___
 <a id="_trie"></a>
@@ -133,7 +133,7 @@ ___
 
 **● _trie**: *`any`*
 
-*Defined in [state/stateManager.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L23)*
+*Defined in [state/stateManager.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L23)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **_getStorageTrie**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:175](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L175)*
+*Defined in [state/stateManager.ts:175](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L175)*
 
 Gets the storage trie for an account from the storage cache or does a lookup
 
@@ -169,7 +169,7 @@ ___
 
 ▸ **_lookupStorageTrie**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:153](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L153)*
+*Defined in [state/stateManager.ts:153](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L153)*
 
 Creates a storage trie from the primary storage trie for an account and saves this in the storage cache.
 
@@ -193,7 +193,7 @@ ___
 
 ▸ **_modifyContractStorage**(address: *`Buffer`*, modifyTrie: *`any`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:257](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L257)*
+*Defined in [state/stateManager.ts:257](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L257)*
 
 Modifies the storage trie of an account
 
@@ -218,7 +218,7 @@ ___
 
 ▸ **accountIsEmpty**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:496](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L496)*
+*Defined in [state/stateManager.ts:496](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L496)*
 
 Checks if the `account` corresponding to `address` is empty as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md))
 
@@ -242,7 +242,7 @@ ___
 
 ▸ **checkpoint**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:329](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L329)*
+*Defined in [state/stateManager.ts:329](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L329)*
 
 Checkpoints the current state of the StateManager instance. State changes that follow can then be committed by calling `commit` or `reverted` by calling rollback.
 
@@ -265,7 +265,7 @@ ___
 
 ▸ **cleanupTouchedAccounts**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:519](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L519)*
+*Defined in [state/stateManager.ts:519](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L519)*
 
 Removes accounts form the state trie that have been touched, as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).
 
@@ -288,7 +288,7 @@ ___
 
 ▸ **clearContractStorage**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:310](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L310)*
+*Defined in [state/stateManager.ts:310](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L310)*
 
 Clears all storage entries for the account corresponding to `address`
 
@@ -312,7 +312,7 @@ ___
 
 ▸ **commit**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:344](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L344)*
+*Defined in [state/stateManager.ts:344](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L344)*
 
 Commits the current change-set to the instance since the last call to checkpoint.
 
@@ -335,7 +335,7 @@ ___
 
 ▸ **copy**(): [StateManager](statemanager.md)
 
-*Defined in [state/stateManager.ts:53](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L53)*
+*Defined in [state/stateManager.ts:53](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L53)*
 
 Copies the current instance of the `DefaultStateManager` at the last fully committed point, i.e. as if all current checkpoints were reverted
 
@@ -352,7 +352,7 @@ ___
 
 ▸ **dumpStorage**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:465](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L465)*
+*Defined in [state/stateManager.ts:465](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L465)*
 
 Dumps the the storage values for an `account` specified by `address`
 
@@ -376,7 +376,7 @@ ___
 
 ▸ **getAccount**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:73](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L73)*
+*Defined in [state/stateManager.ts:73](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L73)*
 
 Gets the [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) associated with `address`. Returns an empty account if the account does not exist.
 
@@ -400,7 +400,7 @@ ___
 
 ▸ **getContractCode**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:135](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L135)*
+*Defined in [state/stateManager.ts:135](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L135)*
 
 Gets the code corresponding to the provided `address`
 
@@ -424,7 +424,7 @@ ___
 
 ▸ **getContractStorage**(address: *`Buffer`*, key: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:202](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L202)*
+*Defined in [state/stateManager.ts:202](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L202)*
 
 Gets the storage value associated with the provided `address` and `key`
 
@@ -449,7 +449,7 @@ ___
 
 ▸ **getOriginalContractStorage**(address: *`Buffer`*, key: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:225](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L225)*
+*Defined in [state/stateManager.ts:225](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L225)*
 
 Caches the storage value associated with the provided `address` and `key` on first invocation, and returns the cached (original) value from then onwards. This is used to get the original value of a storage slot for computing gas costs according to EIP-1283.
 
@@ -470,7 +470,7 @@ ___
 
 ▸ **getStateRoot**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:397](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L397)*
+*Defined in [state/stateManager.ts:397](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L397)*
 
 Gets the state-root of the Merkle-Patricia trie representation of the state of this StateManager. Will error if there are uncommitted checkpoints on the instance.
 
@@ -493,7 +493,7 @@ ___
 
 ▸ **putAccount**(address: *`Buffer`*, account: *`Account`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:86](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L86)*
+*Defined in [state/stateManager.ts:86](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L86)*
 
 Saves an [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) into state under the provided `address`
 
@@ -518,7 +518,7 @@ ___
 
 ▸ **putContractCode**(address: *`Buffer`*, value: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:105](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L105)*
+*Defined in [state/stateManager.ts:105](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L105)*
 
 Adds `value` to the state trie as code, and sets `codeHash` on the account corresponding to `address` to reference this.
 
@@ -543,7 +543,7 @@ ___
 
 ▸ **putContractStorage**(address: *`Buffer`*, key: *`Buffer`*, value: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:286](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L286)*
+*Defined in [state/stateManager.ts:286](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L286)*
 
 Adds value to the state trie for the `account` corresponding to `address` at the provided `key`
 
@@ -569,7 +569,7 @@ ___
 
 ▸ **revert**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:364](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L364)*
+*Defined in [state/stateManager.ts:364](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L364)*
 
 Reverts the current change-set to the instance since the last call to checkpoint.
 
@@ -592,7 +592,7 @@ ___
 
 ▸ **setStateRoot**(stateRoot: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:421](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L421)*
+*Defined in [state/stateManager.ts:421](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/state/stateManager.ts#L421)*
 
 Sets the state of the instance to that represented by the provided `stateRoot`. Will error if there are uncommitted checkpoints on the instance or if the state root does not exist in the state trie.
 

--- a/docs/classes/statemanager.md
+++ b/docs/classes/statemanager.md
@@ -18,7 +18,7 @@ Interface for getting and setting data from an underlying state trie.
 
 * [_cache](statemanager.md#_cache)
 * [_checkpointCount](statemanager.md#_checkpointcount)
-* [_common](statemanager.md#_common)
+* [_originalStorageCache](statemanager.md#_originalstoragecache)
 * [_storageTries](statemanager.md#_storagetries)
 * [_touched](statemanager.md#_touched)
 * [_touchedStack](statemanager.md#_touchedstack)
@@ -36,13 +36,11 @@ Interface for getting and setting data from an underlying state trie.
 * [commit](statemanager.md#commit)
 * [copy](statemanager.md#copy)
 * [dumpStorage](statemanager.md#dumpstorage)
-* [generateCanonicalGenesis](statemanager.md#generatecanonicalgenesis)
-* [generateGenesis](statemanager.md#generategenesis)
 * [getAccount](statemanager.md#getaccount)
 * [getContractCode](statemanager.md#getcontractcode)
 * [getContractStorage](statemanager.md#getcontractstorage)
+* [getOriginalContractStorage](statemanager.md#getoriginalcontractstorage)
 * [getStateRoot](statemanager.md#getstateroot)
-* [hasGenesisState](statemanager.md#hasgenesisstate)
 * [putAccount](statemanager.md#putaccount)
 * [putContractCode](statemanager.md#putcontractcode)
 * [putContractStorage](statemanager.md#putcontractstorage)
@@ -59,7 +57,7 @@ Interface for getting and setting data from an underlying state trie.
 
 ⊕ **new StateManager**(opts?: *`any`*): [StateManager](statemanager.md)
 
-*Defined in [state/stateManager.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L30)*
+*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L29)*
 
 Instantiate the StateManager interface.
 
@@ -81,7 +79,7 @@ ___
 
 **● _cache**: *`Cache`*
 
-*Defined in [state/stateManager.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L27)*
+*Defined in [state/stateManager.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L25)*
 
 ___
 <a id="_checkpointcount"></a>
@@ -90,16 +88,16 @@ ___
 
 **● _checkpointCount**: *`number`*
 
-*Defined in [state/stateManager.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L30)*
+*Defined in [state/stateManager.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L28)*
 
 ___
-<a id="_common"></a>
+<a id="_originalstoragecache"></a>
 
-###  _common
+###  _originalStorageCache
 
-**● _common**: *`Common`*
+**● _originalStorageCache**: *`Map`<`string`, `Map`<`string`, `Buffer`>>*
 
-*Defined in [state/stateManager.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L24)*
+*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L29)*
 
 ___
 <a id="_storagetries"></a>
@@ -108,7 +106,7 @@ ___
 
 **● _storageTries**: *`any`*
 
-*Defined in [state/stateManager.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L26)*
+*Defined in [state/stateManager.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L24)*
 
 ___
 <a id="_touched"></a>
@@ -117,7 +115,7 @@ ___
 
 **● _touched**: *`Set`<`string`>*
 
-*Defined in [state/stateManager.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L28)*
+*Defined in [state/stateManager.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L26)*
 
 ___
 <a id="_touchedstack"></a>
@@ -126,7 +124,7 @@ ___
 
 **● _touchedStack**: *`Set`<`string`>[]*
 
-*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L29)*
+*Defined in [state/stateManager.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L27)*
 
 ___
 <a id="_trie"></a>
@@ -135,7 +133,7 @@ ___
 
 **● _trie**: *`any`*
 
-*Defined in [state/stateManager.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L25)*
+*Defined in [state/stateManager.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L23)*
 
 ___
 
@@ -147,7 +145,7 @@ ___
 
 ▸ **_getStorageTrie**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:182](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L182)*
+*Defined in [state/stateManager.ts:175](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L175)*
 
 Gets the storage trie for an account from the storage cache or does a lookup
 
@@ -171,7 +169,7 @@ ___
 
 ▸ **_lookupStorageTrie**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:160](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L160)*
+*Defined in [state/stateManager.ts:153](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L153)*
 
 Creates a storage trie from the primary storage trie for an account and saves this in the storage cache.
 
@@ -195,7 +193,7 @@ ___
 
 ▸ **_modifyContractStorage**(address: *`Buffer`*, modifyTrie: *`any`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:232](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L232)*
+*Defined in [state/stateManager.ts:257](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L257)*
 
 Modifies the storage trie of an account
 
@@ -220,7 +218,7 @@ ___
 
 ▸ **accountIsEmpty**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:538](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L538)*
+*Defined in [state/stateManager.ts:496](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L496)*
 
 Checks if the `account` corresponding to `address` is empty as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md))
 
@@ -244,7 +242,7 @@ ___
 
 ▸ **checkpoint**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:304](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L304)*
+*Defined in [state/stateManager.ts:329](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L329)*
 
 Checkpoints the current state of the StateManager instance. State changes that follow can then be committed by calling `commit` or `reverted` by calling rollback.
 
@@ -267,7 +265,7 @@ ___
 
 ▸ **cleanupTouchedAccounts**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:561](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L561)*
+*Defined in [state/stateManager.ts:519](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L519)*
 
 Removes accounts form the state trie that have been touched, as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).
 
@@ -290,7 +288,7 @@ ___
 
 ▸ **clearContractStorage**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:285](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L285)*
+*Defined in [state/stateManager.ts:310](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L310)*
 
 Clears all storage entries for the account corresponding to `address`
 
@@ -314,7 +312,7 @@ ___
 
 ▸ **commit**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:319](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L319)*
+*Defined in [state/stateManager.ts:344](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L344)*
 
 Commits the current change-set to the instance since the last call to checkpoint.
 
@@ -337,7 +335,7 @@ ___
 
 ▸ **copy**(): [StateManager](statemanager.md)
 
-*Defined in [state/stateManager.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L60)*
+*Defined in [state/stateManager.ts:53](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L53)*
 
 Copies the current instance of the `DefaultStateManager` at the last fully committed point, i.e. as if all current checkpoints were reverted
 
@@ -354,7 +352,7 @@ ___
 
 ▸ **dumpStorage**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:440](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L440)*
+*Defined in [state/stateManager.ts:465](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L465)*
 
 Dumps the the storage values for an `account` specified by `address`
 
@@ -372,60 +370,13 @@ Dumps the the storage values for an `account` specified by `address`
 **Returns:** `void`
 
 ___
-<a id="generatecanonicalgenesis"></a>
-
-###  generateCanonicalGenesis
-
-▸ **generateCanonicalGenesis**(cb: *`any`*): `void`
-
-*Defined in [state/stateManager.ts:484](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L484)*
-
-Generates a canonical genesis state on the instance based on the configured chain parameters. Will error if there are uncommitted checkpoints on the instance.
-
-*__memberof__*: StateManager
-
-*__method__*: generateCanonicalGenesis
-
-**Parameters:**
-
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| cb | `any` |  Callback function |
-
-**Returns:** `void`
-
-___
-<a id="generategenesis"></a>
-
-###  generateGenesis
-
-▸ **generateGenesis**(initState: *`any`*, cb: *`any`*): `any`
-
-*Defined in [state/stateManager.ts:505](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L505)*
-
-Initializes the provided genesis state into the state trie
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: generateGenesis
-
-**Parameters:**
-
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| initState | `any` |  \- |
-| cb | `any` |  Callback function |
-
-**Returns:** `any`
-
-___
 <a id="getaccount"></a>
 
 ###  getAccount
 
 ▸ **getAccount**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:80](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L80)*
+*Defined in [state/stateManager.ts:73](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L73)*
 
 Gets the [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) associated with `address`. Returns an empty account if the account does not exist.
 
@@ -449,7 +400,7 @@ ___
 
 ▸ **getContractCode**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:142](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L142)*
+*Defined in [state/stateManager.ts:135](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L135)*
 
 Gets the code corresponding to the provided `address`
 
@@ -473,7 +424,7 @@ ___
 
 ▸ **getContractStorage**(address: *`Buffer`*, key: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:209](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L209)*
+*Defined in [state/stateManager.ts:202](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L202)*
 
 Gets the storage value associated with the provided `address` and `key`
 
@@ -492,13 +443,34 @@ Gets the storage value associated with the provided `address` and `key`
 **Returns:** `void`
 
 ___
+<a id="getoriginalcontractstorage"></a>
+
+###  getOriginalContractStorage
+
+▸ **getOriginalContractStorage**(address: *`Buffer`*, key: *`Buffer`*, cb: *`any`*): `void`
+
+*Defined in [state/stateManager.ts:225](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L225)*
+
+Caches the storage value associated with the provided `address` and `key` on first invocation, and returns the cached (original) value from then onwards. This is used to get the original value of a storage slot for computing gas costs according to EIP-1283.
+
+**Parameters:**
+
+| Name | Type | Description |
+| ------ | ------ | ------ |
+| address | `Buffer` |  Address of the account to get the storage for |
+| key | `Buffer` |  Key in the account's storage to get the value for |
+| cb | `any` |
+
+**Returns:** `void`
+
+___
 <a id="getstateroot"></a>
 
 ###  getStateRoot
 
 ▸ **getStateRoot**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:372](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L372)*
+*Defined in [state/stateManager.ts:397](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L397)*
 
 Gets the state-root of the Merkle-Patricia trie representation of the state of this StateManager. Will error if there are uncommitted checkpoints on the instance.
 
@@ -515,36 +487,13 @@ Gets the state-root of the Merkle-Patricia trie representation of the state of t
 **Returns:** `void`
 
 ___
-<a id="hasgenesisstate"></a>
-
-###  hasGenesisState
-
-▸ **hasGenesisState**(cb: *`any`*): `void`
-
-*Defined in [state/stateManager.ts:471](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L471)*
-
-Checks whether the current instance has the canonical genesis state for the configured chain parameters.
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: hasGenesisState
-
-**Parameters:**
-
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| cb | `any` |   |
-
-**Returns:** `void`
-
-___
 <a id="putaccount"></a>
 
 ###  putAccount
 
 ▸ **putAccount**(address: *`Buffer`*, account: *`Account`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:93](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L93)*
+*Defined in [state/stateManager.ts:86](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L86)*
 
 Saves an [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) into state under the provided `address`
 
@@ -569,7 +518,7 @@ ___
 
 ▸ **putContractCode**(address: *`Buffer`*, value: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:112](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L112)*
+*Defined in [state/stateManager.ts:105](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L105)*
 
 Adds `value` to the state trie as code, and sets `codeHash` on the account corresponding to `address` to reference this.
 
@@ -594,7 +543,7 @@ ___
 
 ▸ **putContractStorage**(address: *`Buffer`*, key: *`Buffer`*, value: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:261](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L261)*
+*Defined in [state/stateManager.ts:286](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L286)*
 
 Adds value to the state trie for the `account` corresponding to `address` at the provided `key`
 
@@ -620,7 +569,7 @@ ___
 
 ▸ **revert**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:339](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L339)*
+*Defined in [state/stateManager.ts:364](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L364)*
 
 Reverts the current change-set to the instance since the last call to checkpoint.
 
@@ -643,7 +592,7 @@ ___
 
 ▸ **setStateRoot**(stateRoot: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:396](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/state/stateManager.ts#L396)*
+*Defined in [state/stateManager.ts:421](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/state/stateManager.ts#L421)*
 
 Sets the state of the instance to that represented by the provided `stateRoot`. Will error if there are uncommitted checkpoints on the instance or if the state root does not exist in the state trie.
 

--- a/docs/classes/vm.md
+++ b/docs/classes/vm.md
@@ -44,7 +44,7 @@ Execution engine which can be used to run a blockchain, individual blocks, indiv
 
 ⊕ **new VM**(opts?: *[VMOpts](../interfaces/vmopts.md)*): [VM](vm.md)
 
-*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L60)*
+*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L60)*
 
 Instantiates a new [VM](vm.md) Object.
 
@@ -66,7 +66,7 @@ ___
 
 **● _common**: *`Common`*
 
-*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L57)*
+*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L57)*
 
 ___
 <a id="allowunlimitedcontractsize"></a>
@@ -75,7 +75,7 @@ ___
 
 **● allowUnlimitedContractSize**: *`boolean`*
 
-*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L60)*
+*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L60)*
 
 ___
 <a id="blockchain"></a>
@@ -84,7 +84,7 @@ ___
 
 **● blockchain**: *`any`*
 
-*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L59)*
+*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L59)*
 
 ___
 <a id="opts"></a>
@@ -93,7 +93,7 @@ ___
 
 **● opts**: *[VMOpts](../interfaces/vmopts.md)*
 
-*Defined in [index.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L56)*
+*Defined in [index.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L56)*
 
 ___
 <a id="statemanager"></a>
@@ -102,7 +102,7 @@ ___
 
 **● stateManager**: *[StateManager](statemanager.md)*
 
-*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L58)*
+*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L58)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **_emit**(topic: *`string`*, data: *`any`*): `Promise`<`any`>
 
-*Defined in [index.ts:160](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L160)*
+*Defined in [index.ts:160](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L160)*
 
 **Parameters:**
 
@@ -132,7 +132,7 @@ ___
 
 ▸ **copy**(): [VM](vm.md)
 
-*Defined in [index.ts:152](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L152)*
+*Defined in [index.ts:152](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L152)*
 
 Returns a copy of the [VM](vm.md) instance.
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **runBlock**(opts: *[RunBlockOpts](../interfaces/runblockopts.md)*, cb: *[RunBlockCb](../interfaces/runblockcb.md)*): `void`
 
-*Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L124)*
+*Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L124)*
 
 Processes the `block` running all of the transactions it contains and updating the miner's account
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **runBlockchain**(blockchain: *`any`*, cb: *`any`*): `void`
 
-*Defined in [index.ts:114](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L114)*
+*Defined in [index.ts:114](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L114)*
 
 Processes blocks and adds them to the blockchain.
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **runCall**(opts: *[RunCallOpts](../interfaces/runcallopts.md)*, cb: *[RunCallCb](../interfaces/runcallcb.md)*): `void`
 
-*Defined in [index.ts:138](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L138)*
+*Defined in [index.ts:138](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L138)*
 
 runs a call (or create) operation.
 
@@ -205,7 +205,7 @@ ___
 
 ▸ **runCode**(opts: *[RunCodeOpts](../interfaces/runcodeopts.md)*, cb: *[RunCodeCb](../interfaces/runcodecb.md)*): `void`
 
-*Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L145)*
+*Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L145)*
 
 Runs EVM code.
 
@@ -225,7 +225,7 @@ ___
 
 ▸ **runTx**(opts: *[RunTxOpts](../interfaces/runtxopts.md)*, cb: *[RunTxCb](../interfaces/runtxcb.md)*): `void`
 
-*Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L131)*
+*Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L131)*
 
 Process a transaction. Run the vm. Transfers eth. Checks balances.
 

--- a/docs/classes/vm.md
+++ b/docs/classes/vm.md
@@ -44,7 +44,7 @@ Execution engine which can be used to run a blockchain, individual blocks, indiv
 
 ⊕ **new VM**(opts?: *[VMOpts](../interfaces/vmopts.md)*): [VM](vm.md)
 
-*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L59)*
+*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L60)*
 
 Instantiates a new [VM](vm.md) Object.
 
@@ -66,7 +66,7 @@ ___
 
 **● _common**: *`Common`*
 
-*Defined in [index.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L56)*
+*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L57)*
 
 ___
 <a id="allowunlimitedcontractsize"></a>
@@ -75,7 +75,7 @@ ___
 
 **● allowUnlimitedContractSize**: *`boolean`*
 
-*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L59)*
+*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L60)*
 
 ___
 <a id="blockchain"></a>
@@ -84,7 +84,7 @@ ___
 
 **● blockchain**: *`any`*
 
-*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L58)*
+*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L59)*
 
 ___
 <a id="opts"></a>
@@ -93,7 +93,7 @@ ___
 
 **● opts**: *[VMOpts](../interfaces/vmopts.md)*
 
-*Defined in [index.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L55)*
+*Defined in [index.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L56)*
 
 ___
 <a id="statemanager"></a>
@@ -102,7 +102,7 @@ ___
 
 **● stateManager**: *[StateManager](statemanager.md)*
 
-*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L57)*
+*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L58)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **_emit**(topic: *`string`*, data: *`any`*): `Promise`<`any`>
 
-*Defined in [index.ts:147](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L147)*
+*Defined in [index.ts:160](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L160)*
 
 **Parameters:**
 
@@ -132,7 +132,7 @@ ___
 
 ▸ **copy**(): [VM](vm.md)
 
-*Defined in [index.ts:140](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L140)*
+*Defined in [index.ts:152](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L152)*
 
 Returns a copy of the [VM](vm.md) instance.
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **runBlock**(opts: *[RunBlockOpts](../interfaces/runblockopts.md)*, cb: *[RunBlockCb](../interfaces/runblockcb.md)*): `void`
 
-*Defined in [index.ts:112](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L112)*
+*Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L124)*
 
 Processes the `block` running all of the transactions it contains and updating the miner's account
 
@@ -165,7 +165,7 @@ ___
 
 ▸ **runBlockchain**(blockchain: *`any`*, cb: *`any`*): `void`
 
-*Defined in [index.ts:102](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L102)*
+*Defined in [index.ts:114](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L114)*
 
 Processes blocks and adds them to the blockchain.
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **runCall**(opts: *[RunCallOpts](../interfaces/runcallopts.md)*, cb: *[RunCallCb](../interfaces/runcallcb.md)*): `void`
 
-*Defined in [index.ts:126](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L126)*
+*Defined in [index.ts:138](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L138)*
 
 runs a call (or create) operation.
 
@@ -205,7 +205,7 @@ ___
 
 ▸ **runCode**(opts: *[RunCodeOpts](../interfaces/runcodeopts.md)*, cb: *[RunCodeCb](../interfaces/runcodecb.md)*): `void`
 
-*Defined in [index.ts:133](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L133)*
+*Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L145)*
 
 Runs EVM code.
 
@@ -225,7 +225,7 @@ ___
 
 ▸ **runTx**(opts: *[RunTxOpts](../interfaces/runtxopts.md)*, cb: *[RunTxCb](../interfaces/runtxcb.md)*): `void`
 
-*Defined in [index.ts:119](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L119)*
+*Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L131)*
 
 Process a transaction. Run the vm. Transfers eth. Checks balances.
 

--- a/docs/classes/vmerror.md
+++ b/docs/classes/vmerror.md
@@ -27,7 +27,7 @@
 
 ⊕ **new VmError**(error: *[ERROR](../enums/error.md)*): [VmError](vmerror.md)
 
-*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L17)*
+*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L17)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ ___
 
 **● error**: *[ERROR](../enums/error.md)*
 
-*Defined in [exceptions.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L16)*
+*Defined in [exceptions.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L16)*
 
 ___
 <a id="errortype"></a>
@@ -56,7 +56,7 @@ ___
 
 **● errorType**: *`string`*
 
-*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L17)*
+*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L17)*
 
 ___
 

--- a/docs/classes/vmerror.md
+++ b/docs/classes/vmerror.md
@@ -27,7 +27,7 @@
 
 ⊕ **new VmError**(error: *[ERROR](../enums/error.md)*): [VmError](vmerror.md)
 
-*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L17)*
+*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L17)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ ___
 
 **● error**: *[ERROR](../enums/error.md)*
 
-*Defined in [exceptions.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L16)*
+*Defined in [exceptions.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L16)*
 
 ___
 <a id="errortype"></a>
@@ -56,7 +56,7 @@ ___
 
 **● errorType**: *`string`*
 
-*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L17)*
+*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L17)*
 
 ___
 

--- a/docs/enums/error.md
+++ b/docs/enums/error.md
@@ -28,7 +28,7 @@
 
 **CREATE_COLLISION**:  = "create collision"
 
-*Defined in [exceptions.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L11)*
+*Defined in [exceptions.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L11)*
 
 ___
 <a id="internal_error"></a>
@@ -37,7 +37,7 @@ ___
 
 **INTERNAL_ERROR**:  = "internal error"
 
-*Defined in [exceptions.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L10)*
+*Defined in [exceptions.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L10)*
 
 ___
 <a id="invalid_jump"></a>
@@ -46,7 +46,7 @@ ___
 
 **INVALID_JUMP**:  = "invalid JUMP"
 
-*Defined in [exceptions.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L5)*
+*Defined in [exceptions.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L5)*
 
 ___
 <a id="invalid_opcode"></a>
@@ -55,7 +55,7 @@ ___
 
 **INVALID_OPCODE**:  = "invalid opcode"
 
-*Defined in [exceptions.ts:6](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L6)*
+*Defined in [exceptions.ts:6](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L6)*
 
 ___
 <a id="out_of_gas"></a>
@@ -64,7 +64,7 @@ ___
 
 **OUT_OF_GAS**:  = "out of gas"
 
-*Defined in [exceptions.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L2)*
+*Defined in [exceptions.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L2)*
 
 ___
 <a id="out_of_range"></a>
@@ -73,7 +73,7 @@ ___
 
 **OUT_OF_RANGE**:  = "value out of range"
 
-*Defined in [exceptions.ts:7](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L7)*
+*Defined in [exceptions.ts:7](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L7)*
 
 ___
 <a id="revert"></a>
@@ -82,7 +82,7 @@ ___
 
 **REVERT**:  = "revert"
 
-*Defined in [exceptions.ts:8](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L8)*
+*Defined in [exceptions.ts:8](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L8)*
 
 ___
 <a id="stack_overflow"></a>
@@ -91,7 +91,7 @@ ___
 
 **STACK_OVERFLOW**:  = "stack overflow"
 
-*Defined in [exceptions.ts:4](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L4)*
+*Defined in [exceptions.ts:4](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L4)*
 
 ___
 <a id="stack_underflow"></a>
@@ -100,7 +100,7 @@ ___
 
 **STACK_UNDERFLOW**:  = "stack underflow"
 
-*Defined in [exceptions.ts:3](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L3)*
+*Defined in [exceptions.ts:3](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L3)*
 
 ___
 <a id="static_state_change"></a>
@@ -109,7 +109,7 @@ ___
 
 **STATIC_STATE_CHANGE**:  = "static state change"
 
-*Defined in [exceptions.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L9)*
+*Defined in [exceptions.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L9)*
 
 ___
 <a id="stop"></a>
@@ -118,7 +118,7 @@ ___
 
 **STOP**:  = "stop"
 
-*Defined in [exceptions.ts:12](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L12)*
+*Defined in [exceptions.ts:12](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/exceptions.ts#L12)*
 
 ___
 

--- a/docs/enums/error.md
+++ b/docs/enums/error.md
@@ -28,7 +28,7 @@
 
 **CREATE_COLLISION**:  = "create collision"
 
-*Defined in [exceptions.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L11)*
+*Defined in [exceptions.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L11)*
 
 ___
 <a id="internal_error"></a>
@@ -37,7 +37,7 @@ ___
 
 **INTERNAL_ERROR**:  = "internal error"
 
-*Defined in [exceptions.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L10)*
+*Defined in [exceptions.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L10)*
 
 ___
 <a id="invalid_jump"></a>
@@ -46,7 +46,7 @@ ___
 
 **INVALID_JUMP**:  = "invalid JUMP"
 
-*Defined in [exceptions.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L5)*
+*Defined in [exceptions.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L5)*
 
 ___
 <a id="invalid_opcode"></a>
@@ -55,7 +55,7 @@ ___
 
 **INVALID_OPCODE**:  = "invalid opcode"
 
-*Defined in [exceptions.ts:6](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L6)*
+*Defined in [exceptions.ts:6](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L6)*
 
 ___
 <a id="out_of_gas"></a>
@@ -64,7 +64,7 @@ ___
 
 **OUT_OF_GAS**:  = "out of gas"
 
-*Defined in [exceptions.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L2)*
+*Defined in [exceptions.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L2)*
 
 ___
 <a id="out_of_range"></a>
@@ -73,7 +73,7 @@ ___
 
 **OUT_OF_RANGE**:  = "value out of range"
 
-*Defined in [exceptions.ts:7](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L7)*
+*Defined in [exceptions.ts:7](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L7)*
 
 ___
 <a id="revert"></a>
@@ -82,7 +82,7 @@ ___
 
 **REVERT**:  = "revert"
 
-*Defined in [exceptions.ts:8](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L8)*
+*Defined in [exceptions.ts:8](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L8)*
 
 ___
 <a id="stack_overflow"></a>
@@ -91,7 +91,7 @@ ___
 
 **STACK_OVERFLOW**:  = "stack overflow"
 
-*Defined in [exceptions.ts:4](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L4)*
+*Defined in [exceptions.ts:4](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L4)*
 
 ___
 <a id="stack_underflow"></a>
@@ -100,7 +100,7 @@ ___
 
 **STACK_UNDERFLOW**:  = "stack underflow"
 
-*Defined in [exceptions.ts:3](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L3)*
+*Defined in [exceptions.ts:3](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L3)*
 
 ___
 <a id="static_state_change"></a>
@@ -109,7 +109,7 @@ ___
 
 **STATIC_STATE_CHANGE**:  = "static state change"
 
-*Defined in [exceptions.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L9)*
+*Defined in [exceptions.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L9)*
 
 ___
 <a id="stop"></a>
@@ -118,7 +118,7 @@ ___
 
 **STOP**:  = "stop"
 
-*Defined in [exceptions.ts:12](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/exceptions.ts#L12)*
+*Defined in [exceptions.ts:12](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/exceptions.ts#L12)*
 
 ___
 

--- a/docs/interfaces/execresult.md
+++ b/docs/interfaces/execresult.md
@@ -33,7 +33,7 @@ Result of executing a call via the \[\[Interpreter\]\].
 
 **● exception**: *`IsException`*
 
-*Defined in [evm/interpreter.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L47)*
+*Defined in [evm/interpreter.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L47)*
 
 `0` if the contract encountered an exception, `1` otherwise
 
@@ -44,7 +44,7 @@ ___
 
 **● exceptionError**: *[VmError](../classes/vmerror.md) \| [ERROR](../enums/error.md)*
 
-*Defined in [evm/interpreter.ts:51](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L51)*
+*Defined in [evm/interpreter.ts:51](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L51)*
 
 Description of the exception, if any occured
 
@@ -55,7 +55,7 @@ ___
 
 **● gas**: *`BN`*
 
-*Defined in [evm/interpreter.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L55)*
+*Defined in [evm/interpreter.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L55)*
 
 Amount of gas left
 
@@ -66,7 +66,7 @@ ___
 
 **● gasRefund**: *`BN`*
 
-*Defined in [evm/interpreter.ts:75](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L75)*
+*Defined in [evm/interpreter.ts:75](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L75)*
 
 Amount of gas to refund from deleting storage values
 
@@ -77,7 +77,7 @@ ___
 
 **● gasUsed**: *`BN`*
 
-*Defined in [evm/interpreter.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L59)*
+*Defined in [evm/interpreter.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L59)*
 
 Amount of gas the code used to run
 
@@ -88,7 +88,7 @@ ___
 
 **● logs**: *`any`[]*
 
-*Defined in [evm/interpreter.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L67)*
+*Defined in [evm/interpreter.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L67)*
 
 Array of logs that the contract emitted
 
@@ -99,7 +99,7 @@ ___
 
 **● return**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L63)*
+*Defined in [evm/interpreter.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L63)*
 
 Return value from the contract
 
@@ -110,7 +110,7 @@ ___
 
 **● returnValue**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L71)*
+*Defined in [evm/interpreter.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L71)*
 
 Value returned by the contract
 
@@ -121,7 +121,7 @@ ___
 
 **● runState**: *`RunState`*
 
-*Defined in [evm/interpreter.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L43)*
+*Defined in [evm/interpreter.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L43)*
 
 ___
 <a id="selfdestruct"></a>
@@ -130,7 +130,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [evm/interpreter.ts:79](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L79)*
+*Defined in [evm/interpreter.ts:79](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L79)*
 
 A map from the accounts that have self-destructed to the addresses to send their funds to
 

--- a/docs/interfaces/execresult.md
+++ b/docs/interfaces/execresult.md
@@ -33,7 +33,7 @@ Result of executing a call via the \[\[Interpreter\]\].
 
 **● exception**: *`IsException`*
 
-*Defined in [evm/interpreter.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L48)*
+*Defined in [evm/interpreter.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L47)*
 
 `0` if the contract encountered an exception, `1` otherwise
 
@@ -44,7 +44,7 @@ ___
 
 **● exceptionError**: *[VmError](../classes/vmerror.md) \| [ERROR](../enums/error.md)*
 
-*Defined in [evm/interpreter.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L52)*
+*Defined in [evm/interpreter.ts:51](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L51)*
 
 Description of the exception, if any occured
 
@@ -55,7 +55,7 @@ ___
 
 **● gas**: *`BN`*
 
-*Defined in [evm/interpreter.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L56)*
+*Defined in [evm/interpreter.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L55)*
 
 Amount of gas left
 
@@ -66,7 +66,7 @@ ___
 
 **● gasRefund**: *`BN`*
 
-*Defined in [evm/interpreter.ts:76](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L76)*
+*Defined in [evm/interpreter.ts:75](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L75)*
 
 Amount of gas to refund from deleting storage values
 
@@ -77,7 +77,7 @@ ___
 
 **● gasUsed**: *`BN`*
 
-*Defined in [evm/interpreter.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L60)*
+*Defined in [evm/interpreter.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L59)*
 
 Amount of gas the code used to run
 
@@ -88,7 +88,7 @@ ___
 
 **● logs**: *`any`[]*
 
-*Defined in [evm/interpreter.ts:68](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L68)*
+*Defined in [evm/interpreter.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L67)*
 
 Array of logs that the contract emitted
 
@@ -99,7 +99,7 @@ ___
 
 **● return**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:64](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L64)*
+*Defined in [evm/interpreter.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L63)*
 
 Return value from the contract
 
@@ -110,7 +110,7 @@ ___
 
 **● returnValue**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:72](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L72)*
+*Defined in [evm/interpreter.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L71)*
 
 Value returned by the contract
 
@@ -121,7 +121,7 @@ ___
 
 **● runState**: *`RunState`*
 
-*Defined in [evm/interpreter.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L44)*
+*Defined in [evm/interpreter.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L43)*
 
 ___
 <a id="selfdestruct"></a>
@@ -130,9 +130,9 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [evm/interpreter.ts:80](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L80)*
+*Defined in [evm/interpreter.ts:79](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L79)*
 
-A set of accounts that have self-destructed
+A map from the accounts that have self-destructed to the addresses to send their funds to
 
 ___
 

--- a/docs/interfaces/interpreterresult.md
+++ b/docs/interfaces/interpreterresult.md
@@ -28,7 +28,7 @@ Result of executing a message via the \[\[Interpreter\]\].
 
 **● createdAddress**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L32)*
+*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L32)*
 
 Address of created account durint transaction, if any
 
@@ -39,7 +39,7 @@ ___
 
 **● gasUsed**: *`BN`*
 
-*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L28)*
+*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L28)*
 
 Amount of gas used by the transaction
 
@@ -50,7 +50,7 @@ ___
 
 **● vm**: *[ExecResult](execresult.md)*
 
-*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L36)*
+*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L36)*
 
 Contains the results from running the code, if any, as described in [runCode](../classes/vm.md#runcode)
 

--- a/docs/interfaces/interpreterresult.md
+++ b/docs/interfaces/interpreterresult.md
@@ -28,7 +28,7 @@ Result of executing a message via the \[\[Interpreter\]\].
 
 **● createdAddress**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:33](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L33)*
+*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L32)*
 
 Address of created account durint transaction, if any
 
@@ -39,7 +39,7 @@ ___
 
 **● gasUsed**: *`BN`*
 
-*Defined in [evm/interpreter.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L29)*
+*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L28)*
 
 Amount of gas used by the transaction
 
@@ -50,7 +50,7 @@ ___
 
 **● vm**: *[ExecResult](execresult.md)*
 
-*Defined in [evm/interpreter.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L37)*
+*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L36)*
 
 Contains the results from running the code, if any, as described in [runCode](../classes/vm.md#runcode)
 

--- a/docs/interfaces/runblockcb.md
+++ b/docs/interfaces/runblockcb.md
@@ -11,7 +11,7 @@ Callback function for [runBlock](../classes/vm.md#runblock)
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, result: *[RunBlockResult](runblockresult.md) \| `null`*): `void`
 
-*Defined in [runBlock.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L37)*
+*Defined in [runBlock.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L37)*
 
 Callback function for [runBlock](../classes/vm.md#runblock)
 

--- a/docs/interfaces/runblockcb.md
+++ b/docs/interfaces/runblockcb.md
@@ -11,7 +11,7 @@ Callback function for [runBlock](../classes/vm.md#runblock)
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, result: *[RunBlockResult](runblockresult.md) \| `null`*): `void`
 
-*Defined in [runBlock.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L37)*
+*Defined in [runBlock.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L37)*
 
 Callback function for [runBlock](../classes/vm.md#runblock)
 

--- a/docs/interfaces/runblockopts.md
+++ b/docs/interfaces/runblockopts.md
@@ -27,7 +27,7 @@ Options for running a block.
 
 **● block**: *`any`*
 
-*Defined in [runBlock.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L18)*
+*Defined in [runBlock.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L18)*
 
 The [`Block`](https://github.com/ethereumjs/ethereumjs-block) to process
 
@@ -38,7 +38,7 @@ ___
 
 **● generate**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runBlock.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L27)*
+*Defined in [runBlock.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L27)*
 
 Whether to generate the stateRoot. If false `runBlock` will check the stateRoot of the block against the Trie
 
@@ -49,7 +49,7 @@ ___
 
 **● root**: *`Buffer`*
 
-*Defined in [runBlock.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L22)*
+*Defined in [runBlock.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L22)*
 
 Root of the state trie
 
@@ -60,7 +60,7 @@ ___
 
 **● skipBlockValidation**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runBlock.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L31)*
+*Defined in [runBlock.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L31)*
 
 If true, will skip block validation
 

--- a/docs/interfaces/runblockopts.md
+++ b/docs/interfaces/runblockopts.md
@@ -27,7 +27,7 @@ Options for running a block.
 
 **● block**: *`any`*
 
-*Defined in [runBlock.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L18)*
+*Defined in [runBlock.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L18)*
 
 The [`Block`](https://github.com/ethereumjs/ethereumjs-block) to process
 
@@ -38,7 +38,7 @@ ___
 
 **● generate**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runBlock.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L27)*
+*Defined in [runBlock.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L27)*
 
 Whether to generate the stateRoot. If false `runBlock` will check the stateRoot of the block against the Trie
 
@@ -49,7 +49,7 @@ ___
 
 **● root**: *`Buffer`*
 
-*Defined in [runBlock.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L22)*
+*Defined in [runBlock.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L22)*
 
 Root of the state trie
 
@@ -60,7 +60,7 @@ ___
 
 **● skipBlockValidation**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runBlock.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L31)*
+*Defined in [runBlock.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L31)*
 
 If true, will skip block validation
 

--- a/docs/interfaces/runblockresult.md
+++ b/docs/interfaces/runblockresult.md
@@ -25,7 +25,7 @@ Result of [runBlock](../classes/vm.md#runblock)
 
 **● receipts**: *[TxReceipt](txreceipt.md)[]*
 
-*Defined in [runBlock.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L52)*
+*Defined in [runBlock.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L52)*
 
 Receipts generated for transactions in the block
 
@@ -36,7 +36,7 @@ ___
 
 **● results**: *[RunTxResult](runtxresult.md)[]*
 
-*Defined in [runBlock.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L56)*
+*Defined in [runBlock.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L56)*
 
 Results of executing the transactions in the block
 

--- a/docs/interfaces/runblockresult.md
+++ b/docs/interfaces/runblockresult.md
@@ -25,7 +25,7 @@ Result of [runBlock](../classes/vm.md#runblock)
 
 **● receipts**: *[TxReceipt](txreceipt.md)[]*
 
-*Defined in [runBlock.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L52)*
+*Defined in [runBlock.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L52)*
 
 Receipts generated for transactions in the block
 
@@ -36,7 +36,7 @@ ___
 
 **● results**: *[RunTxResult](runtxresult.md)[]*
 
-*Defined in [runBlock.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L56)*
+*Defined in [runBlock.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L56)*
 
 Results of executing the transactions in the block
 

--- a/docs/interfaces/runcallcb.md
+++ b/docs/interfaces/runcallcb.md
@@ -11,7 +11,7 @@ Callback for the [runCall](../classes/vm.md#runcall) method.
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, results: *[InterpreterResult](interpreterresult.md) \| `null`*): `void`
 
-*Defined in [runCall.ts:38](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L38)*
+*Defined in [runCall.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L36)*
 
 Callback for the [runCall](../classes/vm.md#runcall) method.
 

--- a/docs/interfaces/runcallcb.md
+++ b/docs/interfaces/runcallcb.md
@@ -11,7 +11,7 @@ Callback for the [runCall](../classes/vm.md#runcall) method.
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, results: *[InterpreterResult](interpreterresult.md) \| `null`*): `void`
 
-*Defined in [runCall.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L36)*
+*Defined in [runCall.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L36)*
 
 Callback for the [runCall](../classes/vm.md#runcall) method.
 

--- a/docs/interfaces/runcallopts.md
+++ b/docs/interfaces/runcallopts.md
@@ -38,7 +38,7 @@ Options for running a call (or create) operation
 
 **● block**: *`any`*
 
-*Defined in [runCall.ts:13](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L13)*
+*Defined in [runCall.ts:13](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L13)*
 
 ___
 <a id="caller"></a>
@@ -47,7 +47,7 @@ ___
 
 **● caller**: *`Buffer`*
 
-*Defined in [runCall.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L16)*
+*Defined in [runCall.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L16)*
 
 ___
 <a id="code"></a>
@@ -56,7 +56,7 @@ ___
 
 **● code**: *`Buffer`*
 
-*Defined in [runCall.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L24)*
+*Defined in [runCall.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L24)*
 
 This is for CALLCODE where the code to load is different than the code from the to account
 
@@ -67,7 +67,7 @@ ___
 
 **● compiled**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L26)*
+*Defined in [runCall.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L26)*
 
 ___
 <a id="data"></a>
@@ -76,7 +76,7 @@ ___
 
 **● data**: *`Buffer`*
 
-*Defined in [runCall.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L20)*
+*Defined in [runCall.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L20)*
 
 ___
 <a id="delegatecall"></a>
@@ -85,7 +85,7 @@ ___
 
 **● delegatecall**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L30)*
+*Defined in [runCall.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L30)*
 
 ___
 <a id="depth"></a>
@@ -94,7 +94,7 @@ ___
 
 **● depth**: *`undefined` \| `number`*
 
-*Defined in [runCall.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L25)*
+*Defined in [runCall.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L25)*
 
 ___
 <a id="gaslimit"></a>
@@ -103,7 +103,7 @@ ___
 
 **● gasLimit**: *`Buffer`*
 
-*Defined in [runCall.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L17)*
+*Defined in [runCall.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L17)*
 
 ___
 <a id="gasprice"></a>
@@ -112,7 +112,7 @@ ___
 
 **● gasPrice**: *`Buffer`*
 
-*Defined in [runCall.ts:14](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L14)*
+*Defined in [runCall.ts:14](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L14)*
 
 ___
 <a id="origin"></a>
@@ -121,7 +121,7 @@ ___
 
 **● origin**: *`Buffer`*
 
-*Defined in [runCall.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L15)*
+*Defined in [runCall.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L15)*
 
 ___
 <a id="salt"></a>
@@ -130,7 +130,7 @@ ___
 
 **● salt**: *`Buffer`*
 
-*Defined in [runCall.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L28)*
+*Defined in [runCall.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L28)*
 
 ___
 <a id="selfdestruct"></a>
@@ -139,7 +139,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [runCall.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L29)*
+*Defined in [runCall.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L29)*
 
 ___
 <a id="static"></a>
@@ -148,7 +148,7 @@ ___
 
 **● static**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L27)*
+*Defined in [runCall.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L27)*
 
 ___
 <a id="to"></a>
@@ -157,7 +157,7 @@ ___
 
 **● to**: *`Buffer`*
 
-*Defined in [runCall.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L18)*
+*Defined in [runCall.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L18)*
 
 ___
 <a id="value"></a>
@@ -166,7 +166,7 @@ ___
 
 **● value**: *`Buffer`*
 
-*Defined in [runCall.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L19)*
+*Defined in [runCall.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCall.ts#L19)*
 
 ___
 

--- a/docs/interfaces/runcallopts.md
+++ b/docs/interfaces/runcallopts.md
@@ -25,7 +25,6 @@ Options for running a call (or create) operation
 * [salt](runcallopts.md#salt)
 * [selfdestruct](runcallopts.md#selfdestruct)
 * [static](runcallopts.md#static)
-* [storageReader](runcallopts.md#storagereader)
 * [to](runcallopts.md#to)
 * [value](runcallopts.md#value)
 
@@ -39,7 +38,7 @@ Options for running a call (or create) operation
 
 **● block**: *`any`*
 
-*Defined in [runCall.ts:14](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L14)*
+*Defined in [runCall.ts:13](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L13)*
 
 ___
 <a id="caller"></a>
@@ -48,7 +47,7 @@ ___
 
 **● caller**: *`Buffer`*
 
-*Defined in [runCall.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L18)*
+*Defined in [runCall.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L16)*
 
 ___
 <a id="code"></a>
@@ -57,7 +56,7 @@ ___
 
 **● code**: *`Buffer`*
 
-*Defined in [runCall.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L26)*
+*Defined in [runCall.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L24)*
 
 This is for CALLCODE where the code to load is different than the code from the to account
 
@@ -68,7 +67,7 @@ ___
 
 **● compiled**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L28)*
+*Defined in [runCall.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L26)*
 
 ___
 <a id="data"></a>
@@ -77,7 +76,7 @@ ___
 
 **● data**: *`Buffer`*
 
-*Defined in [runCall.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L22)*
+*Defined in [runCall.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L20)*
 
 ___
 <a id="delegatecall"></a>
@@ -86,7 +85,7 @@ ___
 
 **● delegatecall**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L32)*
+*Defined in [runCall.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L30)*
 
 ___
 <a id="depth"></a>
@@ -95,7 +94,7 @@ ___
 
 **● depth**: *`undefined` \| `number`*
 
-*Defined in [runCall.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L27)*
+*Defined in [runCall.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L25)*
 
 ___
 <a id="gaslimit"></a>
@@ -104,7 +103,7 @@ ___
 
 **● gasLimit**: *`Buffer`*
 
-*Defined in [runCall.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L19)*
+*Defined in [runCall.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L17)*
 
 ___
 <a id="gasprice"></a>
@@ -113,7 +112,7 @@ ___
 
 **● gasPrice**: *`Buffer`*
 
-*Defined in [runCall.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L16)*
+*Defined in [runCall.ts:14](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L14)*
 
 ___
 <a id="origin"></a>
@@ -122,7 +121,7 @@ ___
 
 **● origin**: *`Buffer`*
 
-*Defined in [runCall.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L17)*
+*Defined in [runCall.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L15)*
 
 ___
 <a id="salt"></a>
@@ -131,7 +130,7 @@ ___
 
 **● salt**: *`Buffer`*
 
-*Defined in [runCall.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L30)*
+*Defined in [runCall.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L28)*
 
 ___
 <a id="selfdestruct"></a>
@@ -140,7 +139,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [runCall.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L31)*
+*Defined in [runCall.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L29)*
 
 ___
 <a id="static"></a>
@@ -149,16 +148,7 @@ ___
 
 **● static**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L29)*
-
-___
-<a id="storagereader"></a>
-
-### `<Optional>` storageReader
-
-**● storageReader**: *`StorageReader`*
-
-*Defined in [runCall.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L15)*
+*Defined in [runCall.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L27)*
 
 ___
 <a id="to"></a>
@@ -167,7 +157,7 @@ ___
 
 **● to**: *`Buffer`*
 
-*Defined in [runCall.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L20)*
+*Defined in [runCall.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L18)*
 
 ___
 <a id="value"></a>
@@ -176,7 +166,7 @@ ___
 
 **● value**: *`Buffer`*
 
-*Defined in [runCall.ts:21](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCall.ts#L21)*
+*Defined in [runCall.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCall.ts#L19)*
 
 ___
 

--- a/docs/interfaces/runcodecb.md
+++ b/docs/interfaces/runcodecb.md
@@ -11,7 +11,7 @@ Callback for `runCode` method
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, res: *[ExecResult](execresult.md) \| `null`*): `void`
 
-*Defined in [runCode.ts:75](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L75)*
+*Defined in [runCode.ts:73](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L73)*
 
 Callback for `runCode` method
 

--- a/docs/interfaces/runcodecb.md
+++ b/docs/interfaces/runcodecb.md
@@ -11,7 +11,7 @@ Callback for `runCode` method
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, res: *[ExecResult](execresult.md) \| `null`*): `void`
 
-*Defined in [runCode.ts:73](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L73)*
+*Defined in [runCode.ts:73](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L73)*
 
 Callback for `runCode` method
 

--- a/docs/interfaces/runcodeopts.md
+++ b/docs/interfaces/runcodeopts.md
@@ -26,7 +26,6 @@ Options for the [runCode](../classes/vm.md#runcode) method.
 * [origin](runcodeopts.md#origin)
 * [pc](runcodeopts.md#pc)
 * [selfdestruct](runcodeopts.md#selfdestruct)
-* [storageReader](runcodeopts.md#storagereader)
 * [txContext](runcodeopts.md#txcontext)
 * [value](runcodeopts.md#value)
 
@@ -40,7 +39,7 @@ Options for the [runCode](../classes/vm.md#runcode) method.
 
 **● address**: *`Buffer`*
 
-*Defined in [runCode.ts:65](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L65)*
+*Defined in [runCode.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L63)*
 
 The address of the account that is executing this code. The address should be a `Buffer` of bytes. Defaults to `0`
 
@@ -51,7 +50,7 @@ ___
 
 **● block**: *`any`*
 
-*Defined in [runCode.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L29)*
+*Defined in [runCode.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L28)*
 
 The [`Block`](https://github.com/ethereumjs/ethereumjs-block) the `tx` belongs to. If omitted a blank block will be used
 
@@ -62,7 +61,7 @@ ___
 
 **● caller**: *`Buffer`*
 
-*Defined in [runCode.ts:42](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L42)*
+*Defined in [runCode.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L40)*
 
 The address that ran this code. The address should be a `Buffer` of 20bits. Defaults to `0`
 
@@ -73,7 +72,7 @@ ___
 
 **● code**: *`Buffer`*
 
-*Defined in [runCode.ts:46](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L46)*
+*Defined in [runCode.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L44)*
 
 The EVM code to run
 
@@ -84,7 +83,7 @@ ___
 
 **● data**: *`Buffer`*
 
-*Defined in [runCode.ts:50](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L50)*
+*Defined in [runCode.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L48)*
 
 The input data
 
@@ -95,7 +94,7 @@ ___
 
 **● depth**: *`undefined` \| `number`*
 
-*Defined in [runCode.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L59)*
+*Defined in [runCode.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L57)*
 
 ___
 <a id="gaslimit"></a>
@@ -104,7 +103,7 @@ ___
 
 **● gasLimit**: *`Buffer`*
 
-*Defined in [runCode.ts:54](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L54)*
+*Defined in [runCode.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L52)*
 
 Gas limit
 
@@ -115,7 +114,7 @@ ___
 
 **● gasPrice**: *`Buffer`*
 
-*Defined in [runCode.ts:33](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L33)*
+*Defined in [runCode.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L31)*
 
 ___
 <a id="interpreter"></a>
@@ -124,7 +123,7 @@ ___
 
 **● interpreter**: *`Interpreter`*
 
-*Defined in [runCode.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L31)*
+*Defined in [runCode.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L29)*
 
 ___
 <a id="isstatic"></a>
@@ -133,7 +132,7 @@ ___
 
 **● isStatic**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCode.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L60)*
+*Defined in [runCode.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L58)*
 
 ___
 <a id="message"></a>
@@ -142,7 +141,7 @@ ___
 
 **● message**: *`Message`*
 
-*Defined in [runCode.ts:38](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L38)*
+*Defined in [runCode.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L36)*
 
 ___
 <a id="origin"></a>
@@ -151,7 +150,7 @@ ___
 
 **● origin**: *`Buffer`*
 
-*Defined in [runCode.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L37)*
+*Defined in [runCode.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L35)*
 
 The address where the call originated from. The address should be a `Buffer` of 20bits. Defaults to `0`
 
@@ -162,7 +161,7 @@ ___
 
 **● pc**: *`undefined` \| `number`*
 
-*Defined in [runCode.ts:69](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L69)*
+*Defined in [runCode.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L67)*
 
 The initial program counter. Defaults to `0`
 
@@ -173,16 +172,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [runCode.ts:61](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L61)*
-
-___
-<a id="storagereader"></a>
-
-### `<Optional>` storageReader
-
-**● storageReader**: *`StorageReader`*
-
-*Defined in [runCode.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L30)*
+*Defined in [runCode.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L59)*
 
 ___
 <a id="txcontext"></a>
@@ -191,7 +181,7 @@ ___
 
 **● txContext**: *`TxContext`*
 
-*Defined in [runCode.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L32)*
+*Defined in [runCode.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L30)*
 
 ___
 <a id="value"></a>
@@ -200,7 +190,7 @@ ___
 
 **● value**: *`Buffer`*
 
-*Defined in [runCode.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runCode.ts#L58)*
+*Defined in [runCode.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L56)*
 
 The value in ether that is being sent to `opt.address`. Defaults to `0`
 

--- a/docs/interfaces/runcodeopts.md
+++ b/docs/interfaces/runcodeopts.md
@@ -39,7 +39,7 @@ Options for the [runCode](../classes/vm.md#runcode) method.
 
 **● address**: *`Buffer`*
 
-*Defined in [runCode.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L63)*
+*Defined in [runCode.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L63)*
 
 The address of the account that is executing this code. The address should be a `Buffer` of bytes. Defaults to `0`
 
@@ -50,7 +50,7 @@ ___
 
 **● block**: *`any`*
 
-*Defined in [runCode.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L28)*
+*Defined in [runCode.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L28)*
 
 The [`Block`](https://github.com/ethereumjs/ethereumjs-block) the `tx` belongs to. If omitted a blank block will be used
 
@@ -61,7 +61,7 @@ ___
 
 **● caller**: *`Buffer`*
 
-*Defined in [runCode.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L40)*
+*Defined in [runCode.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L40)*
 
 The address that ran this code. The address should be a `Buffer` of 20bits. Defaults to `0`
 
@@ -72,7 +72,7 @@ ___
 
 **● code**: *`Buffer`*
 
-*Defined in [runCode.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L44)*
+*Defined in [runCode.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L44)*
 
 The EVM code to run
 
@@ -83,7 +83,7 @@ ___
 
 **● data**: *`Buffer`*
 
-*Defined in [runCode.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L48)*
+*Defined in [runCode.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L48)*
 
 The input data
 
@@ -94,7 +94,7 @@ ___
 
 **● depth**: *`undefined` \| `number`*
 
-*Defined in [runCode.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L57)*
+*Defined in [runCode.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L57)*
 
 ___
 <a id="gaslimit"></a>
@@ -103,7 +103,7 @@ ___
 
 **● gasLimit**: *`Buffer`*
 
-*Defined in [runCode.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L52)*
+*Defined in [runCode.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L52)*
 
 Gas limit
 
@@ -114,7 +114,7 @@ ___
 
 **● gasPrice**: *`Buffer`*
 
-*Defined in [runCode.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L31)*
+*Defined in [runCode.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L31)*
 
 ___
 <a id="interpreter"></a>
@@ -123,7 +123,7 @@ ___
 
 **● interpreter**: *`Interpreter`*
 
-*Defined in [runCode.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L29)*
+*Defined in [runCode.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L29)*
 
 ___
 <a id="isstatic"></a>
@@ -132,7 +132,7 @@ ___
 
 **● isStatic**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCode.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L58)*
+*Defined in [runCode.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L58)*
 
 ___
 <a id="message"></a>
@@ -141,7 +141,7 @@ ___
 
 **● message**: *`Message`*
 
-*Defined in [runCode.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L36)*
+*Defined in [runCode.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L36)*
 
 ___
 <a id="origin"></a>
@@ -150,7 +150,7 @@ ___
 
 **● origin**: *`Buffer`*
 
-*Defined in [runCode.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L35)*
+*Defined in [runCode.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L35)*
 
 The address where the call originated from. The address should be a `Buffer` of 20bits. Defaults to `0`
 
@@ -161,7 +161,7 @@ ___
 
 **● pc**: *`undefined` \| `number`*
 
-*Defined in [runCode.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L67)*
+*Defined in [runCode.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L67)*
 
 The initial program counter. Defaults to `0`
 
@@ -172,7 +172,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [runCode.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L59)*
+*Defined in [runCode.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L59)*
 
 ___
 <a id="txcontext"></a>
@@ -181,7 +181,7 @@ ___
 
 **● txContext**: *`TxContext`*
 
-*Defined in [runCode.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L30)*
+*Defined in [runCode.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L30)*
 
 ___
 <a id="value"></a>
@@ -190,7 +190,7 @@ ___
 
 **● value**: *`Buffer`*
 
-*Defined in [runCode.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runCode.ts#L56)*
+*Defined in [runCode.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runCode.ts#L56)*
 
 The value in ether that is being sent to `opt.address`. Defaults to `0`
 

--- a/docs/interfaces/runtxcb.md
+++ b/docs/interfaces/runtxcb.md
@@ -11,7 +11,7 @@ Callback for `runTx` method
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, results: *[RunTxResult](runtxresult.md) \| `null`*): `void`
 
-*Defined in [runTx.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L37)*
+*Defined in [runTx.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L37)*
 
 Callback for `runTx` method
 

--- a/docs/interfaces/runtxcb.md
+++ b/docs/interfaces/runtxcb.md
@@ -11,7 +11,7 @@ Callback for `runTx` method
 ## Callable
 ▸ **__call**(err: *`Error` \| `null`*, results: *[RunTxResult](runtxresult.md) \| `null`*): `void`
 
-*Defined in [runTx.ts:38](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L38)*
+*Defined in [runTx.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L37)*
 
 Callback for `runTx` method
 

--- a/docs/interfaces/runtxopts.md
+++ b/docs/interfaces/runtxopts.md
@@ -27,7 +27,7 @@ Options for the `runTx` method.
 
 **● block**: *`any`*
 
-*Defined in [runTx.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L20)*
+*Defined in [runTx.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L19)*
 
 The block to which the `tx` belongs
 
@@ -38,7 +38,7 @@ ___
 
 **● skipBalance**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runTx.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L32)*
+*Defined in [runTx.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L31)*
 
 If true, skips the balance check
 
@@ -49,7 +49,7 @@ ___
 
 **● skipNonce**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runTx.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L28)*
+*Defined in [runTx.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L27)*
 
 If true, skips the nonce check
 
@@ -60,7 +60,7 @@ ___
 
 **● tx**: *`any`*
 
-*Defined in [runTx.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L24)*
+*Defined in [runTx.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L23)*
 
 A [`Transaction`](https://github.com/ethereum/ethereumjs-tx) to run
 

--- a/docs/interfaces/runtxopts.md
+++ b/docs/interfaces/runtxopts.md
@@ -27,7 +27,7 @@ Options for the `runTx` method.
 
 **● block**: *`any`*
 
-*Defined in [runTx.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L19)*
+*Defined in [runTx.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L19)*
 
 The block to which the `tx` belongs
 
@@ -38,7 +38,7 @@ ___
 
 **● skipBalance**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runTx.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L31)*
+*Defined in [runTx.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L31)*
 
 If true, skips the balance check
 
@@ -49,7 +49,7 @@ ___
 
 **● skipNonce**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runTx.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L27)*
+*Defined in [runTx.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L27)*
 
 If true, skips the nonce check
 
@@ -60,7 +60,7 @@ ___
 
 **● tx**: *`any`*
 
-*Defined in [runTx.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L23)*
+*Defined in [runTx.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L23)*
 
 A [`Transaction`](https://github.com/ethereum/ethereumjs-tx) to run
 

--- a/docs/interfaces/runtxresult.md
+++ b/docs/interfaces/runtxresult.md
@@ -31,7 +31,7 @@ Execution result of a transaction
 
 **● amountSpent**: *`BN`*
 
-*Defined in [runTx.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L57)*
+*Defined in [runTx.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L56)*
 
 The amount of ether used by this transaction
 
@@ -42,7 +42,7 @@ ___
 
 **● bloom**: *`Bloom`*
 
-*Defined in [runTx.ts:53](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L53)*
+*Defined in [runTx.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L52)*
 
 Bloom filter resulted from transaction
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[createdAddress](interpreterresult.md#createdaddress)*
 
-*Defined in [evm/interpreter.ts:33](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L33)*
+*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L32)*
 
 Address of created account durint transaction, if any
 
@@ -66,7 +66,7 @@ ___
 
 **● gasRefund**: *`BN`*
 
-*Defined in [runTx.ts:61](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runTx.ts#L61)*
+*Defined in [runTx.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L60)*
 
 The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[gasUsed](interpreterresult.md#gasused)*
 
-*Defined in [evm/interpreter.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L29)*
+*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L28)*
 
 Amount of gas used by the transaction
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[vm](interpreterresult.md#vm)*
 
-*Defined in [evm/interpreter.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/evm/interpreter.ts#L37)*
+*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L36)*
 
 Contains the results from running the code, if any, as described in [runCode](../classes/vm.md#runcode)
 

--- a/docs/interfaces/runtxresult.md
+++ b/docs/interfaces/runtxresult.md
@@ -31,7 +31,7 @@ Execution result of a transaction
 
 **● amountSpent**: *`BN`*
 
-*Defined in [runTx.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L56)*
+*Defined in [runTx.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L56)*
 
 The amount of ether used by this transaction
 
@@ -42,7 +42,7 @@ ___
 
 **● bloom**: *`Bloom`*
 
-*Defined in [runTx.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L52)*
+*Defined in [runTx.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L52)*
 
 Bloom filter resulted from transaction
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[createdAddress](interpreterresult.md#createdaddress)*
 
-*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L32)*
+*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L32)*
 
 Address of created account durint transaction, if any
 
@@ -66,7 +66,7 @@ ___
 
 **● gasRefund**: *`BN`*
 
-*Defined in [runTx.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runTx.ts#L60)*
+*Defined in [runTx.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runTx.ts#L60)*
 
 The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[gasUsed](interpreterresult.md#gasused)*
 
-*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L28)*
+*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L28)*
 
 Amount of gas used by the transaction
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[vm](interpreterresult.md#vm)*
 
-*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/evm/interpreter.ts#L36)*
+*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/evm/interpreter.ts#L36)*
 
 Contains the results from running the code, if any, as described in [runCode](../classes/vm.md#runcode)
 

--- a/docs/interfaces/txreceipt.md
+++ b/docs/interfaces/txreceipt.md
@@ -27,7 +27,7 @@ Receipt generated for a transaction
 
 **● bitvector**: *`Buffer`*
 
-*Defined in [runBlock.ts:74](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L74)*
+*Defined in [runBlock.ts:74](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L74)*
 
 Bloom bitvector
 
@@ -38,7 +38,7 @@ ___
 
 **● gasUsed**: *`Buffer`*
 
-*Defined in [runBlock.ts:70](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L70)*
+*Defined in [runBlock.ts:70](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L70)*
 
 Gas used
 
@@ -49,7 +49,7 @@ ___
 
 **● logs**: *`any`[]*
 
-*Defined in [runBlock.ts:78](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L78)*
+*Defined in [runBlock.ts:78](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L78)*
 
 Logs emitted
 
@@ -60,7 +60,7 @@ ___
 
 **● status**: *`0` \| `1`*
 
-*Defined in [runBlock.ts:66](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/runBlock.ts#L66)*
+*Defined in [runBlock.ts:66](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L66)*
 
 Status of transaction, `0` if successful, `1` if an exception occured
 

--- a/docs/interfaces/txreceipt.md
+++ b/docs/interfaces/txreceipt.md
@@ -27,7 +27,7 @@ Receipt generated for a transaction
 
 **● bitvector**: *`Buffer`*
 
-*Defined in [runBlock.ts:74](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L74)*
+*Defined in [runBlock.ts:74](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L74)*
 
 Bloom bitvector
 
@@ -38,7 +38,7 @@ ___
 
 **● gasUsed**: *`Buffer`*
 
-*Defined in [runBlock.ts:70](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L70)*
+*Defined in [runBlock.ts:70](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L70)*
 
 Gas used
 
@@ -49,7 +49,7 @@ ___
 
 **● logs**: *`any`[]*
 
-*Defined in [runBlock.ts:78](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L78)*
+*Defined in [runBlock.ts:78](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L78)*
 
 Logs emitted
 
@@ -60,7 +60,7 @@ ___
 
 **● status**: *`0` \| `1`*
 
-*Defined in [runBlock.ts:66](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/runBlock.ts#L66)*
+*Defined in [runBlock.ts:66](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/runBlock.ts#L66)*
 
 Status of transaction, `0` if successful, `1` if an exception occured
 

--- a/docs/interfaces/vmopts.md
+++ b/docs/interfaces/vmopts.md
@@ -16,6 +16,7 @@ Options for instantiating a [VM](../classes/vm.md).
 * [allowUnlimitedContractSize](vmopts.md#allowunlimitedcontractsize)
 * [blockchain](vmopts.md#blockchain)
 * [chain](vmopts.md#chain)
+* [common](vmopts.md#common)
 * [hardfork](vmopts.md#hardfork)
 * [state](vmopts.md#state)
 * [stateManager](vmopts.md#statemanager)
@@ -30,7 +31,7 @@ Options for instantiating a [VM](../classes/vm.md).
 
 **● activatePrecompiles**: *`undefined` \| `false` \| `true`*
 
-*Defined in [index.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L43)*
+*Defined in [index.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L43)*
 
 If true, create entries in the state tree for the precompiled contracts
 
@@ -41,7 +42,7 @@ ___
 
 **● allowUnlimitedContractSize**: *`undefined` \| `false` \| `true`*
 
-*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L47)*
+*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L47)*
 
 Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed
 
@@ -52,7 +53,7 @@ ___
 
 **● blockchain**: *`any`*
 
-*Defined in [index.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L39)*
+*Defined in [index.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L39)*
 
 A [blockchain](https://github.com/ethereumjs/ethereumjs-blockchain) object for storing/retrieving blocks
 
@@ -63,9 +64,18 @@ ___
 
 **● chain**: *`undefined` \| `string`*
 
-*Defined in [index.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L22)*
+*Defined in [index.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L22)*
 
 The chain the VM operates on
+
+___
+<a id="common"></a>
+
+### `<Optional>` common
+
+**● common**: *`Common`*
+
+*Defined in [index.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L48)*
 
 ___
 <a id="hardfork"></a>
@@ -74,7 +84,7 @@ ___
 
 **● hardfork**: *`undefined` \| `string`*
 
-*Defined in [index.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L26)*
+*Defined in [index.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L26)*
 
 Hardfork rules to be used
 
@@ -85,7 +95,7 @@ ___
 
 **● state**: *`any`*
 
-*Defined in [index.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L35)*
+*Defined in [index.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L35)*
 
 A [merkle-patricia-tree](https://github.com/ethereumjs/merkle-patricia-tree) instance for the state tree (ignored if stateManager is passed)
 
@@ -98,7 +108,7 @@ ___
 
 **● stateManager**: *[StateManager](../classes/statemanager.md)*
 
-*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/de4d574/lib/index.ts#L30)*
+*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L30)*
 
 A [StateManager](../classes/statemanager.md) instance to use as the state store (Beta API)
 

--- a/docs/interfaces/vmopts.md
+++ b/docs/interfaces/vmopts.md
@@ -31,7 +31,7 @@ Options for instantiating a [VM](../classes/vm.md).
 
 **● activatePrecompiles**: *`undefined` \| `false` \| `true`*
 
-*Defined in [index.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L43)*
+*Defined in [index.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L43)*
 
 If true, create entries in the state tree for the precompiled contracts
 
@@ -42,7 +42,7 @@ ___
 
 **● allowUnlimitedContractSize**: *`undefined` \| `false` \| `true`*
 
-*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L47)*
+*Defined in [index.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L47)*
 
 Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed
 
@@ -53,7 +53,7 @@ ___
 
 **● blockchain**: *`any`*
 
-*Defined in [index.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L39)*
+*Defined in [index.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L39)*
 
 A [blockchain](https://github.com/ethereumjs/ethereumjs-blockchain) object for storing/retrieving blocks
 
@@ -64,7 +64,7 @@ ___
 
 **● chain**: *`undefined` \| `string`*
 
-*Defined in [index.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L22)*
+*Defined in [index.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L22)*
 
 The chain the VM operates on
 
@@ -75,7 +75,7 @@ ___
 
 **● common**: *`Common`*
 
-*Defined in [index.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L48)*
+*Defined in [index.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L48)*
 
 ___
 <a id="hardfork"></a>
@@ -84,7 +84,7 @@ ___
 
 **● hardfork**: *`undefined` \| `string`*
 
-*Defined in [index.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L26)*
+*Defined in [index.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L26)*
 
 Hardfork rules to be used
 
@@ -95,7 +95,7 @@ ___
 
 **● state**: *`any`*
 
-*Defined in [index.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L35)*
+*Defined in [index.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L35)*
 
 A [merkle-patricia-tree](https://github.com/ethereumjs/merkle-patricia-tree) instance for the state tree (ignored if stateManager is passed)
 
@@ -108,7 +108,7 @@ ___
 
 **● stateManager**: *[StateManager](../classes/statemanager.md)*
 
-*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/5938d6a/lib/index.ts#L30)*
+*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/eab4a99/lib/index.ts#L30)*
 
 A [StateManager](../classes/statemanager.md) instance to use as the state store (Beta API)
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -97,7 +97,7 @@ export default class VM extends AsyncEventEmitter {
           trie.put(new BN(i).toArrayLike(Buffer, 'be', 20), new Account().serialize())
         }
       }
-      this.stateManager = new StateManager({ trie, common: this._common })
+      this.stateManager = new StateManager({ trie })
     }
 
     this.blockchain = opts.blockchain || new Blockchain({ common: this._common })

--- a/lib/runBlockchain.ts
+++ b/lib/runBlockchain.ts
@@ -1,4 +1,10 @@
+import BN = require('bn.js')
+import Common from 'ethereumjs-common'
+import { genesisStateByName } from 'ethereumjs-common/dist/genesisStates'
+import Account from 'ethereumjs-account'
+import { toBuffer } from 'ethereumjs-util'
 import VM from './index'
+import { StateManager } from './state'
 const async = require('async')
 
 /**
@@ -31,7 +37,7 @@ export default function runBlockchain(this: VM, blockchain: any, cb: any) {
           // generate genesis state if we are at the genesis block
           // we don't have the genesis state
           if (!headBlock) {
-            return self.stateManager.generateCanonicalGenesis(cb)
+            return generateCanonicalGenesis(self.stateManager, self._common, cb)
           } else {
             cb(err)
           }
@@ -64,4 +70,66 @@ export default function runBlockchain(this: VM, blockchain: any, cb: any) {
       )
     }
   }
+}
+
+/**
+ * Generates a canonical genesis state on the instance based on the
+ * configured chain parameters. Will error if there are uncommitted
+ * checkpoints on the instance.
+ */
+function generateCanonicalGenesis(stateManager: StateManager, common: Common, cb: any): void {
+  if (stateManager._checkpointCount !== 0) {
+    return cb(new Error('Cannot create genesis state with uncommitted checkpoints'))
+  }
+
+  hasGenesisState(stateManager, common, (err: Error | null, genesis: boolean) => {
+    if (!genesis && !err) {
+      generateGenesis(stateManager, genesisStateByName(common.chainName()), cb)
+    } else {
+      cb(err)
+    }
+  })
+}
+
+interface hasGenesisStateCallback {
+  /**
+   * @param err - An error that may have happened or `null`
+   * @param hasGenesisState - Whether the storage trie contains the
+   * canonical genesis state for the configured chain parameters.
+   */
+  (err: Error | null, hasGenesisState: boolean): void
+}
+
+/**
+ * Checks whether the current instance has the canonical genesis state
+ * for the configured chain parameters.
+ */
+function hasGenesisState(
+  stateManager: StateManager,
+  common: Common,
+  cb: hasGenesisStateCallback,
+): void {
+  const root = common.genesis().stateRoot
+  stateManager._trie.checkRoot(root, cb)
+}
+
+/**
+ * Initializes the provided genesis state into the state trie.
+ */
+function generateGenesis(stateManager: StateManager, initState: any, cb: any) {
+  if (stateManager._checkpointCount !== 0) {
+    return cb(new Error('Cannot create genesis state with uncommitted checkpoints'))
+  }
+
+  const addresses = Object.keys(initState)
+  async.eachSeries(
+    addresses,
+    (address: string, done: any) => {
+      const account = new Account()
+      account.balance = new BN(initState[address]).toArrayLike(Buffer)
+      const addressBuffer = toBuffer(address)
+      stateManager._trie.put(addressBuffer, account.serialize(), done)
+    },
+    cb,
+  )
 }

--- a/lib/state/promisified.ts
+++ b/lib/state/promisified.ts
@@ -73,18 +73,6 @@ export default class PStateManager {
     return promisify(this._wrapped.dumpStorage.bind(this._wrapped))(address)
   }
 
-  hasGenesisState(): Promise<boolean> {
-    return promisify(this._wrapped.hasGenesisState.bind(this._wrapped))()
-  }
-
-  generateCanonicalGenesis(): Promise<void> {
-    return promisify(this._wrapped.generateCanonicalGenesis.bind(this._wrapped))()
-  }
-
-  generateGenesis(initState: any): Promise<void> {
-    return promisify(this._wrapped.generateGenesis.bind(this._wrapped))(initState)
-  }
-
   accountIsEmpty(address: Buffer): Promise<boolean> {
     return promisify(this._wrapped.accountIsEmpty.bind(this._wrapped))(address)
   }

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -33,7 +33,7 @@ tape('VM with default blockchain', (t) => {
   })
 
   t.test('should only accept common or chain and fork', (st) => {
-    const common = new Common('mainnet');
+    const common = new Common('mainnet')
 
     st.throws(() => new VM({ chain: 'a', common }))
     st.throws(() => new VM({ hardfork: 'a', common }))
@@ -53,7 +53,7 @@ tape('VM with default blockchain', (t) => {
 
   t.test('should only accept valid chain and fork', (st) => {
     let vm = new VM({ chain: 'ropsten', hardfork: 'byzantium' })
-    st.equal(vm.stateManager._common.param('gasPrices', 'ecAdd'), 500)
+    st.equal(vm._common.param('gasPrices', 'ecAdd'), 500)
 
     try {
       vm = new VM({ chain: 'mainchain', hardfork: 'homestead' })

--- a/tests/api/runBlockchain.js
+++ b/tests/api/runBlockchain.js
@@ -16,9 +16,11 @@ tape('runBlockchain', (t) => {
     chain: 'goerli',
     validate: false
   })
+  const common = new Common('goerli')
   const vm = {
-    stateManager: new StateManager({ common: new Common('goerli') }),
-    blockchain: blockchain
+    stateManager: new StateManager({ common }),
+    blockchain: blockchain,
+    _common: common
   }
 
   const putGenesisP = promisify(blockchain.putGenesis.bind(blockchain))

--- a/tests/api/state/stateManager.js
+++ b/tests/api/state/stateManager.js
@@ -1,7 +1,6 @@
 const promisify = require('util.promisify')
 const tape = require('tape')
 const util = require('ethereumjs-util')
-const Common = require('ethereumjs-common').default
 const { StateManager } = require('../../../dist/state')
 const { createAccount } = require('../utils')
 
@@ -10,7 +9,6 @@ tape('StateManager', (t) => {
     const stateManager = new StateManager()
 
     st.deepEqual(stateManager._trie.root, util.KECCAK256_RLP, 'it has default root')
-    st.equal(stateManager._common.hardfork(), 'petersburg', 'it has default hardfork')
     stateManager.getStateRoot((err, res) => {
       st.error(err, 'getStateRoot returns no error')
       st.deepEqual(res, util.KECCAK256_RLP, 'it has default root')
@@ -123,21 +121,6 @@ tape('StateManager', (t) => {
     st.end()
   })
 
-  t.test('should generate the genesis state correctly', async (st) => {
-    const genesisData = require('ethereumjs-testing').getSingleFile('BasicTests/genesishashestest.json')
-    const stateManager = new StateManager()
-
-    const generateCanonicalGenesis = promisify((...args) => stateManager.generateCanonicalGenesis(...args))
-    const getStateRoot = promisify((...args) => stateManager.getStateRoot(...args))
-
-    await generateCanonicalGenesis()
-    let stateRoot = await getStateRoot()
-
-    st.equal(stateRoot.toString('hex'), genesisData.genesis_state_root)
-
-    st.end()
-  })
-
   t.test('should dump storage', async st => {
     const stateManager = new StateManager()
     const addressBuffer = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
@@ -160,21 +143,6 @@ tape('StateManager', (t) => {
 
       st.end()
     })
-  })
-
-  t.test('should pass Common object when copying the state manager', st => {
-    const stateManager = new StateManager({
-      common: new Common('goerli', 'byzantium')
-    })
-
-    st.equal(stateManager._common.chainName(), 'goerli')
-    st.equal(stateManager._common.hardfork(), 'byzantium')
-
-    const stateManagerCopy = stateManager.copy()
-    st.equal(stateManagerCopy._common.chainName(), 'goerli')
-    st.equal(stateManagerCopy._common.hardfork(), 'byzantium')
-
-    st.end()
   })
 })
 


### PR DESCRIPTION
Some notes:

- `generateCanonicalGenesis` and its utility methods made use of private `stateManager` attributes (`_checkpointCount` and `_trie`). I've kept it that way for now.
- `hasGenesisState` uses `_trie.checkRoot` which in turn only checks whether the hash exists in leveldb? This seems like a rough heuristic (and can give wrong results I imagine).
- `generateGensis` uses `_trie.put` to save genesis accounts to state (overriding cache and checkpointing).
- I'm not sure if `generateCanonicalGenesis` (and its util methods) should be exported or not.

Generally I don't feel very strongly about this change. I don't like these functions being in `StateManager`, but the alternative is also not that exciting. Leaving it to everyone else to decide.

Fixes #533 