### PR TITLE
Run Consensus Tests on MuirGlacier

### DIFF
--- a/.github/workflows/vm-test.yml
+++ b/.github/workflows/vm-test.yml
@@ -54,7 +54,7 @@ jobs:
       - run: npm install
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
 
-      - run: npm run test:state:allForks
+      - run: npm run test:state:selectedForks
         env:
           CI: true
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:vm": "node ./tests/tester --vm",
     "test:state": "npm run build:dist && node ./tests/tester --state --dist",
     "test:state:allForks": "npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
+    "test:state:selectedForks": "npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "npm run build:dist && node --stack-size=1500 ./tests/tester --blockchain --dist",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs:build": "typedoc lib",
     "test:vm": "node ./tests/tester --vm",
     "test:state": "npm run build:dist && node ./tests/tester --state --dist",
-    "test:state:allForks": "npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul",
+    "test:state:allForks": "npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "npm run build:dist && node --stack-size=1500 ./tests/tester --blockchain --dist",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:vm": "node ./tests/tester --vm",
     "test:state": "npm run build:dist && node ./tests/tester --state --dist",
     "test:state:allForks": "npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
-    "test:state:selectedForks": "npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
+    "test:state:selectedForks": "npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "npm run build:dist && node --stack-size=1500 ./tests/tester --blockchain --dist",

--- a/tests/BlockchainTestsRunner.js
+++ b/tests/BlockchainTestsRunner.js
@@ -20,7 +20,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
   }
   var blockchain = new Blockchain({
     db: blockchainDB,
-    hardfork: options.forkConfig.toLowerCase(),
+    hardfork: options.forkConfigVM,
     validate: validate
   })
   if (validate) {
@@ -35,9 +35,9 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
   var vm = new VM({
     state: state,
     blockchain: blockchain,
-    hardfork: options.forkConfig.toLowerCase()
+    hardfork: options.forkConfigVM
   })
-  var genesisBlock = new Block({ hardfork: options.forkConfig.toLowerCase() })
+  var genesisBlock = new Block({ hardfork: options.forkConfigVM })
 
   testData.homestead = true
   if (testData.homestead) {
@@ -60,7 +60,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
     function (done) {
       // create and add genesis block
       genesisBlock.header = new BlockHeader(formatBlockHeader(testData.genesisBlockHeader), {
-        hardfork: options.forkConfig.toLowerCase()
+        hardfork: options.forkConfigVM
       })
       t.equal(state.root.toString('hex'), genesisBlock.header.stateRoot.toString('hex'), 'correct pre stateRoot')
       if (testData.genesisRLP) {
@@ -74,7 +74,7 @@ module.exports = function runBlockchainTest (options, testData, t, cb) {
       async.eachSeries(testData.blocks, function (raw, cb) {
         try {
           var block = new Block(Buffer.from(raw.rlp.slice(2), 'hex'), {
-            hardfork: options.forkConfig.toLowerCase()
+            hardfork: options.forkConfigVM
           })
           // forces the block into thinking they are homestead
           if (testData.homestead) {

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -178,7 +178,7 @@ function runTests(name, runnerArgs, cb) {
       const runner = require(`./${name}Runner.js`)
       // Tests for HFs before Istanbul have been moved under `LegacyTests/Constantinople`:
       // https://github.com/ethereum/tests/releases/tag/v7.0.0-beta.1
-      if (runnerArgs.forkConfig !== 'Istanbul') {
+      if (testGetterArgs.forkConfig !== 'Istanbul') {
         name = 'LegacyTests/Constantinople/'.concat(name)
       }
       testing

--- a/tests/tester.js
+++ b/tests/tester.js
@@ -3,8 +3,11 @@
 const argv = require('minimist')(process.argv.slice(2))
 const tape = require('tape')
 const testing = require('ethereumjs-testing')
-const FORK_CONFIG = argv.fork || 'Istanbul'
 const { getRequiredForkConfigAlias } = require('./util')
+const FORK_CONFIG = (argv.fork || 'Istanbul')
+const FORK_CONFIG_TEST_SUITE = getRequiredForkConfigAlias(FORK_CONFIG)
+// Istanbul -> istanbul, MuirGlacier -> muirGlacier
+const FORK_CONFIG_VM = FORK_CONFIG.charAt(0).toLowerCase() + FORK_CONFIG.substring(1)
 // tests which should be fixed
 const skipBroken = [
   'dynamicAccountOverwriteEmpty', // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
@@ -138,7 +141,7 @@ function runTests(name, runnerArgs, cb) {
   testGetterArgs.skipTests = getSkipTests(argv.skip, argv.runSkipped ? 'NONE' : 'ALL')
   testGetterArgs.runSkipped = getSkipTests(argv.runSkipped, 'NONE')
   testGetterArgs.skipVM = skipVM
-  testGetterArgs.forkConfig = getRequiredForkConfigAlias(FORK_CONFIG)
+  testGetterArgs.forkConfig = FORK_CONFIG_TEST_SUITE
   testGetterArgs.file = argv.file
   testGetterArgs.test = argv.test
   testGetterArgs.dir = argv.dir
@@ -147,7 +150,8 @@ function runTests(name, runnerArgs, cb) {
 
   testGetterArgs.customStateTest = argv.customStateTest
 
-  runnerArgs.forkConfig = FORK_CONFIG
+  runnerArgs.forkConfigVM = FORK_CONFIG_VM
+  runnerArgs.forkConfigTestSuite = FORK_CONFIG_TEST_SUITE
   runnerArgs.jsontrace = argv.jsontrace
   runnerArgs.debug = argv.debug // for BlockchainTests
 

--- a/tests/util.js
+++ b/tests/util.js
@@ -403,6 +403,11 @@ exports.setupPreConditions = function (state, testData, done) {
  * @returns {String} Either an alias of the forkConfig param, or the forkConfig param itself
  */
 exports.getRequiredForkConfigAlias = function (forkConfig) {
+  // Run the Istanbul tests for MuirGlacier since there are no dedicated tests
+  if (String(forkConfig).match(/^muirGlacier/i)) {
+    return 'Istanbul'
+  }
+  // Petersburg is named ConstantinopleFix in the client-independent consensus test suite
   if (String(forkConfig).match(/^petersburg$/i)) {
     return 'ConstantinopleFix'
   }


### PR DESCRIPTION
The HF comparison error fixed in https://github.com/ethereumjs/ethereumjs-vm/pull/647 by @s1na was one of the most severe bugs in recent times, it actually makes the whole MuirGlacier pretty much unusable (this needs a bug fix release ASAP).

I am actually still amazed that this could slip through, this might need some further postmortem analysis. One major reason is actually the lack of consensus tests for the MuirGlacier HF.

This PR allows the VM to be tested with the MuirGlacier HF setting by falling back to the Istanbul tests. I also did some cleanup of the fork configuration in the test runner so to have a better distinction between the fork names/aliases used in the VM and the test runner.

I tested this with the pre #647 state of the VM (so what was actually released as the MuirGlacier release). Most of the consensus tests fail here.