### PR TITLE
Switch from Coveralls to Codecov

### DIFF
--- a/.github/workflows/vm-coverage.yml
+++ b/.github/workflows/vm-coverage.yml
@@ -22,8 +22,7 @@ jobs:
 
       - run: npm run coverage
 
-      - name: Post coverage data to Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: .nyc_output/lcov.info
+          flags: vm

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Package](https://img.shields.io/npm/v/ethereumjs-vm.svg?style=flat-square)](https://www.npmjs.org/package/ethereumjs-vm)
 [![Actions Status](https://github.com/ethereumjs/ethereumjs-vm/workflows/vm-test/badge.svg)](https://github.com/ethereumjs/ethereumjs-vm/actions)
-[![Coverage Status](https://img.shields.io/coveralls/ethereumjs/ethereumjs-vm.svg?style=flat-square)](https://coveralls.io/r/ethereumjs/ethereumjs-vm)
+[![Code Coverage](https://codecov.io/gh/ethereumjs/ethereumjs-vm/branch/master/graph/badge.svg)](https://codecov.io/gh/ethereumjs/ethereumjs-vm)
 [![Gitter](https://img.shields.io/gitter/room/ethereum/ethereumjs.svg?style=flat-square)](https://gitter.im/ethereum/ethereumjs)
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "ethereumjs-vm",
   "version": "4.1.2",
@@ -10,9 +11,8 @@
   "scripts": {
     "build:dist": "ethereumjs-config-build",
     "prepublishOnly": "npm run lint && npm run build:dist && npm run testBuildIntegrity",
-    "coverage": "nyc npm run coverage:test && nyc report --reporter=text-lcov > .nyc_output/lcov.info",
+    "coverage": "nyc npm run coverage:test && nyc report --reporter=lcov",
     "coverage:test": "npm run build:dist && tape './tests/api/**/*.js' ./tests/tester.js --state --dist",
-    "coveralls": "npm run coverage && if [ -n \"$COVERALLS_REPO_TOKEN\" ]; then coveralls <.nyc_output/lcov.info; fi",
     "docs:build": "typedoc lib",
     "test:vm": "node ./tests/tester --vm",
     "test:state": "npm run build:dist && node ./tests/tester --state --dist",
@@ -72,7 +72,6 @@
     "@types/lru-cache": "^5.1.0",
     "@types/node": "^11.13.4",
     "browserify": "^16.2.3",
-    "coveralls": "^3.0.0",
     "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.3.0",
     "husky": "^2.1.0",
     "karma": "^4.0.1",


### PR DESCRIPTION
Unfortunately Coveralls does not have any support for monorepos or merging reports. There are some tools we can use to merge the reports before submitting to Coveralls however their UI won't give us any detailed insights other than a combined coverage number which is not very useful.

@evertonfraga found Codecov does have this feature, and it is supported well: [Merging Reports](https://docs.codecov.io/docs/merging-reports)

Codecov is also free for public repos.

This PR is an initial step to switch `ethereumjs-vm` to Codecov, and if liked and approved, I can apply it toward the other pending monorepo repos.

I also like [Codecov bot's comments](https://github.com/ryanio/ethereumjs-vm/pull/8#issuecomment-567267115) which are much more detailed than Coveralls. I believe @holgerd77 you can enable them by installing the [Codecov Github App](https://github.com/apps/codecov).