### PR TITLE
New release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2019-08-06
+
+First `TypeScript` based VM release, other highlights:
+
+- New Call and Code Loop Structure / EVM Encapsulation
+- EEI for Environment Communication
+- Istanbul Process Start
+- Promise-based API
+
+See [v4.0.0-beta.1](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/v4.0.0-beta.1)
+release for full release notes.
+
+**Changes since last beta**
+
+- Simplification of execution results,
+  PR [#551](https://github.com/ethereumjs/ethereumjs-vm/pull/551)
+- Fix error propagation in `Cache.flush()` method from `StateManager`,
+  PR [#562](https://github.com/ethereumjs/ethereumjs-vm/pull/562)
+- `StateManager` storage key length validation (now throws on addresses not
+  having a 32-byte length),
+  PR [#565](https://github.com/ethereumjs/ethereumjs-vm/pull/565)
+
+[4.0.0]: https://github.com/ethereumjs/ethereumjs-vm/compare/v4.0.0-beta.1...v4.0.0
+
 ## [4.0.0-beta.1] - 2019-06-19
 
 Since changes in this release are pretty deep reaching and broadly distributed,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-vm",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0",
   "description": "An Ethereum VM implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Still a bit unsure with the release process, but after some back-and-forth thinking it occurred to me that actually both TS respectively promsify updates (block, merkle tree, eventually blockchain as well) are breaking changes here due to the objects being able to be passed from the outside on the VM API.

So likely we will have to make a follow-up v5.0.0 release along with these anyhow (which is also no big deal I think, if necessary so be it). So we might as well just wait for both to be finalized and published to then at least have just one necessary breaking release on the VM, and we can/should then just do the v4 release just now, have this out and go on.

Let me know what you think and eventually approve if you go along.