### PR TITLE
Use typedoc syntax instead of jsdoc, add docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 * [RunCodeOpts](interfaces/runcodeopts.md)
 * [RunTxOpts](interfaces/runtxopts.md)
 * [RunTxResult](interfaces/runtxresult.md)
+* [StateManagerOpts](interfaces/statemanageropts.md)
 * [StorageDump](interfaces/storagedump.md)
 * [TxReceipt](interfaces/txreceipt.md)
 * [VMOpts](interfaces/vmopts.md)

--- a/docs/classes/statemanager.md
+++ b/docs/classes/statemanager.md
@@ -59,9 +59,9 @@ Interface for getting and setting data from an underlying state trie.
 
 ###  constructor
 
-⊕ **new StateManager**(opts?: *`any`*): [StateManager](statemanager.md)
+⊕ **new StateManager**(opts?: *[StateManagerOpts](../interfaces/statemanageropts.md)*): [StateManager](statemanager.md)
 
-*Defined in [state/stateManager.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L31)*
+*Defined in [state/stateManager.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L45)*
 
 Instantiate the StateManager interface.
 
@@ -69,7 +69,7 @@ Instantiate the StateManager interface.
 
 | Name | Type | Default value |
 | ------ | ------ | ------ |
-| `Default value` opts | `any` |  {} |
+| `Default value` opts | [StateManagerOpts](../interfaces/statemanageropts.md) |  {} |
 
 **Returns:** [StateManager](statemanager.md)
 
@@ -83,7 +83,7 @@ ___
 
 **● _cache**: *`Cache`*
 
-*Defined in [state/stateManager.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L27)*
+*Defined in [state/stateManager.ts:41](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L41)*
 
 ___
 <a id="_checkpointcount"></a>
@@ -92,7 +92,7 @@ ___
 
 **● _checkpointCount**: *`number`*
 
-*Defined in [state/stateManager.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L30)*
+*Defined in [state/stateManager.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L44)*
 
 ___
 <a id="_common"></a>
@@ -101,7 +101,7 @@ ___
 
 **● _common**: *`Common`*
 
-*Defined in [state/stateManager.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L24)*
+*Defined in [state/stateManager.ts:38](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L38)*
 
 ___
 <a id="_originalstoragecache"></a>
@@ -110,7 +110,7 @@ ___
 
 **● _originalStorageCache**: *`Map`<`string`, `Map`<`string`, `Buffer`>>*
 
-*Defined in [state/stateManager.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L31)*
+*Defined in [state/stateManager.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L45)*
 
 ___
 <a id="_storagetries"></a>
@@ -119,7 +119,7 @@ ___
 
 **● _storageTries**: *`any`*
 
-*Defined in [state/stateManager.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L26)*
+*Defined in [state/stateManager.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L40)*
 
 ___
 <a id="_touched"></a>
@@ -128,7 +128,7 @@ ___
 
 **● _touched**: *`Set`<`string`>*
 
-*Defined in [state/stateManager.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L28)*
+*Defined in [state/stateManager.ts:42](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L42)*
 
 ___
 <a id="_touchedstack"></a>
@@ -137,7 +137,7 @@ ___
 
 **● _touchedStack**: *`Set`<`string`>[]*
 
-*Defined in [state/stateManager.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L29)*
+*Defined in [state/stateManager.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L43)*
 
 ___
 <a id="_trie"></a>
@@ -146,7 +146,7 @@ ___
 
 **● _trie**: *`any`*
 
-*Defined in [state/stateManager.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L25)*
+*Defined in [state/stateManager.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L39)*
 
 ___
 
@@ -158,20 +158,16 @@ ___
 
 ▸ **_getStorageTrie**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:184](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L184)*
+*Defined in [state/stateManager.ts:177](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L177)*
 
-Gets the storage trie for an account from the storage cache or does a lookup
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: \_getStorageTrie
+Gets the storage trie for an account from the storage cache or does a lookup.
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| address | `Buffer` |  \- |
-| cb | `any` |  Callback function |
+| Name | Type |
+| ------ | ------ |
+| address | `Buffer` |
+| cb | `any` |
 
 **Returns:** `void`
 
@@ -182,20 +178,16 @@ ___
 
 ▸ **_lookupStorageTrie**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:162](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L162)*
+*Defined in [state/stateManager.ts:159](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L159)*
 
 Creates a storage trie from the primary storage trie for an account and saves this in the storage cache.
 
-*__memberof__*: DefaultStateManager
-
-*__method__*: \_lookupStorageTrie
-
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| address | `Buffer` |  \- |
-| cb | `any` |  Callback function |
+| Name | Type |
+| ------ | ------ |
+| address | `Buffer` |
+| cb | `any` |
 
 **Returns:** `void`
 
@@ -206,20 +198,16 @@ ___
 
 ▸ **_modifyContractStorage**(address: *`Buffer`*, modifyTrie: *`any`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:266](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L266)*
+*Defined in [state/stateManager.ts:255](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L255)*
 
 Modifies the storage trie of an account
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: \_modifyContractStorage
 
 **Parameters:**
 
 | Name | Type | Description |
 | ------ | ------ | ------ |
 | address | `Buffer` |  Address of the account whose storage is to be modified |
-| modifyTrie | `any` |  function to modify the storage trie of the account |
+| modifyTrie | `any` |  Function to modify the storage trie of the account |
 | cb | `any` |
 
 **Returns:** `void`
@@ -231,13 +219,9 @@ ___
 
 ▸ **accountIsEmpty**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:572](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L572)*
+*Defined in [state/stateManager.ts:537](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L537)*
 
-Checks if the `account` corresponding to `address` is empty as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md))
-
-*__memberof__*: StateManager
-
-*__method__*: accountIsEmpty
+Checks if the `account` corresponding to `address` is empty as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).
 
 **Parameters:**
 
@@ -255,13 +239,9 @@ ___
 
 ▸ **checkpoint**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:338](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L338)*
+*Defined in [state/stateManager.ts:321](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L321)*
 
 Checkpoints the current state of the StateManager instance. State changes that follow can then be committed by calling `commit` or `reverted` by calling rollback.
-
-*__memberof__*: StateManager
-
-*__method__*: checkpoint
 
 **Parameters:**
 
@@ -278,13 +258,9 @@ ___
 
 ▸ **cleanupTouchedAccounts**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:595](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L595)*
+*Defined in [state/stateManager.ts:558](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L558)*
 
 Removes accounts form the state trie that have been touched, as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).
-
-*__memberof__*: StateManager
-
-*__method__*: cleanupTouchedAccounts
 
 **Parameters:**
 
@@ -301,13 +277,9 @@ ___
 
 ▸ **clearContractStorage**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:319](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L319)*
+*Defined in [state/stateManager.ts:304](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L304)*
 
-Clears all storage entries for the account corresponding to `address`
-
-*__memberof__*: StateManager
-
-*__method__*: clearContractStorage
+Clears all storage entries for the account corresponding to `address`.
 
 **Parameters:**
 
@@ -325,13 +297,9 @@ ___
 
 ▸ **commit**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:353](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L353)*
+*Defined in [state/stateManager.ts:334](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L334)*
 
 Commits the current change-set to the instance since the last call to checkpoint.
-
-*__memberof__*: StateManager
-
-*__method__*: commit
 
 **Parameters:**
 
@@ -348,13 +316,9 @@ ___
 
 ▸ **copy**(): [StateManager](statemanager.md)
 
-*Defined in [state/stateManager.ts:62](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L62)*
+*Defined in [state/stateManager.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L71)*
 
-Copies the current instance of the `DefaultStateManager` at the last fully committed point, i.e. as if all current checkpoints were reverted
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: copy
+Copies the current instance of the `DefaultStateManager` at the last fully committed point, i.e. as if all current checkpoints were reverted.
 
 **Returns:** [StateManager](statemanager.md)
 
