### PR TITLE
Refactor opcodes

### DIFF
--- a/packages/vm/lib/evm/interpreter.ts
+++ b/packages/vm/lib/evm/interpreter.ts
@@ -152,9 +152,7 @@ export default class Interpreter {
    * Get info for an opcode from VM's list of opcodes.
    */
   lookupOpInfo(op: number): Opcode {
-    const opcode = this._vm._opcodes[op]
-      ? this._vm._opcodes[op]
-      : this._vm._opcodes[0xfe]
+    const opcode = this._vm._opcodes[op] ? this._vm._opcodes[op] : this._vm._opcodes[0xfe]
 
     return opcode
   }

--- a/packages/vm/lib/evm/interpreter.ts
+++ b/packages/vm/lib/evm/interpreter.ts
@@ -42,7 +42,11 @@ export interface InterpreterStep {
   address: Buffer
   memory: number[]
   memoryWordCount: BN
-  opcode: Opcode
+  opcode: {
+    name: string
+    fee: number
+    isAsync: boolean
+  }
   account: Account
   codeAddress: Buffer
 }
@@ -147,39 +151,24 @@ export default class Interpreter {
   /**
    * Get info for an opcode from VM's list of opcodes.
    */
-  lookupOpInfo(op: number, full: boolean = false): Opcode {
+  lookupOpInfo(op: number): Opcode {
     const opcode = this._vm._opcodes[op]
       ? this._vm._opcodes[op]
-      : { name: 'INVALID', fee: 0, isAsync: false }
-
-    if (full) {
-      let name = opcode.name
-      if (name === 'LOG') {
-        name += op - 0xa0
-      }
-
-      if (name === 'PUSH') {
-        name += op - 0x5f
-      }
-
-      if (name === 'DUP') {
-        name += op - 0x7f
-      }
-
-      if (name === 'SWAP') {
-        name += op - 0x8f
-      }
-      return { ...opcode, ...{ name } }
-    }
+      : this._vm._opcodes[0xfe]
 
     return opcode
   }
 
   async _runStepHook(): Promise<void> {
+    const opcode = this.lookupOpInfo(this._runState.opCode)
     const eventObj: InterpreterStep = {
       pc: this._runState.programCounter,
       gasLeft: this._eei.getGasLeft(),
-      opcode: this.lookupOpInfo(this._runState.opCode, true),
+      opcode: {
+        name: opcode.fullName,
+        fee: opcode.fee,
+        isAsync: opcode.isAsync,
+      },
       stack: this._runState.stack._store,
       depth: this._eei._env.depth,
       address: this._eei._env.address,

--- a/packages/vm/lib/evm/opcodes.ts
+++ b/packages/vm/lib/evm/opcodes.ts
@@ -14,11 +14,11 @@ export class Opcode {
     fee,
     isAsync,
   }: {
-    code: number,
-    name: string,
-    fullName: string,
-    fee: number,
-    isAsync: boolean,
+    code: number
+    name: string
+    fullName: string
+    fee: number
+    isAsync: boolean
   }) {
     this.code = code
     this.name = name
@@ -213,16 +213,16 @@ const istanbulOpcodes: OpcodeList = createOpcodes({
  * @param opcodes {Object} Receive basic opcodes info dictionary.
  * @returns {OpcodeList} Complete Opcode list
  */
-function createOpcodes(
-  opcodes: {[key:string]: {name: string, fee: number, isAsync: boolean}}
-): OpcodeList {
+function createOpcodes(opcodes: {
+  [key: string]: { name: string; fee: number; isAsync: boolean }
+}): OpcodeList {
   const result: OpcodeList = {}
   for (const [key, value] of Object.entries(opcodes)) {
     const code = parseInt(key, 10)
     result[<any>key] = new Opcode({
       code,
       fullName: getFullname(code, value.name),
-      ...value
+      ...value,
     })
   }
   return result

--- a/packages/vm/lib/evm/opcodes.ts
+++ b/packages/vm/lib/evm/opcodes.ts
@@ -219,7 +219,7 @@ function createOpcodes(
   const result: OpcodeList = {}
   for (const [key, value] of Object.entries(opcodes)) {
     const code = parseInt(key, 10)
-    result[key] = new Opcode({
+    result[<any>key] = new Opcode({
       code,
       fullName: getFullname(code, value.name),
       ...value

--- a/packages/vm/lib/evm/opcodes.ts
+++ b/packages/vm/lib/evm/opcodes.ts
@@ -221,7 +221,7 @@ function createOpcodes(
     const code = parseInt(key, 10)
     result[key] = new Opcode({
       code,
-      fullName: getFullname(code, name),
+      fullName: getFullname(code, value.name),
       ...value
     })
   }


### PR DESCRIPTION
> Recreated PR #659 

I've rewritten Opcodes creation logic what simplified Interpreter and made Opcode object itself easier to use and more informative.

1. Added new Opcode class with fields `code` and `fullName`. Class field `fullName` created for opcodes like PUSH, JUMP, etc. which have similar names. Now this name is calculated only once. Classes are what V8 optimizer loves to use for faster function optimization. Also I protect it from accidental changes with Object.freeze call, so it could be passed anyway without creating of a duplicate. The interface now looks like this:
    ```ts
    class Opcode {
      readonly code: number
      readonly name: string
      readonly fullName: string
      readonly fee: number
      readonly isAsync: boolean
      // ...
    }
    ```
2. Added createOpcodes factory into `lib/evm/opcodes.ts`. It simplified `Interpreter#lookupOpInfo()` and removed recalculation and recreation of opcode objects. Due to opcode is always same for same hardfork, so there is no reason to recreate it in runtime on each VM step.
3. To preserve backward compatibility I reconstructed old Opcode object in the `Interpreter#_runStepHook()` method. This code should be removed in the next major release and replaced with a regular Opcode instance, it will reveal all the benefits of this PR.
    Now it is:
    ```ts
    {
      //...
      opcode: {
        name: opcode.fullName,
        fee: opcode.fee,
        isAsync: opcode.isAsync,
      },
      //...
    }
    ```
    And should become:
    ```ts
    {
      //...
      opcode,
      //...
    }
    ```