### PR TITLE
[WIP] Add precompiledContracts VM option

### DIFF
--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -10,7 +10,7 @@ import {
 import Account from 'ethereumjs-account'
 import { ERROR, VmError } from '../exceptions'
 import PStateManager from '../state/promisified'
-import { getPrecompile, PrecompileFunc, Precompiles, ripemdPrecompileAddress } from './precompiles'
+import { PrecompileFunc, Precompiles } from './precompiles'
 import TxContext from './txContext'
 import Message from './message'
 import EEI from './eei'
@@ -331,7 +331,7 @@ export default class EVM {
    * if no such precompile exists.
    */
   getPrecompile(address: Buffer): PrecompileFunc {
-    return getPrecompile(address.toString('hex'))
+    return this._precompiledContracts[address.toString('hex')]
   }
 
   /**

--- a/lib/evm/evm.ts
+++ b/lib/evm/evm.ts
@@ -10,7 +10,7 @@ import {
 import Account from 'ethereumjs-account'
 import { ERROR, VmError } from '../exceptions'
 import PStateManager from '../state/promisified'
-import { getPrecompile, PrecompileFunc, ripemdPrecompileAddress } from './precompiles'
+import { getPrecompile, PrecompileFunc, Precompiles, ripemdPrecompileAddress } from './precompiles'
 import TxContext from './txContext'
 import Message from './message'
 import EEI from './eei'
@@ -100,6 +100,7 @@ export default class EVM {
    * Amount of gas to refund from deleting storage values
    */
   _refund: BN
+  _precompiledContracts: Precompiles
 
   constructor(vm: any, txContext: TxContext, block: any) {
     this._vm = vm
@@ -107,6 +108,7 @@ export default class EVM {
     this._tx = txContext
     this._block = block
     this._refund = new BN(0)
+    this._precompiledContracts = vm.precompiledContracts
   }
 
   /**

--- a/lib/evm/opFns.ts
+++ b/lib/evm/opFns.ts
@@ -702,7 +702,8 @@ export const handlers: { [k: string]: OpHandler } = {
 
     const empty = await runState.eei.isAccountEmpty(toAddressBuf)
     if (empty) {
-      if (!value.isZero()) {
+      const precompiledContracts = runState.eei._evm._precompiledContracts
+      if (!precompiledContracts[toAddressBuf.toString('hex')] && !value.isZero()) {
         runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
       }
     }

--- a/lib/evm/opFns.ts
+++ b/lib/evm/opFns.ts
@@ -702,8 +702,7 @@ export const handlers: { [k: string]: OpHandler } = {
 
     const empty = await runState.eei.isAccountEmpty(toAddressBuf)
     if (empty) {
-      const precompiledContracts = runState.eei._evm._precompiledContracts
-      if (!precompiledContracts[toAddressBuf.toString('hex')] && !value.isZero()) {
+      if (!value.isZero()) {
         runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
       }
     }

--- a/lib/evm/precompiles/index.ts
+++ b/lib/evm/precompiles/index.ts
@@ -30,4 +30,11 @@ function getPrecompile(address: string): PrecompileFunc {
   return precompiles[address]
 }
 
-export { precompiles, getPrecompile, PrecompileFunc, PrecompileInput, ripemdPrecompileAddress }
+export {
+  Precompiles,
+  precompiles,
+  getPrecompile,
+  PrecompileFunc,
+  PrecompileInput,
+  ripemdPrecompileAddress,
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,7 +50,6 @@ export interface VMOpts {
    *
    * Setting this to true has the effect of precompiled contracts' gas costs matching mainnet's from
    * the very first call, which is intended for testing networks.
-   * @deprecated
    */
   activatePrecompiles?: boolean
   /**
@@ -155,7 +154,7 @@ export default class VM extends AsyncEventEmitter {
 
     if (opts.activatePrecompiles && !opts.stateManager) {
       for (const address of Object.keys(this.precompiledContracts)) {
-        await state.putAccount(new BN(address).toArrayLike(Buffer, 'be', 20), new Account())
+        await state.putAccount(Buffer.from(address, 'hex'), new Account())
       }
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -128,9 +128,9 @@ export default class VM extends AsyncEventEmitter {
     }
 
     if (opts.precompiledContracts) {
-      this.precompiledContracts = {...opts.precompiledContracts}
+      this.precompiledContracts = { ...opts.precompiledContracts }
     } else {
-      this.precompiledContracts = {...precompiles}
+      this.precompiledContracts = { ...precompiles }
     }
 
     this.pStateManager = new PStateManager(this.stateManager)
@@ -153,7 +153,7 @@ export default class VM extends AsyncEventEmitter {
     const { opts } = this
     const state = this.pStateManager
 
-    if (opts.activatePrecompiles && ! opts.stateManager) {
+    if (opts.activatePrecompiles && !opts.stateManager) {
       for (const address of Object.keys(this.precompiledContracts)) {
         await state.putAccount(new BN(address).toArrayLike(Buffer, 'be', 20), new Account())
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -150,11 +150,13 @@ export default class VM extends AsyncEventEmitter {
     }
 
     const { opts } = this
-    const state = this.pStateManager
+    const state = this.stateManager
 
     if (opts.activatePrecompiles && !opts.stateManager) {
+      const put = promisify(state._trie.put.bind(state._trie))
       for (const address of Object.keys(this.precompiledContracts)) {
-        await state.putAccount(Buffer.from(address, 'hex'), new Account())
+        // await state.putAccount(Buffer.from(address, 'hex'), new Account())
+        await put(Buffer.from(address, 'hex'), new Account().serialize())
       }
     }
 

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -17,9 +17,10 @@ tape('VM with default blockchain', (t) => {
     st.end()
   })
 
-  t.test('should be able to activate precompiles', (st) => {
+  t.test('should be able to activate precompiles', async (st) => {
     let vm = new VM({ activatePrecompiles: true })
-    st.notEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
+    await vm.init()
+    st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.end()
   })
 
@@ -72,33 +73,25 @@ tape('VM with default blockchain', (t) => {
   })
 
   t.test('should init precompiled contracts', async (st) => {
-    let trie = new Trie()
-    trie.isTestTrie = true
-
     const address = '0000000000000000000000000000000000000001'
     const vm = new VM({
       activatePrecompiles: true,
       precompiledContracts: {
         [address]: () => {},
       },
-      state: trie,
     })
-    st.notEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
-    st.ok(vm.stateManager._trie.isTestTrie, 'it works on trie provided')
+    await vm.init()
+    st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.end()
   })
 
   t.test('should not init empty precompiled contracts', async (st) => {
-    let trie = new Trie()
-    trie.isTestTrie = true
-
     const vm = new VM({
       activatePrecompiles: true,
       precompiledContracts: {},
-      state: trie,
     })
-    st.deepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
-    st.ok(vm.stateManager._trie.isTestTrie, 'it works on trie provided')
+    await vm.init()
+    st.deepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has similar root')
     st.end()
   })
 })

--- a/tests/api/index.js
+++ b/tests/api/index.js
@@ -70,6 +70,37 @@ tape('VM with default blockchain', (t) => {
     await vm.runBlockchain()
     st.end()
   })
+
+  t.test('should init precompiled contracts', async (st) => {
+    let trie = new Trie()
+    trie.isTestTrie = true
+
+    const address = '0000000000000000000000000000000000000001'
+    const vm = new VM({
+      activatePrecompiles: true,
+      precompiledContracts: {
+        [address]: () => {},
+      },
+      state: trie,
+    })
+    st.notEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
+    st.ok(vm.stateManager._trie.isTestTrie, 'it works on trie provided')
+    st.end()
+  })
+
+  t.test('should not init empty precompiled contracts', async (st) => {
+    let trie = new Trie()
+    trie.isTestTrie = true
+
+    const vm = new VM({
+      activatePrecompiles: true,
+      precompiledContracts: {},
+      state: trie,
+    })
+    st.deepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
+    st.ok(vm.stateManager._trie.isTestTrie, 'it works on trie provided')
+    st.end()
+  })
 })
 
 tape('VM with blockchain', (t) => {


### PR DESCRIPTION
This is the solution for #650 issue. What have been done:

### Changes
1. Method `VM#init()` added.
2. Property `VM#isInitialized` added.
2. VM constructor option `precompiledContracts` added. 

### Checklist

- [x] Create backward compatible automatic initialization:
  - [x] Add `VM#init()` method.
  - [x] Add `VM#isInitialized` flag.
  - [x] Update methods which require initialization.
- [x] Test VM to initialize custom precompiles.