@@ -365,13 +329,9 @@ ___
 
 ▸ **dumpStorage**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:474](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L474)*
+*Defined in [state/stateManager.ts:447](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L447)*
 
-Dumps the the storage values for an `account` specified by `address`
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: dumpStorage
+Dumps the the storage values for an `account` specified by `address`.
 
 **Parameters:**
 
@@ -389,13 +349,9 @@ ___
 
 ▸ **generateCanonicalGenesis**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:518](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L518)*
+*Defined in [state/stateManager.ts:487](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L487)*
 
 Generates a canonical genesis state on the instance based on the configured chain parameters. Will error if there are uncommitted checkpoints on the instance.
-
-*__memberof__*: StateManager
-
-*__method__*: generateCanonicalGenesis
 
 **Parameters:**
 
@@ -412,19 +368,15 @@ ___
 
 ▸ **generateGenesis**(initState: *`any`*, cb: *`any`*): `any`
 
-*Defined in [state/stateManager.ts:539](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L539)*
+*Defined in [state/stateManager.ts:506](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L506)*
 
 Initializes the provided genesis state into the state trie
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: generateGenesis
 
 **Parameters:**
 
 | Name | Type | Description |
 | ------ | ------ | ------ |
-| initState | `any` |  \- |
+| initState | `any` |  Object (address -> balance) |
 | cb | `any` |  Callback function |
 
 **Returns:** `any`
@@ -436,13 +388,9 @@ ___
 
 ▸ **getAccount**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:82](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L82)*
+*Defined in [state/stateManager.ts:89](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L89)*
 
 Gets the [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) associated with `address`. Returns an empty account if the account does not exist.
-
-*__memberof__*: StateManager
-
-*__method__*: getAccount
 
 **Parameters:**
 
@@ -460,13 +408,9 @@ ___
 
 ▸ **getContractCode**(address: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:144](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L144)*
+*Defined in [state/stateManager.ts:145](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L145)*
 
-Gets the code corresponding to the provided `address`
-
-*__memberof__*: StateManager
-
-*__method__*: getContractCode
+Gets the code corresponding to the provided `address`.
 
 **Parameters:**
 
@@ -484,13 +428,9 @@ ___
 
 ▸ **getContractStorage**(address: *`Buffer`*, key: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:211](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L211)*
+*Defined in [state/stateManager.ts:202](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L202)*
 
-Gets the storage value associated with the provided `address` and `key`
-
-*__memberof__*: StateManager
-
-*__method__*: getContractStorage
+Gets the storage value associated with the provided `address` and `key`.
 
 **Parameters:**
 
@@ -509,7 +449,7 @@ ___
 
 ▸ **getOriginalContractStorage**(address: *`Buffer`*, key: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:234](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L234)*
+*Defined in [state/stateManager.ts:225](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L225)*
 
 Caches the storage value associated with the provided `address` and `key` on first invocation, and returns the cached (original) value from then onwards. This is used to get the original value of a storage slot for computing gas costs according to EIP-1283.
 
@@ -530,13 +470,9 @@ ___
 
 ▸ **getStateRoot**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:406](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L406)*
+*Defined in [state/stateManager.ts:383](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L383)*
 
 Gets the state-root of the Merkle-Patricia trie representation of the state of this StateManager. Will error if there are uncommitted checkpoints on the instance.
-
-*__memberof__*: StateManager
-
-*__method__*: getStateRoot
 
 **Parameters:**
 
@@ -553,13 +489,9 @@ ___
 
 ▸ **hasGenesisState**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:505](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L505)*
+*Defined in [state/stateManager.ts:476](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L476)*
 
 Checks whether the current instance has the canonical genesis state for the configured chain parameters.
-
-*__memberof__*: DefaultStateManager
-
-*__method__*: hasGenesisState
 
 **Parameters:**
 
@@ -576,13 +508,9 @@ ___
 
 ▸ **putAccount**(address: *`Buffer`*, account: *`Account`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:95](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L95)*
+*Defined in [state/stateManager.ts:100](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L100)*
 
-Saves an [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) into state under the provided `address`
-
-*__memberof__*: StateManager
-
-*__method__*: putAccount
+Saves an [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) into state under the provided `address`.
 
 **Parameters:**
 
@@ -601,13 +529,9 @@ ___
 
 ▸ **putContractCode**(address: *`Buffer`*, value: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:114](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L114)*
+*Defined in [state/stateManager.ts:117](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L117)*
 
 Adds `value` to the state trie as code, and sets `codeHash` on the account corresponding to `address` to reference this.
-
-*__memberof__*: StateManager
-
-*__method__*: putContractCode
 
 **Parameters:**
 
@@ -626,13 +550,9 @@ ___
 
 ▸ **putContractStorage**(address: *`Buffer`*, key: *`Buffer`*, value: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:295](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L295)*
+*Defined in [state/stateManager.ts:282](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L282)*
 
-Adds value to the state trie for the `account` corresponding to `address` at the provided `key`
-
-*__memberof__*: StateManager
-
-*__method__*: putContractStorage
+Adds value to the state trie for the `account` corresponding to `address` at the provided `key`.
 
 **Parameters:**
 
@@ -652,13 +572,9 @@ ___
 
 ▸ **revert**(cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:373](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L373)*
+*Defined in [state/stateManager.ts:352](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L352)*
 
 Reverts the current change-set to the instance since the last call to checkpoint.
-
-*__memberof__*: StateManager
-
-*__method__*: revert
 
 **Parameters:**
 
@@ -675,13 +591,9 @@ ___
 
 ▸ **setStateRoot**(stateRoot: *`Buffer`*, cb: *`any`*): `void`
 
-*Defined in [state/stateManager.ts:430](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/state/stateManager.ts#L430)*
+*Defined in [state/stateManager.ts:405](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L405)*
 
 Sets the state of the instance to that represented by the provided `stateRoot`. Will error if there are uncommitted checkpoints on the instance or if the state root does not exist in the state trie.
-
-*__memberof__*: StateManager
-
-*__method__*: setStateRoot
 
 **Parameters:**
 

--- a/docs/classes/vm.md
+++ b/docs/classes/vm.md
@@ -44,7 +44,7 @@ Execution engine which can be used to run a blockchain, individual blocks, indiv
 
 ⊕ **new VM**(opts?: *[VMOpts](../interfaces/vmopts.md)*): [VM](vm.md)
 
-*Defined in [index.ts:61](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L61)*
+*Defined in [index.ts:61](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L61)*
 
 Instantiates a new [VM](vm.md) Object.
 
@@ -66,7 +66,7 @@ ___
 
 **● _common**: *`Common`*
 
-*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L58)*
+*Defined in [index.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L58)*
 
 ___
 <a id="allowunlimitedcontractsize"></a>
@@ -75,7 +75,7 @@ ___
 
 **● allowUnlimitedContractSize**: *`boolean`*
 
-*Defined in [index.ts:61](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L61)*
+*Defined in [index.ts:61](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L61)*
 
 ___
 <a id="blockchain"></a>
@@ -84,7 +84,7 @@ ___
 
 **● blockchain**: *`any`*
 
-*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L60)*
+*Defined in [index.ts:60](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L60)*
 
 ___
 <a id="opts"></a>
@@ -93,7 +93,7 @@ ___
 
 **● opts**: *[VMOpts](../interfaces/vmopts.md)*
 
-*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L57)*
+*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L57)*
 
 ___
 <a id="statemanager"></a>
@@ -102,7 +102,7 @@ ___
 
 **● stateManager**: *[StateManager](statemanager.md)*
 
-*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L59)*
+*Defined in [index.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L59)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 ▸ **_emit**(topic: *`string`*, data: *`any`*): `Promise`<`any`>
 
-*Defined in [index.ts:160](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L160)*
+*Defined in [index.ts:160](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L160)*
 
 **Parameters:**
 
