### PR TITLE
Add PR labeler for packages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+'package: account':
+  - package/account/*
+  - package/account/**/*
+
+'package: block':
+  - package/block/*
+  - package/block/**/*
+
+'package: blockchain':
+  - package/blockchain/*
+  - package/blockchain/**/*
+
+'package: common':
+  - package/common/*
+  - package/common/**/*
+
+'package: tx':
+  - package/tx/*
+  - package/tx/**/*
+
+'package: vm':
+  - package/vm/*
+  - package/vm/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: 'Pull Request Labeler'
+on:
+  - pull_request
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Adds a PR labeler for the new monorepo package format thanks to [actions/labeler](https://github.com/actions/labeler).

See it in action with the 2 open PRs here: https://github.com/ryanio/ethereumjs-vm/pulls

closes #629 