### PR TITLE
chore: remove outdated cb param definition

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -136,7 +136,6 @@ export default class VM extends AsyncEventEmitter {
    * This method modifies the state.
    *
    * @param blockchain -  A [blockchain](https://github.com/ethereum/ethereumjs-blockchain) object to process
-   * @param cb - the callback function
    */
   runBlockchain(blockchain: any): Promise<void> {
     return runBlockchain.bind(this)(blockchain)


### PR DESCRIPTION
Found an outdated param definition for `cb` in `runBlockchain` which was removed when promisified in https://github.com/ethereumjs/ethereumjs-vm/pull/546