### PR TITLE
Changes EIP links to preferred citation format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ you upgrade from the first `beta` `Istanbul` release `v4.1.0`.
 - Fixed issues causing `RevertPrecompiled*` test failures
 - Fixed an issue where the `RIPEMD` precompile has to remain _touched_ even
   when the call reverts and be considered for deletion,
-  see [EIP-716](https://github.com/ethereum/EIPs/issues/716) for context
+  see [EIP issue #716](https://github.com/ethereum/EIPs/issues/716) for context
 - Updated `ethereumjs-block` to `v2.2.1`
 - Updated `ethereumjs-blockchain` to `v4.0.2`
 - Limited `ethereumjs-util` from `^6.1.0` to `~6.1.0`
@@ -91,7 +91,7 @@ on all the changes.
 
 Added EIPs:
 
-- [EIP-152](https://github.com/ethereum/EIPs/pull/2129): Blake 2b `F` precompile,
+- [EIP-152](https://eips.ethereum.org/EIPS/eip-152): Blake 2b `F` precompile,
   PR [#584](https://github.com/ethereumjs/ethereumjs-vm/pull/584)
 - [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108): Reduce `alt_bn128`
   precompile gas costs,  
@@ -102,7 +102,7 @@ Added EIPs:
 - [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884): Trie-size-dependent
   Opcode Repricing,
   PR [#581](https://github.com/ethereumjs/ethereumjs-vm/pull/581)
-- [EIP-2200](https://github.com/ethereum/EIPs/pull/2200): Rebalance net-metered
+- [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200): Rebalance net-metered
   SSTORE gas costs,
   PR [#590](https://github.com/ethereumjs/ethereumjs-vm/pull/590)
 
@@ -642,7 +642,7 @@ Thank you all very much, and thanks @axic for keeping an ongoing eye on overall 
 ## [2.4.0] - 2018-07-27
 
 With the `2.4.x` release series we now start to gradually add `Constantinople` features with the
-bitwise shifting instructions from [EIP 145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md)
+bitwise shifting instructions from [EIP 145](https://eips.ethereum.org/EIPS/eip-145)
 making the start being introduced in the `v2.4.0` release.
 
 Since both the scope of the `Constantinople` hardfork as well as the state of at least some of the EIPs

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The VM currently supports the following hardfork rules:
 - `Istanbul`
 - `MuirGlacier` (only `mainnet` and `ropsten`)
 
-If you are still looking for a [Spurious Dragon](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-607.md) compatible version of this library install the latest of the `2.2.x` series (see [Changelog](./CHANGELOG.md)).
+If you are still looking for a [Spurious Dragon](https://eips.ethereum.org/EIPS/eip-607) compatible version of this library install the latest of the `2.2.x` series (see [Changelog](./CHANGELOG.md)).
 
 ##### MuirGlacier Hardfork Support
 
@@ -35,7 +35,7 @@ since the `v4.1.1` VM release. You can activate an `Istanbul` VM by using the
 
 Supported `Istanbul` EIPs:
 
-- [EIP-152](https://github.com/ethereum/EIPs/pull/2129): Blake 2b `F` precompile,
+- [EIP-152](https://eips.ethereum.org/EIPS/eip-152): Blake 2b `F` precompile,
   PR [#584](https://github.com/ethereumjs/ethereumjs-vm/pull/584)
 - [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108): Reduce `alt_bn128`
   precompile gas costs,  
@@ -46,7 +46,7 @@ Supported `Istanbul` EIPs:
 - [EIP-1884](https://eips.ethereum.org/EIPS/eip-1884): Trie-size-dependent
   Opcode Repricing,
   PR [#581](https://github.com/ethereumjs/ethereumjs-vm/pull/581)
-- [EIP-2200](https://github.com/ethereum/EIPs/pull/2200): Rebalance net-metered
+- [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200): Rebalance net-metered
   SSTORE gas costs,
   PR [#590](https://github.com/ethereumjs/ethereumjs-vm/pull/590)
 

--- a/docs/classes/statemanager.md
+++ b/docs/classes/statemanager.md
@@ -221,7 +221,7 @@ ___
 
 *Defined in [state/stateManager.ts:554](https://github.com/ethereumjs/ethereumjs-vm/blob/439570a/lib/state/stateManager.ts#L554)*
 
-Checks if the `account` corresponding to `address` is empty as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).
+Checks if the `account` corresponding to `address` is empty as defined in [EIP-161](https://eips.ethereum.org/EIPS/eip-161).
 
 **Parameters:**
 
@@ -260,7 +260,7 @@ ___
 
 *Defined in [state/stateManager.ts:575](https://github.com/ethereumjs/ethereumjs-vm/blob/439570a/lib/state/stateManager.ts#L575)*
 
-Removes accounts form the state trie that have been touched, as defined in EIP-161 ([https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md)).
+Removes accounts form the state trie that have been touched, as defined in [EIP-161](https://eips.ethereum.org/EIPS/eip-161).
 
 **Parameters:**
 

--- a/lib/state/stateManager.ts
+++ b/lib/state/stateManager.ts
@@ -110,7 +110,7 @@ export default class StateManager {
 
   /**
    * Marks an account as touched, according to the definition
-   * in [EIP-158](https://github.com/ethereum/EIPs/issues/158).
+   * in [EIP-158](https://eips.ethereum.org/EIPS/eip-158).
    * This happens when the account is triggered for a state-changing
    * event. Touched accounts that are empty will be cleared
    * at the end of the tx.
@@ -385,7 +385,7 @@ export default class StateManager {
       throw new Error('Reverting to invalid state checkpoint failed')
     }
     // Exceptional case due to consensus issue in Geth and Parity.
-    // See [EIP-716](https://github.com/ethereum/EIPs/issues/716) for context.
+    // See [EIP issue #716](https://github.com/ethereum/EIPs/issues/716) for context.
     // The RIPEMD precompile has to remain *touched* even when the call reverts,
     // and be considered for deletion.
     if (this._touched.has(ripemdPrecompileAddress)) {
@@ -566,7 +566,7 @@ export default class StateManager {
 
   /**
    * Checks if the `account` corresponding to `address` is empty as defined in
-   * EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md).
+   * EIP-161 (https://eips.ethereum.org/EIPS/eip-161).
    * @param address - Address to check
    * @param {accountIsEmpty~callback} cb
    */
@@ -588,7 +588,7 @@ export default class StateManager {
 
   /**
    * Removes accounts form the state trie that have been touched,
-   * as defined in EIP-161 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md).
+   * as defined in EIP-161 (https://eips.ethereum.org/EIPS/eip-161).
    * @param cb - Callback function
    */
   cleanupTouchedAccounts(cb: any): void {


### PR DESCRIPTION
While updating the links across the 6 repos for the migration, I bumped into these different formats for EIP links. As they does not impact the migration, I decided to update them now.

> **Preferred Citation Format [1]**
> The canonical URL for a EIP that has achieved draft status at any point is at https://eips.ethereum.org/. For example, the canonical URL for EIP-1 is https://eips.ethereum.org/EIPS/eip-1.

[Reference](https://github.com/ethereum/EIPs/blob/af677b348da866d41a58d8948a89d0b00d410e2b/README.md#preferred-citation-format).