### PR TITLE
Test reporting improvements on CircleCI interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,39 @@
 version: 2
 
-defaults: &defaults
-  working_directory: ~/project/ethereumjs-vm
-  docker:
-    - image: circleci/node:8-browsers
-restore_node_modules: &restore_node_modules
-  restore_cache:
-    name: Restore node_modules cache
-    keys:
-      - v1-node-{{ .Branch }}-{{ checksum "package.json" }}
-      - v1-node-{{ checksum "package.json" }}
+aliases: 
+  - &defaults
+    working_directory: ~/project/ethereumjs-vm
+    docker:
+      - image: circleci/node:8-browsers
+
+  - &restore_node_modules
+    restore_cache:
+      name: Restore node_modules cache
+      keys:
+        - v1-node-{{ .Branch }}-{{ checksum "package.json" }}
+        - v1-node-{{ checksum "package.json" }}
+
+  - &convert_tap_to_xunit
+    run: 
+      name: convert TAP results to xunit format
+      command:  |
+        mkdir -p tests/tape;
+        cat results.tap | npx tap-xunit > tests/tape/results.xml
+      when: always
+
+  - &save_test_metadata
+    store_test_results:
+      path: tests/tape/
+
 jobs:
   install:
     <<: *defaults
     steps:
       - checkout
       - *restore_node_modules
+      - run: npm install
       - run:
-          name: npm install
+          name: Install dependencies
           command: npm install
       - save_cache:
           name: Save node_modules cache
@@ -28,6 +44,7 @@ jobs:
           root: ~/project
           paths:
             - ethereumjs-vm/
+
   lint:
     <<: *defaults
     steps:
@@ -37,6 +54,7 @@ jobs:
       - run:
           name: Lint
           command: npm run lint
+
   test_api:
     <<: *defaults
     steps:
@@ -46,6 +64,7 @@ jobs:
       - run:
           name: testAPI
           command: npm run testAPI
+
   test_api_browser:
     <<: *defaults
     steps:
@@ -55,6 +74,7 @@ jobs:
       - run:
           name: testAPI:browser
           command: npm run testAPI:browser
+  
   test_state_byzantium:
     <<: *defaults
     steps:
@@ -63,7 +83,10 @@ jobs:
       - *restore_node_modules
       - run:
           name: testStateByzantium
-          command: npm run testStateByzantium
+          command: npm run testStateByzantium | tee -a results.tap
+      - *convert_tap_to_xunit
+      - *save_test_metadata
+
   test_state_constantinople:
     <<: *defaults
     steps:
@@ -72,7 +95,10 @@ jobs:
       - *restore_node_modules
       - run:
           name: testStateConstantinople
-          command: npm run testStateConstantinople
+          command: npm run testStateConstantinople | tee -a results.tap
+      - *convert_tap_to_xunit
+      - *save_test_metadata
+
   test_state_petersburg:
     <<: *defaults
     steps:
@@ -81,7 +107,10 @@ jobs:
       - *restore_node_modules
       - run:
           name: testStatePetersburg
-          command: npm run testStatePetersburg
+          command: npm run testStatePetersburg | tee -a results.tap
+      - *convert_tap_to_xunit
+      - *save_test_metadata
+
   test_state_istanbul:
     <<: *defaults
     steps:
@@ -90,7 +119,10 @@ jobs:
       - *restore_node_modules
       - run:
           name: testStateIstanbul
-          command: npm run testStateIstanbul
+          command: npm run testStateIstanbul | tee -a results.tap
+      - *convert_tap_to_xunit
+      - *save_test_metadata
+
   test_blockchain:
     <<: *defaults
     steps:
@@ -99,7 +131,10 @@ jobs:
       - *restore_node_modules
       - run:
           name: testBlockchain
-          command: npm run testBlockchain
+          command: npm run testBlockchain | tee -a results.tap
+      - *convert_tap_to_xunit
+      - *save_test_metadata
+
   test_blockchain_petersburg:
     <<: *defaults
     steps:
@@ -108,7 +143,9 @@ jobs:
       - *restore_node_modules
       - run:
           name: testBlockchainPetersburg
-          command: npm run testBlockchainPetersburg
+          command: npm run testBlockchainPetersburg | tee -a results.tap
+      - *convert_tap_to_xunit
+      - *save_test_metadata
   coveralls:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
       - checkout
       - *restore_node_modules
-      - run: npm install
       - run:
           name: Install dependencies
           command: npm install

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "merkle-patricia-tree": "^2.3.2",
     "rustbn.js": "~0.2.0",
     "safe-buffer": "^5.1.1",
-    "tap-xunit": "^2.4.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {
@@ -93,6 +92,7 @@
     "rlp": "^2.2.3",
     "standard": "^10.0.0",
     "tap-spec": "^5.0.0",
+    "tap-xunit": "2.4.1",
     "tape": "4.6.3",
     "tslint": "^5.16.0",
     "typedoc": "^0.14.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "merkle-patricia-tree": "^2.3.2",
     "rustbn.js": "~0.2.0",
     "safe-buffer": "^5.1.1",
+    "tap-xunit": "^2.4.1",
     "util.promisify": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The main reason for this PR is to quickly identify what are the failing tests, instead of skimming through the thousands of lines in the test output.

This PR makes some changes on how tests are ran, so we can take advantage of test analysis and reporting by circleCI. Lifecycle additions:

1. Test commands got a `| tee -a results.tap` suffix. It gets `stdout` and `stderr` from tests, print them out to CI log and save them to a file, which is required for the following step.
2. The package `tap-xunit` converts the original tap format to [xunit](https://xunit.net/docs/format-xml-v2).
3. CircleCI reads that xml and produce a nice output and feed the tests metadata to their Insights platform.

Related: 
- [tape reporters](https://github.com/substack/tape#pretty-reporters)
- [xunit format](https://xunit.net/docs/format-xml-v2)
- [expanded insights via circleCI](https://circleci.com/blog/how-to-output-junit-tests-through-circleci-2-0-for-expanded-insights/)


Should all tests pass, here's the summary:

<img width="433" alt="Screen Shot 2019-11-14 at 11 52 33 AM" src="https://user-images.githubusercontent.com/47108/68887095-59f9a880-06e6-11ea-8fb9-e9eb8ff88a80.png">

Failed tests show up like this ([live example](https://circleci.com/gh/evertonfraga/ethereumjs-vm/108)):

![image](https://user-images.githubusercontent.com/47108/69183531-29987c80-0ae1-11ea-921c-7b9bfc6b0c86.png)
