### PR TITLE
Add initialization method to prevent race conditions

### DIFF
--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -74,7 +74,16 @@ export default class VM extends AsyncEventEmitter {
   public readonly _emit: (topic: string, data: any) => Promise<void>
   public readonly pStateManager: PStateManager
   protected isInitialized: boolean = false
-
+  /**
+   * VM async constructor. Creates engine instance and initializes it.
+   *
+   * @param opts VM engine constructor options
+   */
+  static async create(opts: VMOpts = {}): Promise<VM> {
+    const vm = new this(opts)
+    await vm.init()
+    return vm
+  }
   /**
    * Instantiates a new [[VM]] Object.
    * @param opts - Default values for the options are:

--- a/packages/vm/tests/api/index.js
+++ b/packages/vm/tests/api/index.js
@@ -17,9 +17,10 @@ tape('VM with default blockchain', (t) => {
     st.end()
   })
 
-  t.test('should be able to activate precompiles', (st) => {
+  t.test('should be able to activate precompiles', async (st) => {
     let vm = new VM({ activatePrecompiles: true })
-    st.notEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
+    await vm.init()
+    st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.end()
   })
 

--- a/packages/vm/tests/api/index.js
+++ b/packages/vm/tests/api/index.js
@@ -24,11 +24,18 @@ tape('VM with default blockchain', (t) => {
     st.end()
   })
 
-  t.test('should work with trie (state) provided', (st) => {
+  t.test('should instantiate with async constructor', async (st) => {
+    let vm = await VM.create({ activatePrecompiles: true })
+    st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
+    st.end()
+  })
+
+  t.test('should work with trie (state) provided', async (st) => {
     let trie = new Trie()
     trie.isTestTrie = true
     let vm = new VM({ state: trie, activatePrecompiles: true })
-    st.notEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
+    await vm.init()
+    st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.ok(vm.stateManager._trie.isTestTrie, 'it works on trie provided')
     st.end()
   })
@@ -43,17 +50,19 @@ tape('VM with default blockchain', (t) => {
     st.end()
   })
 
-  t.test('should accept a common object as option', (st) => {
+  t.test('should accept a common object as option', async (st) => {
     const common = new Common('mainnet', 'istanbul')
 
     const vm = new VM({ common })
+    await vm.init()
     st.equal(vm._common, common)
 
     st.end()
   })
 
-  t.test('should only accept valid chain and fork', (st) => {
+  t.test('should only accept valid chain and fork', async (st) => {
     let vm = new VM({ chain: 'ropsten', hardfork: 'byzantium' })
+    await vm.init()
     st.equal(vm.stateManager._common.param('gasPrices', 'ecAdd'), 500)
 
     try {
@@ -74,8 +83,9 @@ tape('VM with default blockchain', (t) => {
 })
 
 tape('VM with blockchain', (t) => {
-  t.test('should instantiate', (st) => {
+  t.test('should instantiate', async (st) => {
     const vm = setupVM()
+    await vm.init()
     st.deepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has default trie')
     st.end()
   })
@@ -88,6 +98,8 @@ tape('VM with blockchain', (t) => {
 
   t.test('should run blockchain with mocked runBlock', async (st) => {
     const vm = setupVM({ chain: 'goerli' })
+    await vm.init()
+
     const genesis = new Block(Buffer.from(testData.genesisRLP.slice(2), 'hex'), { common: vm._common })
     const block = new Block(Buffer.from(testData.blocks[0].rlp.slice(2), 'hex'), { common: vm._common })
 
@@ -115,6 +127,7 @@ tape('VM with blockchain', (t) => {
 
   t.test('should run blockchain with blocks', async (st) => {
     const vm = setupVM({ chain: 'goerli' })
+    await vm.init()
     const genesis = new Block(Buffer.from(testData.genesisRLP.slice(2), 'hex'), { common: vm._common })
     const block = new Block(Buffer.from(testData.blocks[0].rlp.slice(2), 'hex'), { common: vm._common })
 
@@ -136,8 +149,10 @@ tape('VM with blockchain', (t) => {
     st.end()
   })
 
-  t.test('should pass the correct Common object when copying the VM', st => {
+  t.test('should pass the correct Common object when copying the VM', async (st) => {
     const vm = setupVM({ chain: 'goerli', hardfork: 'byzantium' })
+    await vm.init()
+
     st.equal(vm._common.chainName(), 'goerli')
     st.equal(vm._common.hardfork(), 'byzantium')
 


### PR DESCRIPTION
This is the solution for #650 issue. What has been done:

### Changes

1. Method `VM#init()` is added.
3. Method `VM.create()` is added.
2. Property `VM#isInitialized` is added.
3. Methods `VM#runBlockchain()`, `VM#runBlock()`, `VM#runTx()`, `VM#runCall()` and `VM#runCode()` are updated.

### Checklist

- [x] Create backward compatible automatic initialization:
  - [x] Add `VM#init()` method.
  - [x] Add `VM#isInitialized` flag.
  - [x] Update methods which require initialization.
- [x] Create static async constructor `VM.create()`.
- [x] Test VM to initialize custom precompiles.