### PR TITLE
Add State Manager API tests to karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,15 +8,13 @@ module.exports = function(config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['browserify', 'detectBrowsers', 'tap'],
+    frameworks: ['browserify', 'tap'],
 
     // list of files / patterns to load in the browser
     files: ['./tests/api/**/*.js'],
 
     // list of files / patterns to exclude
-    exclude: [
-      './tests/api/state/stateManager.js', // 4, "# should clear the cache when the state root is set"
-    ],
+    exclude: [],
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
@@ -44,20 +42,11 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['FirefoxHeadless'],
+    browsers: ['FirefoxHeadless', 'ChromeHeadless'],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
     singleRun: true,
-
-    // karma-detect-browsers plugin config
-    detectBrowsers: {
-      enabled: true,
-      usePhantomJS: false,
-      postDetection: function(availableBrowsers) {
-        return ['FirefoxHeadless']
-      },
-    },
 
     // Concurrency level
     // how many browser should be started simultaneous

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "karma": "^4.0.1",
     "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.2.0",
-    "karma-detect-browsers": "^2.3.3",
     "karma-firefox-launcher": "^1.1.0",
     "karma-tap": "^4.1.4",
     "level": "^4.0.0",

--- a/tests/util.js
+++ b/tests/util.js
@@ -6,67 +6,70 @@ const Account = require('ethereumjs-account').default
 const Transaction = require('ethereumjs-tx').Transaction
 const Block = require('ethereumjs-block')
 
-exports.dumpState = function (state, cb) {
-  function readAccounts (state) {
+exports.dumpState = function(state, cb) {
+  function readAccounts(state) {
     return new Promise((resolve, reject) => {
       let accounts = []
       var rs = state.createReadStream()
-      rs.on('data', function (data) {
+      rs.on('data', function(data) {
         let account = new Account(data.value)
         account.address = data.key
         accounts.push(account)
       })
 
-      rs.on('end', function () {
+      rs.on('end', function() {
         resolve(accounts)
       })
     })
   }
 
-  function readStorage (state, account) {
+  function readStorage(state, account) {
     return new Promise((resolve, reject) => {
       let storage = {}
       let storageTrie = state.copy()
       storageTrie.root = account.stateRoot
       let storageRS = storageTrie.createReadStream()
 
-      storageRS.on('data', function (data) {
+      storageRS.on('data', function(data) {
         storage[data.key.toString('hex')] = data.value.toString('hex')
       })
 
-      storageRS.on('end', function () {
+      storageRS.on('end', function() {
         resolve(storage)
       })
     })
   }
 
-  readAccounts(state).then(function (accounts) {
-    async.mapSeries(accounts, function (account, cb) {
-      readStorage(state, account).then((storage) => {
-        account.storage = storage
-        cb(null, account)
-      })
-    },
-    function (err, results) {
-      if (err) {
-        cb(err, null)
-      }
-      for (let i = 0; i < results.length; i++) {
-        console.log('SHA3\'d address: ' + results[i].address.toString('hex'))
-        console.log('\tstate root: ' + results[i].stateRoot.toString('hex'))
-        console.log('\tstorage: ')
-        for (let storageKey in results[i].storage) {
-          console.log('\t\t' + storageKey + ': ' + results[i].storage[storageKey])
+  readAccounts(state).then(function(accounts) {
+    async.mapSeries(
+      accounts,
+      function(account, cb) {
+        readStorage(state, account).then(storage => {
+          account.storage = storage
+          cb(null, account)
+        })
+      },
+      function(err, results) {
+        if (err) {
+          cb(err, null)
         }
-        console.log('\tnonce: ' + (new BN(results[i].nonce)).toString())
-        console.log('\tbalance: ' + (new BN(results[i].balance)).toString())
-      }
-      return cb()
-    })
+        for (let i = 0; i < results.length; i++) {
+          console.log("SHA3'd address: " + results[i].address.toString('hex'))
+          console.log('\tstate root: ' + results[i].stateRoot.toString('hex'))
+          console.log('\tstorage: ')
+          for (let storageKey in results[i].storage) {
+            console.log('\t\t' + storageKey + ': ' + results[i].storage[storageKey])
+          }
+          console.log('\tnonce: ' + new BN(results[i].nonce).toString())
+          console.log('\tbalance: ' + new BN(results[i].balance).toString())
+        }
+        return cb()
+      },
+    )
   })
 }
 
-var format = exports.format = function (a, toZero, isHex) {
+var format = (exports.format = function(a, toZero, isHex) {
   if (a === '') {
     return Buffer.alloc(0)
   }
@@ -87,14 +90,14 @@ var format = exports.format = function (a, toZero, isHex) {
   }
 
   return a
-}
+})
 
 /**
  * makeTx using JSON from tests repo
  * @param {[type]} txData the transaction object from tests repo
  * @returns {Object}        object that will be passed to VM.runTx function
  */
-exports.makeTx = function (txData, hf) {
+exports.makeTx = function(txData, hf) {
   var tx = new Transaction({}, { hardfork: hf })
   tx.nonce = format(txData.nonce)
   tx.gasPrice = format(txData.gasPrice)
@@ -113,7 +116,7 @@ exports.makeTx = function (txData, hf) {
   return tx
 }
 
-exports.verifyPostConditions = function (state, testData, t, cb) {
+exports.verifyPostConditions = function(state, testData, t, cb) {
   var hashedAccounts = {}
   var keyMap = {}
 
@@ -123,13 +126,13 @@ exports.verifyPostConditions = function (state, testData, t, cb) {
     keyMap[hash] = key
   }
 
-  var q = async.queue(function (task, cb2) {
+  var q = async.queue(function(task, cb2) {
     exports.verifyAccountPostConditions(state, task.address, task.account, task.testData, t, cb2)
   }, 1)
 
   var stream = state.createReadStream()
 
-  stream.on('data', function (data) {
+  stream.on('data', function(data) {
     var acnt = new Account(rlp.decode(data.value))
     var key = data.key.toString('hex')
     var testData = hashedAccounts[key]
@@ -140,15 +143,15 @@ exports.verifyPostConditions = function (state, testData, t, cb) {
       q.push({
         address: address,
         account: acnt,
-        testData: testData
+        testData: testData,
       })
     } else {
       t.fail('invalid account in the trie: ' + key)
     }
   })
 
-  stream.on('end', function () {
-    function onEnd () {
+  stream.on('end', function() {
+    function onEnd() {
       for (hash in keyMap) {
         t.fail('Missing account!: ' + keyMap[hash])
       }
@@ -171,10 +174,18 @@ exports.verifyPostConditions = function (state, testData, t, cb) {
  * @param {[type]}   acctData postconditions JSON from tests repo
  * @param {Function} cb       completion callback
  */
-exports.verifyAccountPostConditions = function (state, address, account, acctData, t, cb) {
+exports.verifyAccountPostConditions = function(state, address, account, acctData, t, cb) {
   t.comment('Account: ' + address)
-  t.equal(format(account.balance, true).toString('hex'), format(acctData.balance, true).toString('hex'), 'correct balance')
-  t.equal(format(account.nonce, true).toString('hex'), format(acctData.nonce, true).toString('hex'), 'correct nonce')
+  t.equal(
+    format(account.balance, true).toString('hex'),
+    format(acctData.balance, true).toString('hex'),
+    'correct balance',
+  )
+  t.equal(
+    format(account.nonce, true).toString('hex'),
+    format(acctData.nonce, true).toString('hex'),
+    'correct nonce',
+  )
 
   // validate storage
   var origRoot = state.root
@@ -182,19 +193,23 @@ exports.verifyAccountPostConditions = function (state, address, account, acctDat
 
   var hashedStorage = {}
   for (var key in acctData.storage) {
-    hashedStorage[utils.keccak256(utils.setLength(Buffer.from(key.slice(2), 'hex'), 32)).toString('hex')] = acctData.storage[key]
+    hashedStorage[
+      utils.keccak256(utils.setLength(Buffer.from(key.slice(2), 'hex'), 32)).toString('hex')
+    ] = acctData.storage[key]
   }
 
   if (storageKeys.length > 0) {
     state.root = account.stateRoot
     var rs = state.createReadStream()
-    rs.on('data', function (data) {
+    rs.on('data', function(data) {
       var key = data.key.toString('hex')
       var val = '0x' + rlp.decode(data.value).toString('hex')
 
       if (key === '0x') {
         key = '0x00'
-        acctData.storage['0x00'] = acctData.storage['0x00'] ? acctData.storage['0x00'] : acctData.storage['0x']
+        acctData.storage['0x00'] = acctData.storage['0x00']
+          ? acctData.storage['0x00']
+          : acctData.storage['0x']
         delete acctData.storage['0x']
       }
 
@@ -202,7 +217,7 @@ exports.verifyAccountPostConditions = function (state, address, account, acctDat
       delete hashedStorage[key]
     })
 
-    rs.on('end', function () {
+    rs.on('end', function() {
       for (var key in hashedStorage) {
         if (hashedStorage[key] !== '0x00') {
           t.fail('key: ' + key + ' not found in storage')
@@ -222,7 +237,7 @@ exports.verifyAccountPostConditions = function (state, address, account, acctDat
  * @param {Object} results  to verify
  * @param {Object} testData from tests repo
  */
-exports.verifyGas = function (results, testData, t) {
+exports.verifyGas = function(results, testData, t) {
   var coinbaseAddr = testData.env.currentCoinbase
   var preBal = testData.pre[coinbaseAddr] ? testData.pre[coinbaseAddr].balance : 0
 
@@ -245,13 +260,13 @@ exports.verifyGas = function (results, testData, t) {
  * @param {Object} results  to verify
  * @param {Object} testData from tests repo
  */
-exports.verifyLogs = function (logs, testData, t) {
+exports.verifyLogs = function(logs, testData, t) {
   if (testData.logs) {
-    testData.logs.forEach(function (log, i) {
+    testData.logs.forEach(function(log, i) {
       var rlog = logs[i]
       t.equal(rlog[0].toString('hex'), log.address, 'log: valid address')
       t.equal('0x' + rlog[2].toString('hex'), log.data, 'log: valid data')
-      log.topics.forEach(function (topic, i) {
+      log.topics.forEach(function(topic, i) {
         t.equal(rlog[1][i].toString('hex'), topic, 'log: invalid topic')
       })
     })
@@ -263,7 +278,7 @@ exports.verifyLogs = function (logs, testData, t) {
  * @param  {Buffer}
  * @returns {String}
  */
-exports.toDecimal = function (buffer) {
+exports.toDecimal = function(buffer) {
   return new BN(buffer).toString()
 }
 
@@ -272,7 +287,7 @@ exports.toDecimal = function (buffer) {
  * @param {String}
  *  @returns {Buffer}
  */
-exports.fromDecimal = function (string) {
+exports.fromDecimal = function(string) {
   return Buffer.from(new BN(string).toArray())
 }
 
@@ -281,7 +296,7 @@ exports.fromDecimal = function (string) {
  * @param  {String} hexString address for example '0x03'
  * @returns {Buffer}
  */
-exports.fromAddress = function (hexString) {
+exports.fromAddress = function(hexString) {
   return utils.setLength(Buffer.from(new BN(hexString.slice(2), 16).toArray()), 32)
 }
 
@@ -290,11 +305,11 @@ exports.fromAddress = function (hexString) {
  * @param {String} hexCode string from tests repo
  * @returns {Buffer}
  */
-exports.toCodeHash = function (hexCode) {
+exports.toCodeHash = function(hexCode) {
   return utils.keccak256(Buffer.from(hexCode.slice(2), 'hex'))
 }
 
-exports.makeBlockHeader = function (data) {
+exports.makeBlockHeader = function(data) {
   var header = {}
   header.timestamp = format(data.currentTimestamp)
   header.gasLimit = format(data.currentGasLimit)
@@ -313,11 +328,11 @@ exports.makeBlockHeader = function (data) {
  * @param {Object} transactions transactions for the block
  * @returns {Object} the block
  */
-exports.makeBlockFromEnv = function (env, transactions) {
+exports.makeBlockFromEnv = function(env, transactions) {
   return new Block({
     header: exports.makeBlockHeader(env),
     transactions: transactions || {},
-    uncleHeaders: []
+    uncleHeaders: [],
   })
 }
 
@@ -329,7 +344,7 @@ exports.makeBlockFromEnv = function (env, transactions) {
  * @param {Object} block   that the transaction belongs to
  * @returns {Object}       object that will be passed to VM.runCode function
  */
-exports.makeRunCodeData = function (exec, account, block) {
+exports.makeRunCodeData = function(exec, account, block) {
   return {
     account: account,
     origin: format(exec.origin, false, true),
@@ -340,7 +355,7 @@ exports.makeRunCodeData = function (exec, account, block) {
     data: format(exec.data), // slice off 0x
     gasLimit: format(exec.gas),
     gasPrice: format(exec.gasPrice),
-    block: block
+    block: block,
   }
 }
 
@@ -350,51 +365,65 @@ exports.makeRunCodeData = function (exec, account, block) {
  * @param {[type]}   testData - JSON from tests repo
  * @param {Function} done     - callback when function is completed
  */
-exports.setupPreConditions = function (state, testData, done) {
+exports.setupPreConditions = function(state, testData, done) {
   var keysOfPre = Object.keys(testData.pre)
 
-  async.eachSeries(keysOfPre, function (key, callback) {
-    var acctData = testData.pre[key]
-    var account = new Account()
+  async.eachSeries(
+    keysOfPre,
+    function(key, callback) {
+      var acctData = testData.pre[key]
+      var account = new Account()
 
-    account.nonce = format(acctData.nonce)
-    account.balance = format(acctData.balance)
+      account.nonce = format(acctData.nonce)
+      account.balance = format(acctData.balance)
 
-    var codeBuf = Buffer.from(acctData.code.slice(2), 'hex')
-    var storageTrie = state.copy()
-    storageTrie.root = null
+      var codeBuf = Buffer.from(acctData.code.slice(2), 'hex')
+      var storageTrie = state.copy()
+      storageTrie.root = null
 
-    async.series([
+      async.series(
+        [
+          function(cb2) {
+            var keys = Object.keys(acctData.storage)
 
-      function (cb2) {
-        var keys = Object.keys(acctData.storage)
+            async.forEachSeries(
+              keys,
+              function(key, cb3) {
+                const valBN = new BN(acctData.storage[key].slice(2), 16)
+                if (valBN.isZero()) {
+                  return cb3()
+                }
+                let val = rlp.encode(valBN.toArrayLike(Buffer, 'be'))
+                key = utils.setLength(Buffer.from(key.slice(2), 'hex'), 32)
 
-        async.forEachSeries(keys, function (key, cb3) {
-          const valBN = new BN(acctData.storage[key].slice(2), 16)
-          if (valBN.isZero()) {
-            return cb3()
-          }
-          let val = rlp.encode(valBN.toArrayLike(Buffer, 'be'))
-          key = utils.setLength(Buffer.from(key.slice(2), 'hex'), 32)
+                storageTrie.put(key, val, cb3)
+              },
+              cb2,
+            )
+          },
+          function(cb2) {
+            account.setCode(state, codeBuf, cb2)
+          },
+          function(cb2) {
+            account.stateRoot = storageTrie.root
 
-          storageTrie.put(key, val, cb3)
-        }, cb2)
-      },
-      function (cb2) {
-        account.setCode(state, codeBuf, cb2)
-      },
-      function (cb2) {
-        account.stateRoot = storageTrie.root
-
-        if (testData.exec && key === testData.exec.address) {
-          testData.root = storageTrie.root
-        }
-        state.put(Buffer.from(utils.stripHexPrefix(key), 'hex'), account.serialize(), function () {
-          cb2()
-        })
-      }
-    ], callback)
-  }, done)
+            if (testData.exec && key === testData.exec.address) {
+              testData.root = storageTrie.root
+            }
+            state.put(
+              Buffer.from(utils.stripHexPrefix(key), 'hex'),
+              account.serialize(),
+              function() {
+                cb2()
+              },
+            )
+          },
+        ],
+        callback,
+      )
+    },
+    done,
+  )
 }
 
 /**
@@ -402,7 +431,7 @@ exports.setupPreConditions = function (state, testData, done) {
  * @param {String} forkConfig - the name of the hardfork for which an alias should be returned
  * @returns {String} Either an alias of the forkConfig param, or the forkConfig param itself
  */
-exports.getRequiredForkConfigAlias = function (forkConfig) {
+exports.getRequiredForkConfigAlias = function(forkConfig) {
   // Run the Istanbul tests for MuirGlacier since there are no dedicated tests
   if (String(forkConfig).match(/^muirGlacier/i)) {
     return 'Istanbul'
@@ -412,4 +441,12 @@ exports.getRequiredForkConfigAlias = function (forkConfig) {
     return 'ConstantinopleFix'
   }
   return forkConfig
+}
+
+/**
+ * Checks if in a karma test runner.
+ * @returns {bool} is running in karma
+ */
+exports.isRunningInKarma = () => {
+  return typeof window !== 'undefined' && window.__karma__
 }


### PR DESCRIPTION
This PR:
1. Adds `tests/api/state/stateManager.js` back to karma.
1. Skips slow test when running in karma: `should generate the genesis state root correctly for mainnet`
1. Modifies test `should generate correct genesis state root for all chains` to `should generate the genesis state root correctly for all other chains` (since mainnet is already tested prior).
1. Runs karma in both headless Firefox and Chrome for increased browser coverage.
1. Removes unneeded `karma-detect-browsers`.


Closes #465