### PR TITLE
Fix PR Labeler

### DIFF
--- a/.github/workflows/blockchain-lint.yml
+++ b/.github/workflows/blockchain-lint.yml
@@ -2,9 +2,9 @@ name: Blockchain Lint
 'on':
   push:
     branches:
-        - master
-      tags:
-        - '*'
+      - master
+    tags:
+      - '*'
     paths-include:
       - packages/blockchain/**
   pull_request:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,13 @@
 name: PR Labeler
 'on':
   schedule:
-    - cron: '0 * * * *'
+    - cron: '*/5 * * * *'
 jobs:
-  label:
+  labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v2
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: paulfantom/periodic-labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LABEL_MAPPINGS_FILE: .github/labeler.yml'


### PR DESCRIPTION
This PR switches to using [Periodic Labeler](https://github.com/paulfantom/periodic-labeler) as a workaround for actions from forks lacking write access which renders [actions/labeler](https://github.com/actions/labeler) useless.