@@ -132,7 +132,7 @@ ___
 
 ▸ **copy**(): [VM](vm.md)
 
-*Defined in [index.ts:152](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L152)*
+*Defined in [index.ts:152](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L152)*
 
 Returns a copy of the [VM](vm.md) instance.
 
@@ -145,7 +145,7 @@ ___
 
 ▸ **runBlock**(opts: *[RunBlockOpts](../interfaces/runblockopts.md)*): `Promise`<[RunBlockResult](../interfaces/runblockresult.md)>
 
-*Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L124)*
+*Defined in [index.ts:124](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L124)*
 
 Processes the `block` running all of the transactions it contains and updating the miner's account
 
@@ -164,7 +164,7 @@ ___
 
 ▸ **runBlockchain**(blockchain: *`any`*): `Promise`<`void`>
 
-*Defined in [index.ts:115](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L115)*
+*Defined in [index.ts:115](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L115)*
 
 Processes blocks and adds them to the blockchain.
 
@@ -183,7 +183,7 @@ ___
 
 ▸ **runCall**(opts: *[RunCallOpts](../interfaces/runcallopts.md)*): `Promise`<[InterpreterResult](../interfaces/interpreterresult.md)>
 
-*Defined in [index.ts:138](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L138)*
+*Defined in [index.ts:138](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L138)*
 
 runs a call (or create) operation.
 
@@ -202,7 +202,7 @@ ___
 
 ▸ **runCode**(opts: *[RunCodeOpts](../interfaces/runcodeopts.md)*): `Promise`<[ExecResult](../interfaces/execresult.md)>
 
-*Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L145)*
+*Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L145)*
 
 Runs EVM code.
 
@@ -221,7 +221,7 @@ ___
 
 ▸ **runTx**(opts: *[RunTxOpts](../interfaces/runtxopts.md)*): `Promise`<[RunTxResult](../interfaces/runtxresult.md)>
 
-*Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L131)*
+*Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L131)*
 
 Process a transaction. Run the vm. Transfers eth. Checks balances.
 

--- a/docs/classes/vmerror.md
+++ b/docs/classes/vmerror.md
@@ -27,7 +27,7 @@
 
 ⊕ **new VmError**(error: *[ERROR](../enums/error.md)*): [VmError](vmerror.md)
 
-*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L17)*
+*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L17)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ ___
 
 **● error**: *[ERROR](../enums/error.md)*
 
-*Defined in [exceptions.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L16)*
+*Defined in [exceptions.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L16)*
 
 ___
 <a id="errortype"></a>
@@ -56,7 +56,7 @@ ___
 
 **● errorType**: *`string`*
 
-*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L17)*
+*Defined in [exceptions.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L17)*
 
 ___
 

--- a/docs/enums/error.md
+++ b/docs/enums/error.md
@@ -28,7 +28,7 @@
 
 **CREATE_COLLISION**:  = "create collision"
 
-*Defined in [exceptions.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L11)*
+*Defined in [exceptions.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L11)*
 
 ___
 <a id="internal_error"></a>
@@ -37,7 +37,7 @@ ___
 
 **INTERNAL_ERROR**:  = "internal error"
 
-*Defined in [exceptions.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L10)*
+*Defined in [exceptions.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L10)*
 
 ___
 <a id="invalid_jump"></a>
@@ -46,7 +46,7 @@ ___
 
 **INVALID_JUMP**:  = "invalid JUMP"
 
-*Defined in [exceptions.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L5)*
+*Defined in [exceptions.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L5)*
 
 ___
 <a id="invalid_opcode"></a>
@@ -55,7 +55,7 @@ ___
 
 **INVALID_OPCODE**:  = "invalid opcode"
 
-*Defined in [exceptions.ts:6](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L6)*
+*Defined in [exceptions.ts:6](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L6)*
 
 ___
 <a id="out_of_gas"></a>
@@ -64,7 +64,7 @@ ___
 
 **OUT_OF_GAS**:  = "out of gas"
 
-*Defined in [exceptions.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L2)*
+*Defined in [exceptions.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L2)*
 
 ___
 <a id="out_of_range"></a>
@@ -73,7 +73,7 @@ ___
 
 **OUT_OF_RANGE**:  = "value out of range"
 
-*Defined in [exceptions.ts:7](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L7)*
+*Defined in [exceptions.ts:7](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L7)*
 
 ___
 <a id="revert"></a>
@@ -82,7 +82,7 @@ ___
 
 **REVERT**:  = "revert"
 
-*Defined in [exceptions.ts:8](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L8)*
+*Defined in [exceptions.ts:8](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L8)*
 
 ___
 <a id="stack_overflow"></a>
@@ -91,7 +91,7 @@ ___
 
 **STACK_OVERFLOW**:  = "stack overflow"
 
-*Defined in [exceptions.ts:4](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L4)*
+*Defined in [exceptions.ts:4](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L4)*
 
 ___
 <a id="stack_underflow"></a>
@@ -100,7 +100,7 @@ ___
 
 **STACK_UNDERFLOW**:  = "stack underflow"
 
-*Defined in [exceptions.ts:3](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L3)*
+*Defined in [exceptions.ts:3](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L3)*
 
 ___
 <a id="static_state_change"></a>
@@ -109,7 +109,7 @@ ___
 
 **STATIC_STATE_CHANGE**:  = "static state change"
 
-*Defined in [exceptions.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L9)*
+*Defined in [exceptions.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L9)*
 
 ___
 <a id="stop"></a>
@@ -118,7 +118,7 @@ ___
 
 **STOP**:  = "stop"
 
-*Defined in [exceptions.ts:12](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/exceptions.ts#L12)*
+*Defined in [exceptions.ts:12](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/exceptions.ts#L12)*
 
 ___
 

--- a/docs/interfaces/execresult.md
+++ b/docs/interfaces/execresult.md
@@ -33,7 +33,7 @@ Result of executing a call via the \[\[Interpreter\]\].
 
 **● exception**: *`IsException`*
 
-*Defined in [evm/interpreter.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L47)*
+*Defined in [evm/interpreter.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L47)*
 
 `0` if the contract encountered an exception, `1` otherwise
 
@@ -44,7 +44,7 @@ ___
 
 **● exceptionError**: *[VmError](../classes/vmerror.md) \| [ERROR](../enums/error.md)*
 
-*Defined in [evm/interpreter.ts:51](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L51)*
+*Defined in [evm/interpreter.ts:51](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L51)*
 
 Description of the exception, if any occured
 
@@ -55,7 +55,7 @@ ___
 
 **● gas**: *`BN`*
 
-*Defined in [evm/interpreter.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L55)*
+*Defined in [evm/interpreter.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L55)*
 
 Amount of gas left
 
@@ -66,7 +66,7 @@ ___
 
 **● gasRefund**: *`BN`*
 
-*Defined in [evm/interpreter.ts:75](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L75)*
+*Defined in [evm/interpreter.ts:75](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L75)*
 
 Amount of gas to refund from deleting storage values
 
@@ -77,7 +77,7 @@ ___
 
 **● gasUsed**: *`BN`*
 
-*Defined in [evm/interpreter.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L59)*
+*Defined in [evm/interpreter.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L59)*
 
 Amount of gas the code used to run
 
@@ -88,7 +88,7 @@ ___
 
 **● logs**: *`any`[]*
 
-*Defined in [evm/interpreter.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L67)*
+*Defined in [evm/interpreter.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L67)*
 
 Array of logs that the contract emitted
 
@@ -99,7 +99,7 @@ ___
 
 **● return**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L63)*
+*Defined in [evm/interpreter.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L63)*
 
 Return value from the contract
 
@@ -110,7 +110,7 @@ ___
 
 **● returnValue**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L71)*
+*Defined in [evm/interpreter.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L71)*
 
 Value returned by the contract
 
