### PR TITLE
Release two builds of the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ node_modules
 package-lock.json
 yarn.lock
 
-# Build folder
+# Build folders
 dist
+modernjs
 

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,5 @@ yarn.lock
 
 # Build folders
 dist
-modernjs
+/es2017
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ dist
 .nyc_output
 *.json
 docs
+modernjs

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,4 @@ dist
 .nyc_output
 *.json
 docs
-modernjs
+es2017

--- a/README.md
+++ b/README.md
@@ -183,6 +183,19 @@ by it, the exception will bubble into the VM and interrupt it, possibly
 corrupting its state. It's strongly recommended not to throw from withing
 event handlers.
 
+# Running the project in modern environments
+
+The NPM `ethereumjs-vm` package includes two different builds of the project:
+
+1. The default one, located in the `dist/` directory, is an ES5 compatible build, distributed as
+   CommonJS modules.
+
+2. A second build, targeting Node and modern JavaScript bundlers, located in the `modernjs/`
+   directory, is an ES2017 build, distributed as CommonJS modules. To use this version, you should
+   import the VM form `"ethereumjs-vm/modernjs"`.
+
+Using the second build is recommended when possible, as it has significant performance improvements.
+
 # DEVELOPMENT
 
 Developer documentation - currently mainly with information on testing and debugging - can be found [here](./developer.md).

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ The NPM `ethereumjs-vm` package includes two different builds of the project:
 1. The default one, located in the `dist/` directory, is an ES5 compatible build, distributed as
    CommonJS modules.
 
-2. A second build, targeting Node and modern JavaScript bundlers, located in the `modernjs/`
+2. A second build, targeting Node and modern JavaScript bundlers, located in the `es2017/`
    directory, is an ES2017 build, distributed as CommonJS modules. To use this version, you should
-   import the VM form `"ethereumjs-vm/modernjs"`.
+   import the VM form `"ethereumjs-vm/es2017"`.
 
 Using the second build is recommended when possible, as it has significant performance improvements.
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",
-    "modernjs/**/*"
+    "es2017/**/*"
   ],
   "scripts": {
     "build:dist": "ethereumjs-config-build",
-    "build:dist:modernjs": "tsc -p ./tsconfig.modernjs.json",
-    "prepublishOnly": "npm run lint && npm run build:dist && npm run build:dist:modernjs && npm run testBuildIntegrity",
+    "build:dist:es2017": "tsc -p ./tsconfig.es2017.json",
+    "prepublishOnly": "npm run lint && npm run build:dist && npm run build:dist:es2017 && npm run testBuildIntegrity",
     "coverage": "nyc npm run coverageTests && nyc report --reporter=text-lcov > .nyc_output/lcov.info",
     "coverageTests": "npm run build:dist && tape './tests/api/**/*.js' ./tests/tester.js -s --dist",
     "coveralls": "npm run coverage && if [ -n \"$COVERALLS_REPO_TOKEN\" ]; then coveralls <.nyc_output/lcov.info; fi",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "modernjs/**/*"
   ],
   "scripts": {
     "build:dist": "ethereumjs-config-build",
-    "prepublishOnly": "npm run lint && npm run build:dist && npm run testBuildIntegrity",
+    "build:dist:modernjs": "tsc -p ./tsconfig.modernjs.json",
+    "prepublishOnly": "npm run lint && npm run build:dist && npm run build:dist:modernjs && npm run testBuildIntegrity",
     "coverage": "nyc npm run coverageTests && nyc report --reporter=text-lcov > .nyc_output/lcov.info",
     "coverageTests": "npm run build:dist && tape './tests/api/**/*.js' ./tests/tester.js -s --dist",
     "coveralls": "npm run coverage && if [ -n \"$COVERALLS_REPO_TOKEN\" ]; then coveralls <.nyc_output/lcov.info; fi",

--- a/tsconfig.es2017.json
+++ b/tsconfig.es2017.json
@@ -2,7 +2,7 @@
   "extends": "@ethereumjs/config-tsc",
   "compilerOptions": {
     "target": "ES2017",
-    "outDir": "./modernjs"
+    "outDir": "./es2017"
   },
   "include": ["lib/**/*.ts"]
 }

--- a/tsconfig.modernjs.json
+++ b/tsconfig.modernjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@ethereumjs/config-tsc",
+  "compilerOptions": {
+    "target": "ES2017",
+    "outDir": "./modernjs"
+  },
+  "include": ["lib/**/*.ts"]
+}


### PR DESCRIPTION
This PR prepares the tooling to release two different builds (ES5 & ES2017) of the project in the same NPM package.

I chose the name "modernjs" to avoid using a specific ES version, as we may want to revisit which version we target in the future.