### PR TITLE
github actions: cache deps, run nightly test

### DIFF
--- a/.github/workflows/vm-coverage.yml
+++ b/.github/workflows/vm-coverage.yml
@@ -1,5 +1,5 @@
 name: vm-coverage
-on: [push]
+on: [push, pull_request]
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -9,7 +9,17 @@ jobs:
           node-version: 8.x
 
       - uses: actions/checkout@v1
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node8-${{ hashFiles('**/package.json') }}
+
       - run: npm install
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+
       - run: npm run coverage
       - run: npm run coveralls
 

--- a/.github/workflows/vm-lint.yml
+++ b/.github/workflows/vm-lint.yml
@@ -1,5 +1,5 @@
 name: vm-lint
-on: [push]
+on: [push, pull_request]
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -9,7 +9,17 @@ jobs:
           node-version: 8.x
 
       - uses: actions/checkout@v1
+
+      - name: Cache node modules
+        id: cache-node-modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node8-${{ hashFiles('**/package.json') }}
+
       - run: npm install
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+
       - run: npm run lint
         env:
           CI: true

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -1,5 +1,7 @@
-name: vm-test
-on: [push, pull_request]
+name: vm-nightly-test # without caching
+on:
+  schedule:
+    - cron: '0 0 * * *' # once a day at midnight
 jobs:
   test-api:
     runs-on: ubuntu-latest
@@ -10,15 +12,7 @@ jobs:
 
       - uses: actions/checkout@v1
 
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node8-${{ hashFiles('**/package.json') }}
-
       - run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
       - run: npm run testAPI
         env:
@@ -41,15 +35,7 @@ jobs:
 
       - uses: actions/checkout@v1
 
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node8-${{ hashFiles('**/package.json') }}
-
       - run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true''
 
       - run: mkdir -p tests/tape
 
@@ -86,15 +72,7 @@ jobs:
 
       - uses: actions/checkout@v1
 
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node8-${{ hashFiles('**/package.json') }}
-
       - run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
       - run: mkdir -p tests/tape
 

--- a/.github/workflows/vm-test.yml
+++ b/.github/workflows/vm-test.yml
@@ -49,7 +49,7 @@ jobs:
           key: ${{ runner.os }}-node8-${{ hashFiles('**/package.json') }}
 
       - run: npm install
-        if: steps.cache-node-modules.outputs.cache-hit != 'true''
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
       - run: mkdir -p tests/tape
 


### PR DESCRIPTION
Adds caching of `node_modules` for faster gh action runs.

See how a cache hit looks [here](https://github.com/ethereumjs/ethereumjs-vm/pull/628/checks?check_run_id=348087266).

Note: we don't have a `package-lock.json` file in this repository so I am hashing `package.json` as the cache key instead (also what happens in current `.circleci`). @alcuadrado likes not having a `package-lock.json`  "as it forces us and the CI to experience the libraries as users would."

@evertonfraga suggested we run a nightly job without caching to catch any potential issues that may happen when an in-range dependency update breaks the build or tests, so I added `vm-nightly-test.yml` that runs without any caching.

Also accidentally missed running gh actions on `pull_request` so this PR includes that.