### PR TITLE
fix: tx error strings should not contain multiple consecutive whitespace characters

### DIFF
--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -114,15 +114,14 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     throw new Error(
       `sender doesn't have enough funds to send tx. The upfront cost is: ${tx
         .getUpfrontCost()
-        .toString()}` + 
-      ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
+        .toString()}` +
+        ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
     )
   } else if (!opts.skipNonce && !new BN(fromAccount.nonce).eq(new BN(tx.nonce))) {
     throw new Error(
       `the tx doesn't have the correct nonce. account has nonce of: ${new BN(
         fromAccount.nonce,
-      ).toString()} ` + 
-      `tx has nonce of: ${new BN(tx.nonce).toString()}`,
+      ).toString()} tx has nonce of: ${new BN(tx.nonce).toString()}`,
     )
   }
   // Update from account's nonce and balance

--- a/lib/runTx.ts
+++ b/lib/runTx.ts
@@ -114,15 +114,15 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     throw new Error(
       `sender doesn't have enough funds to send tx. The upfront cost is: ${tx
         .getUpfrontCost()
-        .toString()}\
-      and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
+        .toString()}` + 
+      ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
     )
   } else if (!opts.skipNonce && !new BN(fromAccount.nonce).eq(new BN(tx.nonce))) {
     throw new Error(
       `the tx doesn't have the correct nonce. account has nonce of: ${new BN(
         fromAccount.nonce,
-      ).toString()}\
-      tx has nonce of: ${new BN(tx.nonce).toString()}`,
+      ).toString()} ` + 
+      `tx has nonce of: ${new BN(tx.nonce).toString()}`,
     )
   }
   // Update from account's nonce and balance


### PR DESCRIPTION
https://github.com/ethereumjs/ethereumjs-vm/commit/519a07646d4bd892c2427548fb79d6fa259d99b6#diff-f5570026bc45fa69b273a873ea7ab1c4R93 caused an unintended breaking change by changing the output of the error strings.

Also, I couldn't test this because I couldn't figure out how to get things working. I also couldn't push without adding `--no-verify` due to the linter not working out of the box (something about `ethereumjs-config-format` not available).