### PR TITLE
Add an explanation on why we cache promisifyed functions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -127,6 +127,8 @@ export default class VM extends AsyncEventEmitter {
     this.allowUnlimitedContractSize =
       opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
 
+    // We cache this promisified function as it's called from the main execution loop, and
+    // promisifying each time has a huge performance impact.
     this._emit = promisify(this.emit.bind(this))
   }
 

--- a/lib/state/promisified.ts
+++ b/lib/state/promisified.ts
@@ -32,6 +32,8 @@ export default class PStateManager {
   constructor(wrapped: StateManager) {
     this._wrapped = wrapped
 
+    // We cache these promisified function as they are called lots of times during the VM execution,
+    // and promisifying them each time has degrades its performance.
     this.getAccount = promisify(this._wrapped.getAccount.bind(this._wrapped))
 
     this.putAccount = promisify(this._wrapped.putAccount.bind(this._wrapped))


### PR DESCRIPTION
Just a small PR responding to some comments from @holgerd77 in #600 