### PR TITLE
Remove empty doc

### DIFF
--- a/packages/vm/docs/README.md
+++ b/packages/vm/docs/README.md
@@ -14,6 +14,5 @@
 * ["runCall"](modules/_runcall_.md)
 * ["runCode"](modules/_runcode_.md)
 * ["runTx"](modules/_runtx_.md)
-* ["state/cache"](modules/_state_cache_.md)
 * ["state/index"](modules/_state_index_.md)
 * ["state/stateManager"](modules/_state_statemanager_.md)

--- a/packages/vm/docs/modules/_state_cache_.md
+++ b/packages/vm/docs/modules/_state_cache_.md
@@ -1,5 +1,0 @@
-[ethereumjs-vm](../README.md) › ["state/cache"](_state_cache_.md)
-
-# Module: "state/cache"
-
-

--- a/packages/vm/typedoc.js
+++ b/packages/vm/typedoc.js
@@ -17,6 +17,7 @@ module.exports = {
     'lib/evm/opFns.ts',
     'lib/evm/stack.ts',
     'lib/evm/txContext.ts',
+    'lib/state/cache.ts',
     'lib/state/promisified.ts',
   ],
   excludeNotExported: true,


### PR DESCRIPTION
In the vm `state/cache.ts` has `@ignore` and had no documentation generated for it, so this PR removes the empty file by adding it to the `exclude` in `typedoc.js`.