### PR TITLE
Fix Node v12 repo installation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-tap": "^4.1.4",
-    "level": "^4.0.0",
+    "level": "^6.0.0",
     "level-mem": "^3.0.1",
     "minimist": "^1.1.1",
     "nyc": "^12.0.2",


### PR DESCRIPTION
This commit fixes broken repository's package installation on Node v12 (#661).

### Changes

1. Package `level` updated to version 6.0.0.

### Checklist

- [x] Run tests.