@@ -121,7 +121,7 @@ ___
 
 **● runState**: *`RunState`*
 
-*Defined in [evm/interpreter.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L43)*
+*Defined in [evm/interpreter.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L43)*
 
 ___
 <a id="selfdestruct"></a>
@@ -130,7 +130,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [evm/interpreter.ts:79](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L79)*
+*Defined in [evm/interpreter.ts:79](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L79)*
 
 A map from the accounts that have self-destructed to the addresses to send their funds to
 

--- a/docs/interfaces/interpreterresult.md
+++ b/docs/interfaces/interpreterresult.md
@@ -28,7 +28,7 @@ Result of executing a message via the \[\[Interpreter\]\].
 
 **● createdAddress**: *`Buffer`*
 
-*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L32)*
+*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L32)*
 
 Address of created account durint transaction, if any
 
@@ -39,7 +39,7 @@ ___
 
 **● gasUsed**: *`BN`*
 
-*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L28)*
+*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L28)*
 
 Amount of gas used by the transaction
 
@@ -50,7 +50,7 @@ ___
 
 **● vm**: *[ExecResult](execresult.md)*
 
-*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L36)*
+*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L36)*
 
 Contains the results from running the code, if any, as described in [runCode](../classes/vm.md#runcode)
 

--- a/docs/interfaces/runblockopts.md
+++ b/docs/interfaces/runblockopts.md
@@ -27,7 +27,7 @@ Options for running a block.
 
 **● block**: *`any`*
 
-*Defined in [runBlock.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L18)*
+*Defined in [runBlock.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L18)*
 
 The [`Block`](https://github.com/ethereumjs/ethereumjs-block) to process
 
@@ -38,7 +38,7 @@ ___
 
 **● generate**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runBlock.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L27)*
+*Defined in [runBlock.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L27)*
 
 Whether to generate the stateRoot. If false `runBlock` will check the stateRoot of the block against the Trie
 
@@ -49,7 +49,7 @@ ___
 
 **● root**: *`Buffer`*
 
-*Defined in [runBlock.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L22)*
+*Defined in [runBlock.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L22)*
 
 Root of the state trie
 
@@ -60,7 +60,7 @@ ___
 
 **● skipBlockValidation**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runBlock.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L31)*
+*Defined in [runBlock.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L31)*
 
 If true, will skip block validation
 

--- a/docs/interfaces/runblockresult.md
+++ b/docs/interfaces/runblockresult.md
@@ -25,7 +25,7 @@ Result of [runBlock](../classes/vm.md#runblock)
 
 **● receipts**: *[TxReceipt](txreceipt.md)[]*
 
-*Defined in [runBlock.ts:41](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L41)*
+*Defined in [runBlock.ts:41](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L41)*
 
 Receipts generated for transactions in the block
 
@@ -36,7 +36,7 @@ ___
 
 **● results**: *[RunTxResult](runtxresult.md)[]*
 
-*Defined in [runBlock.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L45)*
+*Defined in [runBlock.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L45)*
 
 Results of executing the transactions in the block
 

--- a/docs/interfaces/runcallopts.md
+++ b/docs/interfaces/runcallopts.md
@@ -38,7 +38,7 @@ Options for running a call (or create) operation
 
 **● block**: *`any`*
 
-*Defined in [runCall.ts:13](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L13)*
+*Defined in [runCall.ts:13](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L13)*
 
 ___
 <a id="caller"></a>
@@ -47,7 +47,7 @@ ___
 
 **● caller**: *`Buffer`*
 
-*Defined in [runCall.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L16)*
+*Defined in [runCall.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L16)*
 
 ___
 <a id="code"></a>
@@ -56,7 +56,7 @@ ___
 
 **● code**: *`Buffer`*
 
-*Defined in [runCall.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L24)*
+*Defined in [runCall.ts:24](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L24)*
 
 This is for CALLCODE where the code to load is different than the code from the to account
 
@@ -67,7 +67,7 @@ ___
 
 **● compiled**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L26)*
+*Defined in [runCall.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L26)*
 
 ___
 <a id="data"></a>
@@ -76,7 +76,7 @@ ___
 
 **● data**: *`Buffer`*
 
-*Defined in [runCall.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L20)*
+*Defined in [runCall.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L20)*
 
 ___
 <a id="delegatecall"></a>
@@ -85,7 +85,7 @@ ___
 
 **● delegatecall**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L30)*
+*Defined in [runCall.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L30)*
 
 ___
 <a id="depth"></a>
@@ -94,7 +94,7 @@ ___
 
 **● depth**: *`undefined` \| `number`*
 
-*Defined in [runCall.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L25)*
+*Defined in [runCall.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L25)*
 
 ___
 <a id="gaslimit"></a>
@@ -103,7 +103,7 @@ ___
 
 **● gasLimit**: *`Buffer`*
 
-*Defined in [runCall.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L17)*
+*Defined in [runCall.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L17)*
 
 ___
 <a id="gasprice"></a>
@@ -112,7 +112,7 @@ ___
 
 **● gasPrice**: *`Buffer`*
 
-*Defined in [runCall.ts:14](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L14)*
+*Defined in [runCall.ts:14](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L14)*
 
 ___
 <a id="origin"></a>
@@ -121,7 +121,7 @@ ___
 
 **● origin**: *`Buffer`*
 
-*Defined in [runCall.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L15)*
+*Defined in [runCall.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L15)*
 
 ___
 <a id="salt"></a>
@@ -130,7 +130,7 @@ ___
 
 **● salt**: *`Buffer`*
 
-*Defined in [runCall.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L28)*
+*Defined in [runCall.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L28)*
 
 ___
 <a id="selfdestruct"></a>
@@ -139,7 +139,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [runCall.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L29)*
+*Defined in [runCall.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L29)*
 
 ___
 <a id="static"></a>
@@ -148,7 +148,7 @@ ___
 
 **● static**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCall.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L27)*
+*Defined in [runCall.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L27)*
 
 ___
 <a id="to"></a>
@@ -157,7 +157,7 @@ ___
 
 **● to**: *`Buffer`*
 
-*Defined in [runCall.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L18)*
+*Defined in [runCall.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L18)*
 
 ___
 <a id="value"></a>
@@ -166,7 +166,7 @@ ___
 
 **● value**: *`Buffer`*
 
