### PR TITLE
Fix getOpcodesForHF for when HF > istanbul

### DIFF
--- a/lib/evm/opcodes.ts
+++ b/lib/evm/opcodes.ts
@@ -1,3 +1,5 @@
+import Common from 'ethereumjs-common'
+
 export interface Opcode {
   name: string
   fee: number
@@ -180,8 +182,8 @@ const istanbulOpcodes: OpcodeList = {
   0x54: { name: 'SLOAD', fee: 800, isAsync: true },
 }
 
-export function getOpcodesForHF(hf: string) {
-  if (hf === 'istanbul') {
+export function getOpcodesForHF(common: Common) {
+  if (common.gteHardfork('istanbul')) {
     return { ...opcodes, ...istanbulOpcodes }
   } else {
     return { ...opcodes }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -110,7 +110,7 @@ export default class VM extends AsyncEventEmitter {
     }
 
     // Set list of opcodes based on HF
-    this._opcodes = getOpcodesForHF(this._common.hardfork()!)
+    this._opcodes = getOpcodesForHF(this._common)
 
     if (opts.stateManager) {
       this.stateManager = opts.stateManager

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -43,7 +43,7 @@ tape('VM with default blockchain', (t) => {
   })
 
   t.test('should accept a common object as option', (st) => {
-    const common = new Common('mainnet')
+    const common = new Common('mainnet', 'istanbul')
 
     const vm = new VM({ common })
     st.equal(vm._common, common)

--- a/tests/api/opcodes.js
+++ b/tests/api/opcodes.js
@@ -1,0 +1,26 @@
+const tape = require('tape')
+const { getOpcodesForHF } = require('../../dist/evm/opcodes')
+const Common = require('ethereumjs-common').default
+
+const CHAINID = 0x46
+
+tape('getOpcodesForHF', (t) => {
+  t.test('shouldnt apply istanbul opcode changes for petersburg', (st) => {
+    const c = new Common('mainnet', 'petersburg')
+    const opcodes = getOpcodesForHF(c)
+    st.assert(opcodes[CHAINID] === undefined)
+    st.end()
+  })
+
+  t.test('should correctly apply istanbul opcode when hf >= istanbul', (st) => {
+    let c = new Common('mainnet', 'istanbul')
+    let opcodes = getOpcodesForHF(c)
+    st.equal(opcodes[CHAINID].name, 'CHAINID')
+
+    c = new Common('mainnet', 'muirGlacier')
+    opcodes = getOpcodesForHF(c)
+    st.equal(opcodes[CHAINID].name, 'CHAINID')
+
+    st.end()
+  })
+})


### PR DESCRIPTION
When adding support for Istanbul opcode changes in https://github.com/ethereumjs/ethereumjs-vm/pull/582, I had taken an approach that was prone to errors when adding new hardforks, and this has happened. Muir Glacier doesn't inherit the opcode changes from istanbul.

I think it's still open how to approach opcode info for HFs, but for now I've changed the condition in `getOpcodesForHF` to apply istanbul changes to every HF gte Istanbul. Also added tests.

This needs to be released soon as it affects evm execution in Muir Glacier.