### PR TITLE
Issue creation fitted to monorepo standards; README changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,10 @@
+---
+name: General
+about: Open blank issue
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-account.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-account.md
@@ -1,0 +1,10 @@
+---
+name: 'Package: ethereumjs-account'
+about: Create issue for ethereumjs-account package
+title: ''
+labels: 'package: account'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-block.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-block.md
@@ -1,0 +1,10 @@
+---
+name: 'Package: ethereumjs-block'
+about: Create issue for ethereumjs-block
+title: ''
+labels: 'package: block'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-blockchain.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-blockchain.md
@@ -1,0 +1,10 @@
+---
+name: 'Package: ethereumjs-blockchain'
+about: Create issue for ethereumjs-blockchain package
+title: ''
+labels: 'package: blockchain'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-common.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-common.md
@@ -1,0 +1,10 @@
+---
+name: 'Package: ethereumjs-common'
+about: Create issue for ethereumjs-common package
+title: ''
+labels: 'package: common'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-tx.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-tx.md
@@ -1,0 +1,10 @@
+---
+name: 'Package: ethereumjs-tx'
+about: Create issue for ethereumjs-tx package
+title: ''
+labels: 'package: tx'
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/package--ethereumjs-vm.md
+++ b/.github/ISSUE_TEMPLATE/package--ethereumjs-vm.md
@@ -1,0 +1,10 @@
+---
+name: 'Package: ethereumjs-vm'
+about: Create issue for ethereumjs-vm package
+title: ''
+labels: 'package: vm'
+assignees: ''
+
+---
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://avatars1.githubusercontent.com/u/16297473?s=200&v=4">
+  <img src="https://user-images.githubusercontent.com/47108/78779352-d0839500-796a-11ea-9468-fd2a0b3fe1ef.png" width=280>
 </p>
 
 # EthereumJS Monorepo
@@ -26,6 +26,28 @@ This was originally the EthereumJS VM repository. On Q1 2020 we brought some of 
 Detailed version can be seen on [Codecov.io][coverage-link]
 
 [![Code Coverage](https://codecov.io/gh/ethereumjs/ethereumjs-vm/branch/master/graphs/icicle.svg)][coverage-link]
+
+## Package dependency relationship
+
+<p align="center">
+ <img width="409" alt="diagram" src="https://user-images.githubusercontent.com/47108/78778883-007e6880-796a-11ea-8353-772d6923d336.png">
+</p>
+
+<!-- CREATED WITH MERMAID
+https://mermaid-js.github.io/mermaid-live-editor/#/view/eyJjb2RlIjoiZ3JhcGggVERcbiAgdm17Vk19XG5cbiAgY29tbW9uIC0tPiBibG9ja2NoYWluXG4gIGNvbW1vbiAtLT4gYmxvY2tcbiAgY29tbW9uIC0tPiB2bVxuICBjb21tb24gLS0-IHR4XG5cbiAgYmxvY2sgLS0-IGJsb2NrY2hhaW5cbiAgYmxvY2tjaGFpbiAtLT4gdm1cbiAgYmxvY2sgLS0-IHZtXG5cbiAgdHggLS0-IHZtXG4gIHR4IC0tPiBibG9ja1xuXG4gIGFjY291bnQgLS0-IHZtXG5cblxuIiwibWVybWFpZCI6eyJ0aGVtZSI6ImRlZmF1bHQifSwidXBkYXRlRWRpdG9yIjpmYWxzZX0
+graph TD
+  vm{VM}
+  common -> blockchain
+  common -> block
+  common -> vm
+  common -> tx
+  block -> blockchain
+  blockchain -> vm
+  block -> vm
+  tx -> vm
+  tx -> block
+  account -> vm
+-->
 
 ## Developing in a monorepo
 


### PR DESCRIPTION
This PR addresses some scattered changes.

#### 1. Issue templates
The baseline of issue organization of a monorepo is to identify which package the issue relates to. GitHub issue templates help with that, in a way that users can choose the package from a list, and its corresponding label will be added upon issue creation.

[A simplified live example](https://github.com/evertonfraga/ethereumjs-vm/issues/new/choose):

![image](https://user-images.githubusercontent.com/47108/78780598-db3f2980-796c-11ea-9496-a662116d3901.png)


#### 2. Added social image
Displayed in Twitter, Chat applications, sometimes on search results. Example:

![image](https://user-images.githubusercontent.com/47108/78780918-5accf880-796d-11ea-83f1-91c0ad160960.png)

#### 3. Higher resolution ethereumJS logo
Added to README.

#### 4. Package dependency diagram 
<p align="center">
 <img width="409" alt="diagram" src="https://user-images.githubusercontent.com/47108/78778883-007e6880-796a-11ea-8353-772d6923d336.png">
</p>

Closes #716.
