### PR TITLE
Add nightly slow state test

### DIFF
--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -61,3 +61,15 @@ jobs:
         run: npm run ${{ format('testBlockchain{0}', matrix.hardfork) }}
         env:
           CI: true
+
+  slow-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 8.x
+      - uses: actions/checkout@v1
+      - run: npm install
+      - run: npm run testStateIstanbul -- --runSkipped=SLOW
+        env:
+          CI: true


### PR DESCRIPTION
This PR adds a nightly slow test run.

Since my last check there are just slow state tests, and no slow blockchain tests.

See an example of the nightly slow test run [here](https://github.com/ryanio/ethereumjs-vm/commit/12f7acc94e2ac5fcae91cf7a0668655d18eb0b50/checks?check_suite_id=361578920), which succeeded in 2h 17m.

According to [here in the gh actions docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#usage-limits), "Each job in a workflow can run for up to 6 hours of execution time", which is great.

Closes one task in #610 
Closes #472