### PR TITLE
fix: properly output zero balance in examples/run-transactions-complete

### DIFF
--- a/examples/run-transactions-complete/index.ts
+++ b/examples/run-transactions-complete/index.ts
@@ -44,7 +44,7 @@ async function main() {
 
   console.log('-------results-------')
   console.log('nonce: ' + createdAccount.nonce.toString('hex'))
-  console.log('balance in wei: ' + createdAccount.balance.toString('hex'))
+  console.log('balance in wei: ', createdAccount.balance.toString('hex') || 0)
   console.log('stateRoot: ' + createdAccount.stateRoot.toString('hex'))
   console.log('codeHash: ' + createdAccount.codeHash.toString('hex'))
   console.log('---------------------')


### PR DESCRIPTION
I was trying to recreate https://github.com/ethereumjs/ethereumjs-vm/issues/234 however it looks like the example code has since been updated and the output looked good to me.

I did find that the output for the contract balance was blank like so:

```
-------results-------
nonce: 01
balance in wei:
stateRoot: 56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421
codeHash: a6db6bcd1c3757abef01cdf587304df3698a3b1e6b93667fbe87072d261ee7e1
---------------------
```

It seemed strange so digging in it looks like `createdAccount.balance.toString('hex')` outputs a blank string on zero, so this PR outputs a more friendly `0`.