-*Defined in [runCall.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCall.ts#L19)*
+*Defined in [runCall.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCall.ts#L19)*
 
 ___
 

--- a/docs/interfaces/runcodeopts.md
+++ b/docs/interfaces/runcodeopts.md
@@ -39,7 +39,7 @@ Options for the [runCode](../classes/vm.md#runcode) method.
 
 **● address**: *`Buffer`*
 
-*Defined in [runCode.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L63)*
+*Defined in [runCode.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L63)*
 
 The address of the account that is executing this code. The address should be a `Buffer` of bytes. Defaults to `0`
 
@@ -50,7 +50,7 @@ ___
 
 **● block**: *`any`*
 
-*Defined in [runCode.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L28)*
+*Defined in [runCode.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L28)*
 
 The [`Block`](https://github.com/ethereumjs/ethereumjs-block) the `tx` belongs to. If omitted a blank block will be used
 
@@ -61,7 +61,7 @@ ___
 
 **● caller**: *`Buffer`*
 
-*Defined in [runCode.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L40)*
+*Defined in [runCode.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L40)*
 
 The address that ran this code. The address should be a `Buffer` of 20bits. Defaults to `0`
 
@@ -72,7 +72,7 @@ ___
 
 **● code**: *`Buffer`*
 
-*Defined in [runCode.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L44)*
+*Defined in [runCode.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L44)*
 
 The EVM code to run
 
@@ -83,7 +83,7 @@ ___
 
 **● data**: *`Buffer`*
 
-*Defined in [runCode.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L48)*
+*Defined in [runCode.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L48)*
 
 The input data
 
@@ -94,7 +94,7 @@ ___
 
 **● depth**: *`undefined` \| `number`*
 
-*Defined in [runCode.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L57)*
+*Defined in [runCode.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L57)*
 
 ___
 <a id="gaslimit"></a>
@@ -103,7 +103,7 @@ ___
 
 **● gasLimit**: *`Buffer`*
 
-*Defined in [runCode.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L52)*
+*Defined in [runCode.ts:52](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L52)*
 
 Gas limit
 
@@ -114,7 +114,7 @@ ___
 
 **● gasPrice**: *`Buffer`*
 
-*Defined in [runCode.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L31)*
+*Defined in [runCode.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L31)*
 
 ___
 <a id="interpreter"></a>
@@ -123,7 +123,7 @@ ___
 
 **● interpreter**: *`Interpreter`*
 
-*Defined in [runCode.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L29)*
+*Defined in [runCode.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L29)*
 
 ___
 <a id="isstatic"></a>
@@ -132,7 +132,7 @@ ___
 
 **● isStatic**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runCode.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L58)*
+*Defined in [runCode.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L58)*
 
 ___
 <a id="message"></a>
@@ -141,7 +141,7 @@ ___
 
 **● message**: *`Message`*
 
-*Defined in [runCode.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L36)*
+*Defined in [runCode.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L36)*
 
 ___
 <a id="origin"></a>
@@ -150,7 +150,7 @@ ___
 
 **● origin**: *`Buffer`*
 
-*Defined in [runCode.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L35)*
+*Defined in [runCode.ts:35](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L35)*
 
 The address where the call originated from. The address should be a `Buffer` of 20bits. Defaults to `0`
 
@@ -161,7 +161,7 @@ ___
 
 **● pc**: *`undefined` \| `number`*
 
-*Defined in [runCode.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L67)*
+*Defined in [runCode.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L67)*
 
 The initial program counter. Defaults to `0`
 
@@ -172,7 +172,7 @@ ___
 
 **● selfdestruct**: *`undefined` \| `object`*
 
-*Defined in [runCode.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L59)*
+*Defined in [runCode.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L59)*
 
 ___
 <a id="txcontext"></a>
@@ -181,7 +181,7 @@ ___
 
 **● txContext**: *`TxContext`*
 
-*Defined in [runCode.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L30)*
+*Defined in [runCode.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L30)*
 
 ___
 <a id="value"></a>
@@ -190,7 +190,7 @@ ___
 
 **● value**: *`Buffer`*
 
-*Defined in [runCode.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runCode.ts#L56)*
+*Defined in [runCode.ts:56](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runCode.ts#L56)*
 
 The value in ether that is being sent to `opt.address`. Defaults to `0`
 

--- a/docs/interfaces/runtxopts.md
+++ b/docs/interfaces/runtxopts.md
@@ -27,7 +27,7 @@ Options for the `runTx` method.
 
 **● block**: *`any`*
 
-*Defined in [runTx.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L19)*
+*Defined in [runTx.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L19)*
 
 The block to which the `tx` belongs
 
@@ -38,7 +38,7 @@ ___
 
 **● skipBalance**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runTx.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L31)*
+*Defined in [runTx.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L31)*
 
 If true, skips the balance check
 
@@ -49,7 +49,7 @@ ___
 
 **● skipNonce**: *`undefined` \| `false` \| `true`*
 
-*Defined in [runTx.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L27)*
+*Defined in [runTx.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L27)*
 
 If true, skips the nonce check
 
@@ -60,7 +60,7 @@ ___
 
 **● tx**: *`any`*
 
-*Defined in [runTx.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L23)*
+*Defined in [runTx.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L23)*
 
 A [`Transaction`](https://github.com/ethereum/ethereumjs-tx) to run
 

--- a/docs/interfaces/runtxresult.md
+++ b/docs/interfaces/runtxresult.md
@@ -31,7 +31,7 @@ Execution result of a transaction
 
 **● amountSpent**: *`BN`*
 
-*Defined in [runTx.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L45)*
+*Defined in [runTx.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L45)*
 
 The amount of ether used by this transaction
 
@@ -42,7 +42,7 @@ ___
 
 **● bloom**: *`Bloom`*
 
-*Defined in [runTx.ts:41](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L41)*
+*Defined in [runTx.ts:41](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L41)*
 
 Bloom filter resulted from transaction
 
@@ -55,7 +55,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[createdAddress](interpreterresult.md#createdaddress)*
 
-*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L32)*
+*Defined in [evm/interpreter.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L32)*
 
 Address of created account durint transaction, if any
 
@@ -66,7 +66,7 @@ ___
 
 **● gasRefund**: *`BN`*
 
-*Defined in [runTx.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runTx.ts#L49)*
+*Defined in [runTx.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runTx.ts#L49)*
 
 The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
 
@@ -79,7 +79,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[gasUsed](interpreterresult.md#gasused)*
 
-*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L28)*
+*Defined in [evm/interpreter.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L28)*
 
 Amount of gas used by the transaction
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [InterpreterResult](interpreterresult.md).[vm](interpreterresult.md#vm)*
 
-*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/evm/interpreter.ts#L36)*
+*Defined in [evm/interpreter.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/evm/interpreter.ts#L36)*
 
 Contains the results from running the code, if any, as described in [runCode](../classes/vm.md#runcode)
 

--- a/docs/interfaces/statemanageropts.md
+++ b/docs/interfaces/statemanageropts.md
@@ -1,0 +1,44 @@
+[ethereumjs-vm](../README.md) > [StateManagerOpts](../interfaces/statemanageropts.md)
+
+# Interface: StateManagerOpts
+
+Options for constructing a [StateManager](../classes/statemanager.md).
+
+## Hierarchy
+
+**StateManagerOpts**
+
+## Index
+
+### Properties
+
+* [common](statemanageropts.md#common)
+* [trie](statemanageropts.md#trie)
+
+---
+
+## Properties
+
+<a id="common"></a>
+
+### `<Optional>` common
+
+**● common**: *`Common`*
+
+*Defined in [state/stateManager.ts:26](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L26)*
+
+Parameters of the chain ([`Common`](https://github.com/ethereumjs/ethereumjs-common))
+
+___
+<a id="trie"></a>
+
+### `<Optional>` trie
+
+**● trie**: *`any`*
+
+*Defined in [state/stateManager.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/state/stateManager.ts#L30)*
+
+A [`merkle-patricia-tree`](https://github.com/ethereumjs/merkle-patricia-tree) instance
+
+___
+

--- a/docs/interfaces/txreceipt.md
+++ b/docs/interfaces/txreceipt.md
@@ -27,7 +27,7 @@ Receipt generated for a transaction
 
 **● bitvector**: *`Buffer`*
 
-*Defined in [runBlock.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L63)*
+*Defined in [runBlock.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L63)*
 
 Bloom bitvector
 
@@ -38,7 +38,7 @@ ___
 
 **● gasUsed**: *`Buffer`*
 
-*Defined in [runBlock.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L59)*
+*Defined in [runBlock.ts:59](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L59)*
 
 Gas used
 
@@ -49,7 +49,7 @@ ___
 
 **● logs**: *`any`[]*
 
-*Defined in [runBlock.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L67)*
+*Defined in [runBlock.ts:67](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L67)*
 
 Logs emitted
 
@@ -60,7 +60,7 @@ ___
 
 **● status**: *`0` \| `1`*
 
-*Defined in [runBlock.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/runBlock.ts#L55)*
+*Defined in [runBlock.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/runBlock.ts#L55)*
 
 Status of transaction, `0` if successful, `1` if an exception occured
 

--- a/docs/interfaces/vmopts.md
+++ b/docs/interfaces/vmopts.md
@@ -31,7 +31,7 @@ Options for instantiating a [VM](../classes/vm.md).
 
 **● activatePrecompiles**: *`undefined` \| `false` \| `true`*
 
-*Defined in [index.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L44)*
+*Defined in [index.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L44)*
 
 If true, create entries in the state tree for the precompiled contracts
 
@@ -42,7 +42,7 @@ ___
 
 **● allowUnlimitedContractSize**: *`undefined` \| `false` \| `true`*
 
-*Defined in [index.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L48)*
+*Defined in [index.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L48)*
 
 Allows unlimited contract sizes while debugging. By setting this to `true`, the check for contract size limit of 24KB (see [EIP-170](https://git.io/vxZkK)) is bypassed
 
@@ -53,7 +53,7 @@ ___
 
 **● blockchain**: *`any`*
 
-*Defined in [index.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L40)*
+*Defined in [index.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L40)*
 
 A [blockchain](https://github.com/ethereumjs/ethereumjs-blockchain) object for storing/retrieving blocks
 
@@ -64,7 +64,7 @@ ___
 
 **● chain**: *`undefined` \| `string`*
 
-*Defined in [index.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L23)*
+*Defined in [index.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L23)*
 
 The chain the VM operates on
 
@@ -75,7 +75,7 @@ ___
 
 **● common**: *`Common`*
 
-*Defined in [index.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L49)*
+*Defined in [index.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L49)*
 
 ___
 <a id="hardfork"></a>
@@ -84,7 +84,7 @@ ___
 
 **● hardfork**: *`undefined` \| `string`*
 
-*Defined in [index.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L27)*
+*Defined in [index.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L27)*
 
 Hardfork rules to be used
 
@@ -95,7 +95,7 @@ ___
 
 **● state**: *`any`*
 
-*Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L36)*
+*Defined in [index.ts:36](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L36)*
 
 A [merkle-patricia-tree](https://github.com/ethereumjs/merkle-patricia-tree) instance for the state tree (ignored if stateManager is passed)
 
@@ -108,7 +108,7 @@ ___
 
 **● stateManager**: *[StateManager](../classes/statemanager.md)*
 
-*Defined in [index.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/2fcfe31/lib/index.ts#L31)*
+*Defined in [index.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/4fbb5ef/lib/index.ts#L31)*
 
 A [StateManager](../classes/statemanager.md) instance to use as the state store (Beta API)
 

--- a/lib/bloom/index.ts
+++ b/lib/bloom/index.ts
@@ -7,9 +7,7 @@ export default class Bloom {
   bitvector: Buffer
 
   /**
-   * Represents a Bloom
-   * @constructor
-   * @param {Buffer} bitvector
+   * Represents a Bloom filter.
    */
   constructor(bitvector?: Buffer) {
     if (!bitvector) {
@@ -21,9 +19,8 @@ export default class Bloom {
   }
 
   /**
-   * adds an element to a bit vector of a 64 byte bloom filter
-   * @method add
-   * @param {Buffer} e the element to add
+   * Adds an element to a bit vector of a 64 byte bloom filter.
+   * @param e - The element to add
    */
   add(e: Buffer) {
     assert(Buffer.isBuffer(e), 'Element should be buffer')
@@ -40,10 +37,8 @@ export default class Bloom {
   }
 
   /**
-   * checks if an element is in the bloom
-   * @method check
-   * @param {Buffer} e the element to check
-   * @returns {boolean} Returns {@code true} if the element is in the bloom
+   * Checks if an element is in the bloom.
+   * @param e - The element to check
    */
   check(e: Buffer): boolean {
     assert(Buffer.isBuffer(e), 'Element should be Buffer')
@@ -63,19 +58,15 @@ export default class Bloom {
   }
 
   /**
-   * checks if multiple topics are in a bloom
-   * @method multiCheck
-   * @param {Buffer[]} topics
-   * @returns {boolean} Returns {@code true} if every topic is in the bloom
+   * Checks if multiple topics are in a bloom.
+   * @returns `true` if every topic is in the bloom
    */
   multiCheck(topics: Buffer[]): boolean {
     return topics.every((t: Buffer) => this.check(t))
   }
 
   /**
-   * bitwise or blooms together
-   * @method or
-   * @param {Bloom} bloom
+   * Bitwise or blooms together.
    */
   or(bloom: Bloom) {
     if (bloom) {

--- a/lib/evm/loop.ts
+++ b/lib/evm/loop.ts
@@ -35,6 +35,9 @@ export interface LoopResult {
   exceptionError?: VmError | ERROR
 }
 
+/**
+ * Parses and executes EVM bytecode.
+ */
 export default class Loop {
   _vm: any
   _state: PStateManager
@@ -98,6 +101,10 @@ export default class Loop {
     }
   }
 
+  /**
+   * Executes the opcode to which the program counter is pointing,
+   * reducing it's base gas cost, and increments the program counter.
+   */
   async runStep(): Promise<void> {
     const opInfo = lookupOpInfo(this._runState.opCode)
     // Check for invalid opcode
@@ -119,6 +126,9 @@ export default class Loop {
     }
   }
 
+  /**
+   * Get the handler function for an opcode.
+   */
   getOpHandler(opInfo: OpInfo): OpHandler {
     return opHandlers[opInfo.name]
   }

--- a/lib/evm/memory.ts
+++ b/lib/evm/memory.ts
@@ -14,8 +14,6 @@ export default class Memory {
   /**
    * Extends the memory given an offset and size. Rounds extended
    * memory to word-size.
-   * @param {Number} offset
-   * @param {Number} size
    */
   extend(offset: number, size: number) {
     if (size === 0) {
@@ -31,9 +29,9 @@ export default class Memory {
 
   /**
    * Writes a byte array with length `size` to memory, starting from `offset`.
-   * @param {Number} offset - Starting position
-   * @param {Number} size - How many bytes to write
-   * @param {Buffer} value - Value
+   * @param offset - Starting position
+   * @param size - How many bytes to write
+   * @param value - Value
    */
   write(offset: number, size: number, value: Buffer) {
     if (size === 0) {
@@ -52,9 +50,8 @@ export default class Memory {
   /**
    * Reads a slice of memory from `offset` till `offset + size` as a `Buffer`.
    * It fills up the difference between memory's length and `offset + size` with zeros.
-   * @param {Number} offset - Starting position
-   * @param {Number} size - How many bytes to read
-   * @returns {Buffer}
+   * @param offset - Starting position
+   * @param size - How many bytes to read
    */
   read(offset: number, size: number): Buffer {
     const loaded = this._store.slice(offset, offset + size)

--- a/lib/evm/stack.ts
+++ b/lib/evm/stack.ts
@@ -44,8 +44,7 @@ export default class Stack {
   /**
    * Pop multiple items from stack. Top of stack is first item
    * in returned array.
-   * @param {Number} num - Number of items to pop
-   * @returns {Array}
+   * @param num - Number of items to pop
    */
   popN(num: number = 1): BN[] {
     if (this._store.length < num) {
@@ -61,7 +60,7 @@ export default class Stack {
 
   /**
    * Swap top of stack with an item in the stack.
-   * @param {Number} position - Index of item from top of the stack (0-indexed)
+   * @param position - Index of item from top of the stack (0-indexed)
    */
   swap(position: number) {
     if (this._store.length <= position) {
@@ -78,7 +77,7 @@ export default class Stack {
 
   /**
    * Pushes a copy of an item in the stack.
-   * @param {Number} position - Index of item to be copied (1-indexed)
+   * @param position - Index of item to be copied (1-indexed)
    */
   dup(position: number) {
     if (this._store.length < position) {

--- a/lib/state/cache.ts
+++ b/lib/state/cache.ts
@@ -18,18 +18,17 @@ export default class Cache {
 
   /**
    * Puts account to cache under its address.
-   * @param {Buffer} key - Address of account
-   * @param {Account} val - Account
-   * @param {bool} [fromTrie]
+   * @param key - Address of account
+   * @param val - Account
    */
-  put(key: Buffer, val: Account, fromTrie = false): void {
+  put(key: Buffer, val: Account, fromTrie: boolean = false): void {
     const modified = !fromTrie
     this._update(key, val, modified, false)
   }
 
   /**
    * Returns the queried account or an empty account.
-   * @param {Buffer} key - Address of account
+   * @param key - Address of account
    */
   get(key: Buffer): Account {
     let account = this.lookup(key)
@@ -41,7 +40,7 @@ export default class Cache {
 
   /**
    * Returns the queried account or undefined.
-   * @param {buffer} key - Address of account
+   * @param key - Address of account
    */
   lookup(key: Buffer): Account | undefined {
     const keyStr = key.toString('hex')
@@ -55,8 +54,8 @@ export default class Cache {
 
   /**
    * Looks up address in underlying trie.
-   * @param {Buffer} address - Address of account
-   * @param {Function} cb - Callback with params (err, account)
+   * @param address - Address of account
+   * @param cb - Callback with params (err, account)
    */
   _lookupAccount(address: Buffer, cb: any): void {
     this._trie.get(address, (err: Error, raw: Buffer) => {
@@ -69,8 +68,8 @@ export default class Cache {
   /**
    * Looks up address in cache, if not found, looks it up
    * in the underlying trie.
-   * @param {Buffer} key - Address of account
-   * @param {Function} cb - Callback with params (err, account)
+   * @param key - Address of account
+   * @param cb - Callback with params (err, account)
    */
   getOrLoad(key: Buffer, cb: any): void {
     const account = this.lookup(key)
@@ -88,8 +87,8 @@ export default class Cache {
   /**
    * Warms cache by loading their respective account from trie
    * and putting them in cache.
-   * @param {Array} addresses - Array of addresses
-   * @param {Function} cb - Callback
+   * @param addresses - Array of addresses
+   * @param cb - Callback
    */
   warm(addresses: string[], cb: any): void {
     // shim till async supports iterators
@@ -115,7 +114,7 @@ export default class Cache {
   /**
    * Flushes cache by updating accounts that have been modified
    * and removing accounts that have been deleted.
-   * @param {function} cb - Callback
+   * @param cb - Callback
    */
   flush(cb: any): void {
     const it = this._cache.begin
@@ -181,7 +180,7 @@ export default class Cache {
 
   /**
    * Marks address as deleted in cache.
-   * @params {Buffer} key - Address
+   * @param key - Address
    */
   del(key: Buffer): void {
     this._update(key, new Account(), false, true)

--- a/lib/state/stateManager.ts
+++ b/lib/state/stateManager.ts
@@ -17,6 +17,20 @@ export interface StorageDump {
 }
 
 /**
+ * Options for constructing a [[StateManager]].
+ */
+export interface StateManagerOpts {
+  /**
+   * Parameters of the chain ([`Common`](https://github.com/ethereumjs/ethereumjs-common))
+   */
+  common?: Common
+  /**
+   * A [`merkle-patricia-tree`](https://github.com/ethereumjs/merkle-patricia-tree) instance
+   */
+  trie?: any
+}
+
+/**
  * Interface for getting and setting data from an underlying
  * state trie.
  */
@@ -32,11 +46,8 @@ export default class StateManager {
 
   /**
    * Instantiate the StateManager interface.
-   * @param {Object} [opts={}]
-   * @param {Common} [opts.common] - [`Common`](https://github.com/ethereumjs/ethereumjs-common) parameters of the chain
-   * @param {Trie} [opts.trie] - a [`merkle-patricia-tree`](https://github.com/ethereumjs/merkle-patricia-tree) instance
    */
-  constructor(opts: any = {}) {
+  constructor(opts: StateManagerOpts = {}) {
     let common = opts.common
     if (!common) {
       common = new Common('mainnet', 'petersburg')
@@ -55,28 +66,24 @@ export default class StateManager {
   /**
    * Copies the current instance of the `DefaultStateManager`
    * at the last fully committed point, i.e. as if all current
-   * checkpoints were reverted
-   * @memberof DefaultStateManager
-   * @method copy
+   * checkpoints were reverted.
    */
   copy(): StateManager {
     return new StateManager({ trie: this._trie.copy(), common: this._common })
   }
 
   /**
-   * Callback for `getAccount` method
+   * Callback for `getAccount` method.
    * @callback getAccount~callback
-   * @param {Error} error an error that may have happened or `null`
-   * @param {Account} account An [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account)
+   * @param error - an error that may have happened or `null`
+   * @param account - An [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account)
    * instance corresponding to the provided `address`
    */
 
   /**
    * Gets the [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account)
    * associated with `address`. Returns an empty account if the account does not exist.
-   * @memberof StateManager
-   * @method getAccount
-   * @param {Buffer} address Address of the `account` to get
+   * @param address - Address of the `account` to get
    * @param {getAccount~callback} cb
    */
   getAccount(address: Buffer, cb: any): void {
@@ -85,12 +92,10 @@ export default class StateManager {
 
   /**
    * Saves an [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account)
-   * into state under the provided `address`
-   * @memberof StateManager
-   * @method putAccount
-   * @param {Buffer} address Address under which to store `account`
-   * @param {Account} account The [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) to store
-   * @param {Function} cb Callback function
+   * into state under the provided `address`.
+   * @param address - Address under which to store `account`
+   * @param account - The [`ethereumjs-account`](https://github.com/ethereumjs/ethereumjs-account) to store
+   * @param cb - Callback function
    */
   putAccount(address: Buffer, account: Account, cb: any): void {
     // TODO: dont save newly created accounts that have no balance
@@ -105,11 +110,9 @@ export default class StateManager {
   /**
    * Adds `value` to the state trie as code, and sets `codeHash` on the account
    * corresponding to `address` to reference this.
-   * @memberof StateManager
-   * @method putContractCode
-   * @param {Buffer} address - Address of the `account` to add the `code` for
-   * @param {Buffer} value - The value of the `code`
-   * @param {Function} cb Callback function
+   * @param address - Address of the `account` to add the `code` for
+   * @param value - The value of the `code`
+   * @param cb - Callback function
    */
   putContractCode(address: Buffer, value: Buffer, cb: any): void {
     this.getAccount(address, (err: Error, account: Account) => {
@@ -129,16 +132,14 @@ export default class StateManager {
   /**
    * Callback for `getContractCode` method
    * @callback getContractCode~callback
-   * @param {Error} error an error that may have happened or `null`
-   * @param {Buffer} code The code corresponding to the provided address.
+   * @param error - an error that may have happened or `null`
+   * @param code - The code corresponding to the provided address.
    * Returns an empty `Buffer` if the account has no associated code.
    */
 
   /**
-   * Gets the code corresponding to the provided `address`
-   * @memberof StateManager
-   * @method getContractCode
-   * @param {Buffer} address Address to get the `code` for
+   * Gets the code corresponding to the provided `address`.
+   * @param address - Address to get the `code` for
    * @param {getContractCode~callback} cb
    */
   getContractCode(address: Buffer, cb: any): void {
@@ -154,10 +155,6 @@ export default class StateManager {
    * Creates a storage trie from the primary storage trie
    * for an account and saves this in the storage cache.
    * @private
-   * @memberof DefaultStateManager
-   * @method _lookupStorageTrie
-   * @param {Buffer} address
-   * @param {Function} cb Callback function
    */
   _lookupStorageTrie(address: Buffer, cb: any): void {
     // from state trie
@@ -174,12 +171,8 @@ export default class StateManager {
 
   /**
    * Gets the storage trie for an account from the storage
-   * cache or does a lookup
+   * cache or does a lookup.
    * @private
-   * @memberof DefaultStateManager
-   * @method _getStorageTrie
-   * @param {Buffer} address
-   * @param {Function} cb Callback function
    */
   _getStorageTrie(address: Buffer, cb: any): void {
     const storageTrie = this._storageTries[address.toString('hex')]
@@ -201,11 +194,9 @@ export default class StateManager {
    */
 
   /**
-   * Gets the storage value associated with the provided `address` and `key`
-   * @memberof StateManager
-   * @method getContractStorage
-   * @param {Buffer} address Address of the account to get the storage for
-   * @param {Buffer} key Key in the account's storage to get the value for
+   * Gets the storage value associated with the provided `address` and `key`.
+   * @param address -  Address of the account to get the storage for
+   * @param key - Key in the account's storage to get the value for
    * @param {getContractCode~callback} cb
    */
   getContractStorage(address: Buffer, key: Buffer, cb: any): void {
@@ -258,10 +249,8 @@ export default class StateManager {
   /**
    * Modifies the storage trie of an account
    * @private
-   * @memberof DefaultStateManager
-   * @method _modifyContractStorage
-   * @param {Buffer} address Address of the account whose storage is to be modified
-   * @param {Function} modifyTrie function to modify the storage trie of the account
+   * @param address -  Address of the account whose storage is to be modified
+   * @param modifyTrie - Function to modify the storage trie of the account
    */
   _modifyContractStorage(address: Buffer, modifyTrie: any, cb: any): void {
     this._getStorageTrie(address, (err: Error, storageTrie: any) => {
@@ -284,13 +273,11 @@ export default class StateManager {
 
   /**
    * Adds value to the state trie for the `account`
-   * corresponding to `address` at the provided `key`
-   * @memberof StateManager
-   * @method putContractStorage
-   * @param {Buffer} address Address to set a storage value for
-   * @param {Buffer} key Key to set the value at
-   * @param {Buffer} value Value to set at `key` for account corresponding to `address`
-   * @param {Function} cb Callback function
+   * corresponding to `address` at the provided `key`.
+   * @param address -  Address to set a storage value for
+   * @param key - Key to set the value at
+   * @param value - Value to set at `key` for account corresponding to `address`
+   * @param cb - Callback function
    */
   putContractStorage(address: Buffer, key: Buffer, value: Buffer, cb: any): void {
     this._modifyContractStorage(
@@ -310,11 +297,9 @@ export default class StateManager {
   }
 
   /**
-   * Clears all storage entries for the account corresponding to `address`
-   * @memberof StateManager
-   * @method clearContractStorage
-   * @param {Buffer} address Address to clear the storage of
-   * @param {Function} cb Callback function
+   * Clears all storage entries for the account corresponding to `address`.
+   * @param address -  Address to clear the storage of
+   * @param cb - Callback function
    */
   clearContractStorage(address: Buffer, cb: any) {
     this._modifyContractStorage(
@@ -331,9 +316,7 @@ export default class StateManager {
    * Checkpoints the current state of the StateManager instance.
    * State changes that follow can then be committed by calling
    * `commit` or `reverted` by calling rollback.
-   * @memberof StateManager
-   * @method checkpoint
-   * @param {Function} cb Callback function
+   * @param cb - Callback function
    */
   checkpoint(cb: any): void {
     this._trie.checkpoint()
@@ -346,9 +329,7 @@ export default class StateManager {
   /**
    * Commits the current change-set to the instance since the
    * last call to checkpoint.
-   * @memberof StateManager
-   * @method commit
-   * @param {Function} cb Callback function
+   * @param cb - Callback function
    */
   commit(cb: any): void {
     // setup trie checkpointing
@@ -366,9 +347,7 @@ export default class StateManager {
   /**
    * Reverts the current change-set to the instance since the
    * last call to checkpoint.
-   * @memberof StateManager
-   * @method revert
-   * @param {Function} cb Callback function
+   * @param cb - Callback function
    */
   revert(cb: any): void {
     // setup trie checkpointing
@@ -399,8 +378,6 @@ export default class StateManager {
    * Gets the state-root of the Merkle-Patricia trie representation
    * of the state of this StateManager. Will error if there are uncommitted
    * checkpoints on the instance.
-   * @memberof StateManager
-   * @method getStateRoot
    * @param {getStateRoot~callback} cb
    */
   getStateRoot(cb: any): void {
@@ -422,10 +399,8 @@ export default class StateManager {
    * by the provided `stateRoot`. Will error if there are uncommitted
    * checkpoints on the instance or if the state root does not exist in
    * the state trie.
-   * @memberof StateManager
-   * @method setStateRoot
-   * @param {Buffer} stateRoot The state-root to reset the instance to
-   * @param {Function} cb Callback function
+   * @param stateRoot - The state-root to reset the instance to
+   * @param cb - Callback function
    */
   setStateRoot(stateRoot: Buffer, cb: any): void {
     if (this._checkpointCount !== 0) {
@@ -465,10 +440,8 @@ export default class StateManager {
    */
 
   /**
-   * Dumps the the storage values for an `account` specified by `address`
-   * @memberof DefaultStateManager
-   * @method dumpStorage
-   * @param {Buffer} address The address of the `account` to return storage for
+   * Dumps the the storage values for an `account` specified by `address`.
+   * @param address - The address of the `account` to return storage for
    * @param {dumpStorage~callback} cb
    */
   dumpStorage(address: Buffer, cb: any): void {
@@ -498,8 +471,6 @@ export default class StateManager {
   /**
    * Checks whether the current instance has the canonical genesis state
    * for the configured chain parameters.
-   * @memberof DefaultStateManager
-   * @method hasGenesisState
    * @param {hasGenesisState~callback} cb
    */
   hasGenesisState(cb: any): void {
@@ -511,9 +482,7 @@ export default class StateManager {
    * Generates a canonical genesis state on the instance based on the
    * configured chain parameters. Will error if there are uncommitted
    * checkpoints on the instance.
-   * @memberof StateManager
-   * @method generateCanonicalGenesis
-   * @param {Function} cb Callback function
+   * @param cb - Callback function
    */
   generateCanonicalGenesis(cb: any): void {
     if (this._checkpointCount !== 0) {
@@ -531,10 +500,8 @@ export default class StateManager {
 
   /**
    * Initializes the provided genesis state into the state trie
-   * @memberof DefaultStateManager
-   * @method generateGenesis
-   * @param {Object} initState
-   * @param {Function} cb Callback function
+   * @param initState - Object (address -> balance)
+   * @param cb - Callback function
    */
   generateGenesis(initState: any, cb: any) {
     if (this._checkpointCount !== 0) {
@@ -563,10 +530,8 @@ export default class StateManager {
 
   /**
    * Checks if the `account` corresponding to `address` is empty as defined in
-   * EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)
-   * @memberof StateManager
-   * @method accountIsEmpty
-   * @param {Buffer} address Address to check
+   * EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md).
+   * @param address - Address to check
    * @param {accountIsEmpty~callback} cb
    */
   accountIsEmpty(address: Buffer, cb: any): void {
@@ -588,9 +553,7 @@ export default class StateManager {
   /**
    * Removes accounts form the state trie that have been touched,
    * as defined in EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md).
-   * @memberof StateManager
-   * @method cleanupTouchedAccounts
-   * @param {Function} cb Callback function
+   * @param cb - Callback function
    */
   cleanupTouchedAccounts(cb: any): void {
     const touchedArray = Array.from(this._touched)


### PR DESCRIPTION
Regarding the names of `Interpreter` and `Loop`:

I think `Interpreter` makes more sense for `Loop` as it reads the bytecode and executes the opcodes. For the current `Interpreter`, the closest concept that comes to my mind is `StateTransition` or `TxExecutor` or `MessageRunner` or something of the like. Another alternative is simply `EVM` which is very general and vague. But I'm hoping others chime in here and come up with better names :)