### PR TITLE
ExecResult simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ vm.runCode({
   gasLimit: new BN(0xffff),
 })
   .then(results => {
-    console.log('Returned : ' + results.return.toString('hex'))
+    console.log('Returned : ' + results.returnValue.toString('hex'))
     console.log('gasUsed  : ' + results.gasUsed.toString())
   })
   .catch(err => console.log('Error    : ' + err))

--- a/examples/run-solidity-contract/index.ts
+++ b/examples/run-solidity-contract/index.ts
@@ -107,8 +107,8 @@ async function deployContract(
 
   const deploymentResult = await vm.runTx({ tx })
 
-  if (deploymentResult.vm.exception === 0) {
-    throw deploymentResult.vm.exceptionError
+  if (deploymentResult.execResult.exception === 0) {
+    throw deploymentResult.execResult.exceptionError
   }
 
   return deploymentResult.createdAddress!
@@ -135,8 +135,8 @@ async function setGreeting(
 
   const setGreetingResult = await vm.runTx({ tx })
 
-  if (setGreetingResult.vm.exception === 0) {
-    throw setGreetingResult.vm.exceptionError
+  if (setGreetingResult.execResult.exception === 0) {
+    throw setGreetingResult.execResult.exceptionError
   }
 }
 
@@ -148,11 +148,11 @@ async function getGreeting(vm: VM, contractAddress: Buffer, caller: Buffer) {
     data: abi.methodID('greet', []),
   })
 
-  if (greetResult.vm.exception === 0) {
-    throw greetResult.vm.exceptionError
+  if (greetResult.execResult.exception === 0) {
+    throw greetResult.execResult.exceptionError
   }
 
-  const results = abi.rawDecode(['string'], greetResult.vm.return)
+  const results = abi.rawDecode(['string'], greetResult.execResult.return)
 
   return results[0]
 }

--- a/examples/run-solidity-contract/index.ts
+++ b/examples/run-solidity-contract/index.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs'
 import { promisify } from 'util'
 import * as util from 'ethereumjs-util'
 import Account from 'ethereumjs-account'
-const Transaction = require('ethereumjs-tx') // Change when https://github.com/ethereumjs/ethereumjs-vm/pull/541 gets merged
+import { Transaction } from 'ethereumjs-tx'
 const abi = require('ethereumjs-abi')
 const solc = require('solc')
 
@@ -95,9 +95,8 @@ async function deployContract(
   const params = abi.rawEncode(['string'], [greeting])
 
   const tx = new Transaction({
-    to: null,
     value: 0,
-    gas: 2000000, // We assume that 2M is enough,
+    gasLimit: 2000000, // We assume that 2M is enough,
     gasPrice: 1,
     data: '0x' + deploymentBytecode + params.toString('hex'),
     nonce: await getAccountNonce(vm, senderPrivateKey),
@@ -107,7 +106,7 @@ async function deployContract(
 
   const deploymentResult = await vm.runTx({ tx })
 
-  if (deploymentResult.execResult.exception === 0) {
+  if (deploymentResult.execResult.exceptionError) {
     throw deploymentResult.execResult.exceptionError
   }
 
@@ -125,7 +124,7 @@ async function setGreeting(
   const tx = new Transaction({
     to: contractAddress,
     value: 0,
-    gas: 2000000, // We assume that 2M is enough,
+    gasLimit: 2000000, // We assume that 2M is enough,
     gasPrice: 1,
     data: '0x' + abi.methodID('setGreeting', ['string']).toString('hex') + params.toString('hex'),
     nonce: await getAccountNonce(vm, senderPrivateKey),
@@ -135,7 +134,7 @@ async function setGreeting(
 
   const setGreetingResult = await vm.runTx({ tx })
 
-  if (setGreetingResult.execResult.exception === 0) {
+  if (setGreetingResult.execResult.exceptionError) {
     throw setGreetingResult.execResult.exceptionError
   }
 }
@@ -148,7 +147,7 @@ async function getGreeting(vm: VM, contractAddress: Buffer, caller: Buffer) {
     data: abi.methodID('greet', []),
   })
 
-  if (greetResult.execResult.exception === 0) {
+  if (greetResult.execResult.exceptionError) {
     throw greetResult.execResult.exceptionError
   }
 

--- a/examples/run-transactions-complete/index.ts
+++ b/examples/run-transactions-complete/index.ts
@@ -2,8 +2,7 @@ import VM from '../..'
 import Account from 'ethereumjs-account'
 import * as utils from 'ethereumjs-util'
 import PStateManager from '../../lib/state/promisified'
-
-const Transaction = require('ethereumjs-tx') // Change when https://github.com/ethereumjs/ethereumjs-vm/pull/541 gets merged
+import { Transaction } from 'ethereumjs-tx'
 
 async function main() {
   const vm = new VM()

--- a/examples/run-transactions-complete/index.ts
+++ b/examples/run-transactions-complete/index.ts
@@ -62,7 +62,7 @@ async function runTx(vm: VM, rawTx: any, privateKey: Buffer) {
   })
 
   console.log('gas used: ' + results.gasUsed.toString())
-  console.log('returned: ' + results.vm.return.toString('hex'))
+  console.log('returned: ' + results.execResult.return.toString('hex'))
 
   const createdAddress = results.createdAddress
 

--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -460,13 +460,13 @@ export default class EEI {
 
     const results = await this._evm.executeMessage(msg)
 
-    if (results.vm.logs) {
-      this._result.logs = this._result.logs.concat(results.vm.logs)
+    if (results.execResult.logs) {
+      this._result.logs = this._result.logs.concat(results.execResult.logs)
     }
 
     // add gasRefund
-    if (results.vm.gasRefund) {
-      this._result.gasRefund = this._result.gasRefund.add(results.vm.gasRefund)
+    if (results.execResult.gasRefund) {
+      this._result.gasRefund = this._result.gasRefund.add(results.execResult.gasRefund)
     }
 
     // this should always be safe
@@ -474,20 +474,21 @@ export default class EEI {
 
     // Set return value
     if (
-      results.vm.return &&
-      (!results.vm.exceptionError || results.vm.exceptionError.error === ERROR.REVERT)
+      results.execResult.return &&
+      (!results.execResult.exceptionError ||
+        results.execResult.exceptionError.error === ERROR.REVERT)
     ) {
-      this._lastReturned = results.vm.return
+      this._lastReturned = results.execResult.return
     }
 
-    if (!results.vm.exceptionError) {
+    if (!results.execResult.exceptionError) {
       Object.assign(this._result.selfdestruct, selfdestruct)
       // update stateRoot on current contract
       const account = await this._state.getAccount(this._env.address)
       this._env.contract = account
     }
 
-    return new BN(results.vm.exception)
+    return new BN(results.execResult.exception)
   }
 
   /**
@@ -521,24 +522,27 @@ export default class EEI {
 
     const results = await this._evm.executeMessage(msg)
 
-    if (results.vm.logs) {
-      this._result.logs = this._result.logs.concat(results.vm.logs)
+    if (results.execResult.logs) {
+      this._result.logs = this._result.logs.concat(results.execResult.logs)
     }
 
     // add gasRefund
-    if (results.vm.gasRefund) {
-      this._result.gasRefund = this._result.gasRefund.add(results.vm.gasRefund)
+    if (results.execResult.gasRefund) {
+      this._result.gasRefund = this._result.gasRefund.add(results.execResult.gasRefund)
     }
 
     // this should always be safe
     this.useGas(results.gasUsed)
 
     // Set return buffer in case revert happened
-    if (results.vm.exceptionError && results.vm.exceptionError.error === ERROR.REVERT) {
-      this._lastReturned = results.vm.return
+    if (
+      results.execResult.exceptionError &&
+      results.execResult.exceptionError.error === ERROR.REVERT
+    ) {
+      this._lastReturned = results.execResult.return
     }
 
-    if (!results.vm.exceptionError) {
+    if (!results.execResult.exceptionError) {
       Object.assign(this._result.selfdestruct, selfdestruct)
       // update stateRoot on current contract
       const account = await this._state.getAccount(this._env.address)
@@ -549,7 +553,7 @@ export default class EEI {
       }
     }
 
-    return new BN(results.vm.exception)
+    return new BN(results.execResult.exception)
   }
 
   /**

--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -475,7 +475,7 @@ export default class EEI {
     // Set return value
     if (
       results.vm.return &&
-      (!results.vm.exceptionError || (results.vm.exceptionError as VmError).error === ERROR.REVERT)
+      (!results.vm.exceptionError || results.vm.exceptionError.error === ERROR.REVERT)
     ) {
       this._lastReturned = results.vm.return
     }
@@ -534,10 +534,7 @@ export default class EEI {
     this.useGas(results.gasUsed)
 
     // Set return buffer in case revert happened
-    if (
-      results.vm.exceptionError &&
-      (results.vm.exceptionError as VmError).error === ERROR.REVERT
-    ) {
+    if (results.vm.exceptionError && results.vm.exceptionError.error === ERROR.REVERT) {
       this._lastReturned = results.vm.return
     }
 

--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -32,7 +32,7 @@ export interface Env {
  */
 export interface RunResult {
   logs: any // TODO: define type for Log (each log: [Buffer(address), [Buffer(topic0), ...]])
-  return?: Buffer
+  returnValue?: Buffer
   gasRefund: BN
   /**
    * A map from the accounts that have self-destructed to the addresses to send their funds to
@@ -66,7 +66,7 @@ export default class EEI {
     this._gasLeft = gasLeft
     this._result = {
       logs: [],
-      return: undefined,
+      returnValue: undefined,
       gasRefund: new BN(0),
       selfdestruct: {},
     }
@@ -300,7 +300,7 @@ export default class EEI {
    * @param returnData - Output data to return
    */
   finish(returnData: Buffer): void {
-    this._result.return = returnData
+    this._result.returnValue = returnData
     trap(ERROR.STOP)
   }
 
@@ -310,7 +310,7 @@ export default class EEI {
    * @param returnData - Output data to return
    */
   revert(returnData: Buffer): void {
-    this._result.return = returnData
+    this._result.returnValue = returnData
     trap(ERROR.REVERT)
   }
 
@@ -474,11 +474,11 @@ export default class EEI {
 
     // Set return value
     if (
-      results.execResult.return &&
+      results.execResult.returnValue &&
       (!results.execResult.exceptionError ||
         results.execResult.exceptionError.error === ERROR.REVERT)
     ) {
-      this._lastReturned = results.execResult.return
+      this._lastReturned = results.execResult.returnValue
     }
 
     if (!results.execResult.exceptionError) {
@@ -539,7 +539,7 @@ export default class EEI {
       results.execResult.exceptionError &&
       results.execResult.exceptionError.error === ERROR.REVERT
     ) {
-      this._lastReturned = results.execResult.return
+      this._lastReturned = results.execResult.returnValue
     }
 
     if (!results.execResult.exceptionError) {

--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -6,7 +6,7 @@ import Common from 'ethereumjs-common'
 import PStateManager from '../state/promisified'
 import { VmError, ERROR } from '../exceptions'
 import Message from './message'
-import EVM from './evm'
+import EVM, { EVMResult } from './evm'
 const promisify = require('util.promisify')
 
 /**
@@ -488,7 +488,7 @@ export default class EEI {
       this._env.contract = account
     }
 
-    return new BN(results.execResult.exception)
+    return this._getReturnCode(results)
   }
 
   /**
@@ -553,7 +553,7 @@ export default class EEI {
       }
     }
 
-    return new BN(results.execResult.exception)
+    return this._getReturnCode(results)
   }
 
   /**
@@ -570,6 +570,16 @@ export default class EEI {
    */
   async isAccountEmpty(address: Buffer): Promise<boolean> {
     return this._state.accountIsEmpty(address)
+  }
+
+  private _getReturnCode(results: EVMResult) {
+    // This preserves the previous logic, but seems to contradict the EEI spec
+    // https://github.com/ewasm/design/blob/38eeded28765f3e193e12881ea72a6ab807a3371/eth_interface.md
+    if (results.execResult.exceptionError) {
+      return new BN(0)
+    } else {
+      return new BN(1)
+    }
   }
 }
 

--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -32,7 +32,7 @@ export interface Env {
  */
 export interface RunResult {
   logs: any // TODO: define type for Log (each log: [Buffer(address), [Buffer(topic0), ...]])
-  returnValue?: Buffer
+  return?: Buffer
   gasRefund: BN
   /**
    * A map from the accounts that have self-destructed to the addresses to send their funds to
@@ -66,7 +66,7 @@ export default class EEI {
     this._gasLeft = gasLeft
     this._result = {
       logs: [],
-      returnValue: undefined,
+      return: undefined,
       gasRefund: new BN(0),
       selfdestruct: {},
     }
@@ -300,7 +300,7 @@ export default class EEI {
    * @param returnData - Output data to return
    */
   finish(returnData: Buffer): void {
-    this._result.returnValue = returnData
+    this._result.return = returnData
     trap(ERROR.STOP)
   }
 
@@ -310,7 +310,7 @@ export default class EEI {
    * @param returnData - Output data to return
    */
   revert(returnData: Buffer): void {
-    this._result.returnValue = returnData
+    this._result.return = returnData
     trap(ERROR.REVERT)
   }
 

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -15,13 +15,7 @@ import { OOGResult } from './precompiles/types'
 import TxContext from './txContext'
 import Message from './message'
 import EEI from './eei'
-import {
-  default as Interpreter,
-  InterpreterResult,
-  RunState,
-  IsException,
-  InterpreterOpts,
-} from './interpreter'
+import { default as Interpreter, RunState, IsException, InterpreterOpts } from './interpreter'
 const Block = require('ethereumjs-block')
 
 /**
@@ -54,7 +48,7 @@ export interface ExecResult {
   /**
    * Description of the exception, if any occured
    */
-  exceptionError?: VmError | ERROR
+  exceptionError?: VmError
   /**
    * Amount of gas left
    */
@@ -128,7 +122,7 @@ export default class EVM {
         // because the bug in both Geth and Parity led to deleting RIPEMD precompiled in this case
         // see https://github.com/ethereum/go-ethereum/pull/3341/files#diff-2433aa143ee4772026454b8abd76b9dd
         // We mark the account as touched here, so that is can be removed among other touched empty accounts (after tx finalization)
-        if ((err as ERROR) === ERROR.OUT_OF_GAS || (err as VmError).error === ERROR.OUT_OF_GAS) {
+        if (err.error === ERROR.OUT_OF_GAS) {
           await this._touchAccount(message.to)
         }
       }
@@ -198,7 +192,7 @@ export default class EVM {
         vm: {
           return: Buffer.alloc(0),
           exception: 0,
-          exceptionError: ERROR.CREATE_COLLISION,
+          exceptionError: new VmError(ERROR.CREATE_COLLISION),
           gasUsed: message.gasLimit,
         },
       }
@@ -290,7 +284,7 @@ export default class EVM {
     let result = eei._result
     let gasUsed = message.gasLimit.sub(eei._gasLeft)
     if (interpreterRes.exceptionError) {
-      if ((interpreterRes.exceptionError as VmError).error !== ERROR.REVERT) {
+      if (interpreterRes.exceptionError.error !== ERROR.REVERT) {
         gasUsed = message.gasLimit
       }
 

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -56,7 +56,7 @@ export interface ExecResult {
   /**
    * Return value from the contract
    */
-  return: Buffer
+  returnValue: Buffer
   /**
    * Array of logs that the contract emitted
    */
@@ -73,7 +73,7 @@ export interface ExecResult {
 
 export function OOGResult(gasLimit: BN): ExecResult {
   return {
-    return: Buffer.alloc(0),
+    returnValue: Buffer.alloc(0),
     gasUsed: gasLimit,
     exceptionError: new VmError(ERROR.OUT_OF_GAS),
   }
@@ -153,7 +153,7 @@ export default class EVM {
         gasUsed: new BN(0),
         execResult: {
           gasUsed: new BN(0),
-          return: Buffer.alloc(0),
+          returnValue: Buffer.alloc(0),
         },
       }
     }
@@ -189,7 +189,7 @@ export default class EVM {
         gasUsed: message.gasLimit,
         createdAddress: message.to,
         execResult: {
-          return: Buffer.alloc(0),
+          returnValue: Buffer.alloc(0),
           exceptionError: new VmError(ERROR.CREATE_COLLISION),
           gasUsed: message.gasLimit,
         },
@@ -213,7 +213,7 @@ export default class EVM {
         createdAddress: message.to,
         execResult: {
           gasUsed: new BN(0),
-          return: Buffer.alloc(0),
+          returnValue: Buffer.alloc(0),
         },
       }
     }
@@ -224,7 +224,7 @@ export default class EVM {
     let totalGas = result.gasUsed
     if (!result.exceptionError) {
       const returnFee = new BN(
-        result.return.length * this._vm._common.param('gasPrices', 'createData'),
+        result.returnValue.length * this._vm._common.param('gasPrices', 'createData'),
       )
       totalGas = totalGas.add(returnFee)
     }
@@ -232,7 +232,7 @@ export default class EVM {
     // if not enough gas
     if (
       totalGas.lte(message.gasLimit) &&
-      (this._vm.allowUnlimitedContractSize || result.return.length <= 24576)
+      (this._vm.allowUnlimitedContractSize || result.returnValue.length <= 24576)
     ) {
       result.gasUsed = totalGas
     } else {
@@ -240,8 +240,8 @@ export default class EVM {
     }
 
     // Save code if a new contract was created
-    if (!result.exceptionError && result.return && result.return.toString() !== '') {
-      await this._state.putContractCode(message.to, result.return)
+    if (!result.exceptionError && result.returnValue && result.returnValue.toString() !== '') {
+      await this._state.putContractCode(message.to, result.returnValue)
     }
 
     return {
@@ -304,7 +304,7 @@ export default class EVM {
       exceptionError: interpreterRes.exceptionError,
       gas: eei._gasLeft,
       gasUsed,
-      return: result.return ? result.return : Buffer.alloc(0),
+      returnValue: result.returnValue ? result.returnValue : Buffer.alloc(0),
     }
   }
 

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -33,7 +33,7 @@ export interface EVMResult {
   /**
    * Contains the results from running the code, if any, as described in [[runCode]]
    */
-  vm: ExecResult
+  execResult: ExecResult
 }
 
 /**
@@ -122,9 +122,9 @@ export default class EVM {
       result = await this._executeCreate(message)
     }
 
-    const err = result.vm.exceptionError
+    const err = result.execResult.exceptionError
     if (err) {
-      result.vm.logs = []
+      result.execResult.logs = []
       await this._state.revert()
       if (message.isCompiled) {
         // Empty precompiled contracts need to be deleted even in case of OOG
@@ -160,7 +160,7 @@ export default class EVM {
     if (!message.code || message.code.length === 0) {
       return {
         gasUsed: new BN(0),
-        vm: {
+        execResult: {
           exception: 1,
           gasUsed: new BN(0),
           return: Buffer.alloc(0),
@@ -177,7 +177,7 @@ export default class EVM {
 
     return {
       gasUsed: result.gasUsed,
-      vm: result,
+      execResult: result,
     }
   }
 
@@ -198,7 +198,7 @@ export default class EVM {
       return {
         gasUsed: message.gasLimit,
         createdAddress: message.to,
-        vm: {
+        execResult: {
           return: Buffer.alloc(0),
           exception: 0,
           exceptionError: new VmError(ERROR.CREATE_COLLISION),
@@ -222,7 +222,7 @@ export default class EVM {
       return {
         gasUsed: new BN(0),
         createdAddress: message.to,
-        vm: {
+        execResult: {
           exception: 1,
           gasUsed: new BN(0),
           return: Buffer.alloc(0),
@@ -259,7 +259,7 @@ export default class EVM {
     return {
       gasUsed: result.gasUsed,
       createdAddress: message.to,
-      vm: result,
+      execResult: result,
     }
   }
 

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -14,7 +14,7 @@ import { getPrecompile, PrecompileFunc, ExecResult } from './precompiles'
 import TxContext from './txContext'
 import Message from './message'
 import EEI from './eei'
-import { default as Interpreter, InterpreterOpts, IsException, RunState } from './interpreter'
+import { default as Interpreter, InterpreterOpts, RunState } from './interpreter'
 
 const Block = require('ethereumjs-block')
 
@@ -41,10 +41,6 @@ export interface EVMResult {
  */
 export interface ExecResult {
   runState?: RunState
-  /**
-   * `0` if the contract encountered an exception, `1` otherwise
-   */
-  exception: IsException
   /**
    * Description of the exception, if any occured
    */
@@ -79,7 +75,6 @@ export function OOGResult(gasLimit: BN): ExecResult {
   return {
     return: Buffer.alloc(0),
     gasUsed: gasLimit,
-    exception: 0, // 0 means VM fail (in this case because of OOG)
     exceptionError: new VmError(ERROR.OUT_OF_GAS),
   }
 }
@@ -157,7 +152,6 @@ export default class EVM {
       return {
         gasUsed: new BN(0),
         execResult: {
-          exception: 1,
           gasUsed: new BN(0),
           return: Buffer.alloc(0),
         },
@@ -196,7 +190,6 @@ export default class EVM {
         createdAddress: message.to,
         execResult: {
           return: Buffer.alloc(0),
-          exception: 0,
           exceptionError: new VmError(ERROR.CREATE_COLLISION),
           gasUsed: message.gasLimit,
         },
@@ -219,7 +212,6 @@ export default class EVM {
         gasUsed: new BN(0),
         createdAddress: message.to,
         execResult: {
-          exception: 1,
           gasUsed: new BN(0),
           return: Buffer.alloc(0),
         },
@@ -309,7 +301,6 @@ export default class EVM {
         ...result,
         ...eei._env,
       },
-      exception: interpreterRes.exception,
       exceptionError: interpreterRes.exceptionError,
       gas: eei._gasLeft,
       gasUsed,

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -66,10 +66,6 @@ export interface ExecResult {
    */
   logs?: any[]
   /**
-   * Value returned by the contract
-   */
-  returnValue?: Buffer
-  /**
    * Amount of gas to refund from deleting storage values
    */
   gasRefund?: BN
@@ -317,7 +313,7 @@ export default class EVM {
       exceptionError: interpreterRes.exceptionError,
       gas: eei._gasLeft,
       gasUsed,
-      return: result.returnValue ? result.returnValue : Buffer.alloc(0),
+      return: result.return ? result.return : Buffer.alloc(0),
     }
   }
 

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -10,7 +10,7 @@ import {
 import Account from 'ethereumjs-account'
 import { ERROR, VmError } from '../exceptions'
 import PStateManager from '../state/promisified'
-import { getPrecompile, PrecompileFunc, ExecResult } from './precompiles'
+import { getPrecompile, PrecompileFunc } from './precompiles'
 import TxContext from './txContext'
 import Message from './message'
 import EEI from './eei'

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -32,7 +32,7 @@ export interface RunState {
 export interface InterpreterResult {
   runState?: RunState
   exception: IsException
-  exceptionError?: VmError | ERROR
+  exceptionError?: VmError
 }
 
 /**

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -9,8 +9,6 @@ import EEI from './eei'
 import { lookupOpInfo, OpInfo } from './opcodes'
 import { handlers as opHandlers, OpHandler } from './opFns.js'
 
-export type IsException = 0 | 1
-
 export interface InterpreterOpts {
   pc?: number
 }
@@ -31,7 +29,6 @@ export interface RunState {
 
 export interface InterpreterResult {
   runState?: RunState
-  exception: IsException
   exceptionError?: VmError
 }
 
@@ -96,7 +93,6 @@ export default class Interpreter {
 
     return {
       runState: this._runState,
-      exception: err ? (0 as IsException) : (1 as IsException),
       exceptionError: err,
     }
   }

--- a/lib/evm/precompiles/01-ecrecover.ts
+++ b/lib/evm/precompiles/01-ecrecover.ts
@@ -27,13 +27,11 @@ export default function(opts: PrecompileInput): ExecResult {
     return {
       gasUsed,
       return: Buffer.alloc(0),
-      exception: 1,
     }
   }
 
   return {
     gasUsed,
     return: setLengthLeft(publicToAddress(publicKey), 32),
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/01-ecrecover.ts
+++ b/lib/evm/precompiles/01-ecrecover.ts
@@ -26,12 +26,12 @@ export default function(opts: PrecompileInput): ExecResult {
   } catch (e) {
     return {
       gasUsed,
-      return: Buffer.alloc(0),
+      returnValue: Buffer.alloc(0),
     }
   }
 
   return {
     gasUsed,
-    return: setLengthLeft(publicToAddress(publicKey), 32),
+    returnValue: setLengthLeft(publicToAddress(publicKey), 32),
   }
 }

--- a/lib/evm/precompiles/01-ecrecover.ts
+++ b/lib/evm/precompiles/01-ecrecover.ts
@@ -1,9 +1,10 @@
 import BN = require('bn.js')
 import { setLengthLeft, setLengthRight, ecrecover, publicToAddress } from 'ethereumjs-util'
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const gasUsed = new BN(opts._common.param('gasPrices', 'ecRecover'))

--- a/lib/evm/precompiles/02-sha256.ts
+++ b/lib/evm/precompiles/02-sha256.ts
@@ -21,6 +21,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: sha256(data),
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/02-sha256.ts
+++ b/lib/evm/precompiles/02-sha256.ts
@@ -1,9 +1,10 @@
 import BN = require('bn.js')
 import { sha256 } from 'ethereumjs-util'
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const data = opts.data

--- a/lib/evm/precompiles/02-sha256.ts
+++ b/lib/evm/precompiles/02-sha256.ts
@@ -20,6 +20,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: sha256(data),
+    returnValue: sha256(data),
   }
 }

--- a/lib/evm/precompiles/03-ripemd160.ts
+++ b/lib/evm/precompiles/03-ripemd160.ts
@@ -1,9 +1,10 @@
 import BN = require('bn.js')
 import { ripemd160 } from 'ethereumjs-util'
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const data = opts.data

--- a/lib/evm/precompiles/03-ripemd160.ts
+++ b/lib/evm/precompiles/03-ripemd160.ts
@@ -20,6 +20,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: ripemd160(data, true),
+    returnValue: ripemd160(data, true),
   }
 }

--- a/lib/evm/precompiles/03-ripemd160.ts
+++ b/lib/evm/precompiles/03-ripemd160.ts
@@ -21,6 +21,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: ripemd160(data, true),
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/04-identity.ts
+++ b/lib/evm/precompiles/04-identity.ts
@@ -20,6 +20,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: data,
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/04-identity.ts
+++ b/lib/evm/precompiles/04-identity.ts
@@ -19,6 +19,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: data,
+    returnValue: data,
   }
 }

--- a/lib/evm/precompiles/04-identity.ts
+++ b/lib/evm/precompiles/04-identity.ts
@@ -1,8 +1,9 @@
 import BN = require('bn.js')
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const data = opts.data

--- a/lib/evm/precompiles/05-modexp.ts
+++ b/lib/evm/precompiles/05-modexp.ts
@@ -95,14 +95,14 @@ export default function(opts: PrecompileInput): ExecResult {
   if (bLen.isZero()) {
     return {
       gasUsed,
-      return: new BN(0).toArrayLike(Buffer, 'be', 1),
+      returnValue: new BN(0).toArrayLike(Buffer, 'be', 1),
     }
   }
 
   if (mLen.isZero()) {
     return {
       gasUsed,
-      return: Buffer.alloc(0),
+      returnValue: Buffer.alloc(0),
     }
   }
 
@@ -137,6 +137,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: R.toArrayLike(Buffer, 'be', mLen.toNumber()),
+    returnValue: R.toArrayLike(Buffer, 'be', mLen.toNumber()),
   }
 }

--- a/lib/evm/precompiles/05-modexp.ts
+++ b/lib/evm/precompiles/05-modexp.ts
@@ -1,6 +1,7 @@
 import BN = require('bn.js')
 import { setLengthRight } from 'ethereumjs-util'
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 
 function multComplexity(x: BN): BN {
@@ -66,7 +67,7 @@ function expmod(B: BN, E: BN, M: BN): BN {
   return res.fromRed()
 }
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const data = opts.data

--- a/lib/evm/precompiles/05-modexp.ts
+++ b/lib/evm/precompiles/05-modexp.ts
@@ -96,7 +96,6 @@ export default function(opts: PrecompileInput): ExecResult {
     return {
       gasUsed,
       return: new BN(0).toArrayLike(Buffer, 'be', 1),
-      exception: 1,
     }
   }
 
@@ -104,7 +103,6 @@ export default function(opts: PrecompileInput): ExecResult {
     return {
       gasUsed,
       return: Buffer.alloc(0),
-      exception: 1,
     }
   }
 
@@ -140,6 +138,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: R.toArrayLike(Buffer, 'be', mLen.toNumber()),
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/06-ecadd.ts
+++ b/lib/evm/precompiles/06-ecadd.ts
@@ -24,6 +24,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: returnData,
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/06-ecadd.ts
+++ b/lib/evm/precompiles/06-ecadd.ts
@@ -1,9 +1,10 @@
 import BN = require('bn.js')
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 const bn128 = require('rustbn.js')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   let inputData = opts.data

--- a/lib/evm/precompiles/06-ecadd.ts
+++ b/lib/evm/precompiles/06-ecadd.ts
@@ -23,6 +23,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: returnData,
+    returnValue: returnData,
   }
 }

--- a/lib/evm/precompiles/07-ecmul.ts
+++ b/lib/evm/precompiles/07-ecmul.ts
@@ -22,6 +22,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: returnData,
+    returnValue: returnData,
   }
 }

--- a/lib/evm/precompiles/07-ecmul.ts
+++ b/lib/evm/precompiles/07-ecmul.ts
@@ -1,9 +1,10 @@
 import BN = require('bn.js')
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 const bn128 = require('rustbn.js')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const inputData = opts.data

--- a/lib/evm/precompiles/07-ecmul.ts
+++ b/lib/evm/precompiles/07-ecmul.ts
@@ -23,6 +23,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: returnData,
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/08-ecpairing.ts
+++ b/lib/evm/precompiles/08-ecpairing.ts
@@ -29,6 +29,5 @@ export default function(opts: PrecompileInput): ExecResult {
   return {
     gasUsed,
     return: returnData,
-    exception: 1,
   }
 }

--- a/lib/evm/precompiles/08-ecpairing.ts
+++ b/lib/evm/precompiles/08-ecpairing.ts
@@ -1,9 +1,10 @@
 import BN = require('bn.js')
-import { PrecompileInput, PrecompileResult, OOGResult } from './types'
+import { PrecompileInput } from './types'
+import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')
 const bn128 = require('rustbn.js')
 
-export default function(opts: PrecompileInput): PrecompileResult {
+export default function(opts: PrecompileInput): ExecResult {
   assert(opts.data)
 
   const inputData = opts.data

--- a/lib/evm/precompiles/08-ecpairing.ts
+++ b/lib/evm/precompiles/08-ecpairing.ts
@@ -28,6 +28,6 @@ export default function(opts: PrecompileInput): ExecResult {
 
   return {
     gasUsed,
-    return: returnData,
+    returnValue: returnData,
   }
 }

--- a/lib/evm/precompiles/index.ts
+++ b/lib/evm/precompiles/index.ts
@@ -1,4 +1,4 @@
-import { PrecompileInput, PrecompileResult, PrecompileFunc } from './types'
+import { PrecompileInput, PrecompileFunc } from './types'
 import { default as p1 } from './01-ecrecover'
 import { default as p2 } from './02-sha256'
 import { default as p3 } from './03-ripemd160'
@@ -7,6 +7,7 @@ import { default as p5 } from './05-modexp'
 import { default as p6 } from './06-ecadd'
 import { default as p7 } from './07-ecmul'
 import { default as p8 } from './08-ecpairing'
+import { ExecResult } from '../evm'
 
 interface Precompiles {
   [key: string]: PrecompileFunc
@@ -27,4 +28,4 @@ function getPrecompile(address: string): PrecompileFunc {
   return precompiles[address]
 }
 
-export { precompiles, getPrecompile, PrecompileFunc, PrecompileInput, PrecompileResult }
+export { precompiles, getPrecompile, PrecompileFunc, PrecompileInput, ExecResult }

--- a/lib/evm/precompiles/index.ts
+++ b/lib/evm/precompiles/index.ts
@@ -7,7 +7,6 @@ import { default as p5 } from './05-modexp'
 import { default as p6 } from './06-ecadd'
 import { default as p7 } from './07-ecmul'
 import { default as p8 } from './08-ecpairing'
-import { ExecResult } from '../evm'
 
 interface Precompiles {
   [key: string]: PrecompileFunc
@@ -28,4 +27,4 @@ function getPrecompile(address: string): PrecompileFunc {
   return precompiles[address]
 }
 
-export { precompiles, getPrecompile, PrecompileFunc, PrecompileInput, ExecResult }
+export { precompiles, getPrecompile, PrecompileFunc, PrecompileInput }

--- a/lib/evm/precompiles/types.ts
+++ b/lib/evm/precompiles/types.ts
@@ -1,29 +1,13 @@
 import BN = require('bn.js')
 import Common from 'ethereumjs-common'
-import { ERROR, VmError } from '../../exceptions'
+import { ExecResult } from '../evm'
 
 export interface PrecompileFunc {
-  (opts: PrecompileInput): PrecompileResult
+  (opts: PrecompileInput): ExecResult
 }
 
 export interface PrecompileInput {
   data: Buffer
   gasLimit: BN
   _common: Common
-}
-
-export interface PrecompileResult {
-  gasUsed: BN
-  return: Buffer
-  exception: 0 | 1
-  exceptionError?: VmError
-}
-
-export function OOGResult(gasLimit: BN): PrecompileResult {
-  return {
-    return: Buffer.alloc(0),
-    gasUsed: gasLimit,
-    exception: 0, // 0 means VM fail (in this case because of OOG)
-    exceptionError: new VmError(ERROR.OUT_OF_GAS),
-  }
 }

--- a/lib/evm/precompiles/types.ts
+++ b/lib/evm/precompiles/types.ts
@@ -1,6 +1,6 @@
 import BN = require('bn.js')
 import Common from 'ethereumjs-common'
-import { ERROR } from '../../exceptions'
+import { ERROR, VmError } from '../../exceptions'
 
 export interface PrecompileFunc {
   (opts: PrecompileInput): PrecompileResult
@@ -16,7 +16,7 @@ export interface PrecompileResult {
   gasUsed: BN
   return: Buffer
   exception: 0 | 1
-  exceptionError?: ERROR
+  exceptionError?: VmError
 }
 
 export function OOGResult(gasLimit: BN): PrecompileResult {
@@ -24,6 +24,6 @@ export function OOGResult(gasLimit: BN): PrecompileResult {
     return: Buffer.alloc(0),
     gasUsed: gasLimit,
     exception: 0, // 0 means VM fail (in this case because of OOG)
-    exceptionError: ERROR.OUT_OF_GAS,
+    exceptionError: new VmError(ERROR.OUT_OF_GAS),
   }
 }

--- a/lib/runBlock.ts
+++ b/lib/runBlock.ts
@@ -212,10 +212,10 @@ async function applyTransactions(this: VM, block: any) {
     bloom.or(txRes.bloom)
 
     const txReceipt: TxReceipt = {
-      status: txRes.vm.exception ? 1 : 0, // result.vm.exception is 0 when an exception occurs, and 1 when it doesn't.  TODO make this the opposite
+      status: txRes.execResult.exception ? 1 : 0, // result.execResult.exception is 0 when an exception occurs, and 1 when it doesn't.  TODO make this the opposite
       gasUsed: gasUsed.toArrayLike(Buffer),
       bitvector: txRes.bloom.bitvector,
-      logs: txRes.vm.logs || [],
+      logs: txRes.execResult.logs || [],
     }
     receipts.push(txReceipt)
 

--- a/lib/runBlock.ts
+++ b/lib/runBlock.ts
@@ -50,7 +50,7 @@ export interface RunBlockResult {
  */
 export interface TxReceipt {
   /**
-   * Status of transaction, `0` if successful, `1` if an exception occured
+   * Status of transaction, `1` if successful, `0` if an exception occured
    */
   status: 0 | 1
   /**

--- a/lib/runBlock.ts
+++ b/lib/runBlock.ts
@@ -212,7 +212,7 @@ async function applyTransactions(this: VM, block: any) {
     bloom.or(txRes.bloom)
 
     const txReceipt: TxReceipt = {
-      status: txRes.execResult.exception ? 1 : 0, // result.execResult.exception is 0 when an exception occurs, and 1 when it doesn't.  TODO make this the opposite
+      status: txRes.execResult.exceptionError ? 0 : 1, // Receipts have a 0 as status on error
       gasUsed: gasUsed.toArrayLike(Buffer),
       bitvector: txRes.bloom.bitvector,
       logs: txRes.execResult.logs || [],

--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -151,11 +151,11 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    * Parse results
    */
   // Generate the bloom for the tx
-  results.bloom = txLogsBloom(results.vm.logs)
+  results.bloom = txLogsBloom(results.execResult.logs)
   // Caculate the total gas used
   results.gasUsed = results.gasUsed.add(basefee)
   // Process any gas refund
-  results.gasRefund = results.vm.gasRefund
+  results.gasRefund = results.execResult.gasRefund
   if (results.gasRefund) {
     if (results.gasRefund.lt(results.gasUsed.divn(2))) {
       results.gasUsed.isub(results.gasRefund)
@@ -185,8 +185,8 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   /*
    * Cleanup accounts
    */
-  if (results.vm.selfdestruct) {
-    const keys = Object.keys(results.vm.selfdestruct)
+  if (results.execResult.selfdestruct) {
+    const keys = Object.keys(results.execResult.selfdestruct)
     for (const k of keys) {
       await state.putAccount(Buffer.from(k, 'hex'), new Account())
     }


### PR DESCRIPTION
This is a WIP that simplifies the `ExecResult` type.

The changes I made so far are:

* Always use VMError, and not directly `ERROR`.
* Unified `ExecResult` and `PrecompileResult`.
* Moved `OOGResult` to `evm.ts`
* Renamed `EVMResult#vm` to `EVMResult#execResult`

Each of them is implemented in separate commits, so we can pick/discard whatever we want.