### PR TITLE
Running API tests with ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "node -r ts-node/register --stack-size=1500 ./tests/tester --blockchain",
-    "test:API": "npm run build && node ./node_modules/tape/bin/tape './tests/api/**/*.js'",
+    "test:API": "npm run build && ts-node ./node_modules/tape/bin/tape './tests/api/**/*.js'",
     "test:API:browser": "npm run build && karma start karma.conf.js",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
     "tslint": "ethereumjs-config-tslint",


### PR DESCRIPTION
This little change aims to allow cross-package tests using TypeScript + Lerna.

It solves the problem below, in the monorepo context: 

![image](https://user-images.githubusercontent.com/47108/74282291-def85c00-4ced-11ea-8328-b7d2a004031e.png)
