### PR TITLE
Add codeAddress to step event

### DIFF
--- a/lib/evm/eei.ts
+++ b/lib/evm/eei.ts
@@ -25,6 +25,8 @@ export interface Env {
   origin: Buffer
   block: any
   contract: Account
+  // Different than address for DELEGATECALL and CALLCODE
+  codeAddress: Buffer
 }
 
 /**

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -282,6 +282,7 @@ export default class EVM {
       origin: this._tx.origin || message.caller || zeros(32),
       block: this._block || new Block(),
       contract: await this._state.getAccount(message.to || zeros(32)),
+      codeAddress: message.codeAddress,
     }
     const eei = new EEI(env, this._state, this, this._vm._common, message.gasLimit.clone())
     if (message.selfdestruct) {

--- a/lib/evm/interpreter.ts
+++ b/lib/evm/interpreter.ts
@@ -44,6 +44,7 @@ export interface InterpreterStep {
   memoryWordCount: BN
   opcode: Opcode
   account: Account
+  codeAddress: Buffer
 }
 
 /**
@@ -186,6 +187,7 @@ export default class Interpreter {
       stateManager: this._runState.stateManager,
       memory: this._runState.memory._store, // Return underlying array for backwards-compatibility
       memoryWordCount: this._runState.memoryWordCount,
+      codeAddress: this._eei._env.codeAddress,
     }
     /**
      * The `step` event for trace output


### PR DESCRIPTION
`DELEGATECALL` and `CALLCODE` call the code of contract B in the context of contract A. So that the environment's address is still A, but B's code is being executed. I need a reliable way of knowing which contract's code is being executed atm so I added `codeAddress` to the `step` event.