### PR TITLE
Handle balance overflow as evm exception

### DIFF
--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -151,24 +151,24 @@ export default class EVM {
     // Load `to` account
     const toAccount = await this._state.getAccount(message.to)
     // Add tx value to the `to` account
-    let overflowError
+    let errorMessage
     if (!message.delegatecall) {
       try {
         await this._addToBalance(toAccount, message)
       } catch (e) {
-        overflowError = e
+        errorMessage = e
       }
     }
 
     // Load code
     await this._loadCode(message)
     // Exit early if there's no code or value transfer overflowed
-    if (!message.code || message.code.length === 0 || overflowError) {
+    if (!message.code || message.code.length === 0 || errorMessage) {
       return {
         gasUsed: new BN(0),
         execResult: {
           gasUsed: new BN(0),
-          exceptionError: overflowError, // Only defined if addToBalance failed
+          exceptionError: errorMessage, // Only defined if addToBalance failed
           returnValue: Buffer.alloc(0),
         },
       }
@@ -225,21 +225,21 @@ export default class EVM {
     toAccount.nonce = new BN(toAccount.nonce).addn(1).toArrayLike(Buffer)
 
     // Add tx value to the `to` account
-    let overflowError
+    let errorMessage
     try {
       await this._addToBalance(toAccount, message)
     } catch (e) {
-      overflowError = e
+      errorMessage = e
     }
 
     // Exit early if there's no contract code or value transfer overflowed
-    if (!message.code || message.code.length === 0 || overflowError) {
+    if (!message.code || message.code.length === 0 || errorMessage) {
       return {
         gasUsed: new BN(0),
         createdAddress: message.to,
         execResult: {
           gasUsed: new BN(0),
-          exceptionError: overflowError, // only defined if addToBalance failed
+          exceptionError: errorMessage, // only defined if addToBalance failed
           returnValue: Buffer.alloc(0),
         },
       }

--- a/packages/vm/lib/exceptions.ts
+++ b/packages/vm/lib/exceptions.ts
@@ -11,7 +11,7 @@ export enum ERROR {
   CREATE_COLLISION = 'create collision',
   STOP = 'stop',
   REFUND_EXHAUSTED = 'refund exhausted',
-  VALUE_OVERFLOW = 'Value overflow',
+  VALUE_OVERFLOW = 'value overflow',
 }
 
 export class VmError {

--- a/packages/vm/lib/exceptions.ts
+++ b/packages/vm/lib/exceptions.ts
@@ -11,6 +11,7 @@ export enum ERROR {
   CREATE_COLLISION = 'create collision',
   STOP = 'stop',
   REFUND_EXHAUSTED = 'refund exhausted',
+  VALUE_OVERFLOW = 'Value overflow',
 }
 
 export class VmError {

--- a/packages/vm/tests/api/runTx.js
+++ b/packages/vm/tests/api/runTx.js
@@ -74,7 +74,7 @@ tape('should run simple tx without errors', async (t) => {
   t.end()
 })
 
-tape('should fail when account balance overflows', async t => {
+tape('should fail when account balance overflows (call)', async t => {
   const vm = new VM()
   const suite = setup(vm)
 
@@ -84,11 +84,28 @@ tape('should fail when account balance overflows', async t => {
   await suite.putAccount(tx.from.toString('hex'), from)
   await suite.putAccount(tx.to, to)
 
-  shouldFail(t,
-    suite.runTx({ tx }),
-    (e) => t.equal(e.message, 'Value overflow')
-  )
+  const res = await suite.runTx({ tx })
 
+  t.equal(res.execResult.exceptionError.error, 'Value overflow')
+  t.equal(vm.stateManager._checkpointCount, 0)
+  t.end()
+})
+
+tape('should fail when account balance overflows (create)', async t => {
+  const vm = new VM()
+  const suite = setup(vm)
+
+  const contractAddress = Buffer.from('37d6c3cdbc9304cad74eef8e18a85ed54263b4e7', 'hex')
+  const tx = getTransaction(true, true, '0x01', true)
+  const from = createAccount()
+  const to = createAccount('0x00', ethUtil.MAX_INTEGER)
+  await suite.putAccount(tx.from.toString('hex'), from)
+  await suite.putAccount(contractAddress, to)
+
+  const res = await suite.runTx({ tx })
+
+  t.equal(res.execResult.exceptionError.error, 'Value overflow')
+  t.equal(vm.stateManager._checkpointCount, 0)
   t.end()
 })
 
@@ -117,15 +134,25 @@ function shouldFail (st, p, onErr) {
   p.then(() => st.fail('runTx didnt return any errors')).catch(onErr)
 }
 
-function getTransaction (sign = false, calculageGas = false, value = '0x00') {
+function getTransaction (sign = false, calculageGas = false, value = '0x00', createContract = false) {
+  let to = '0x0000000000000000000000000000000000000000'
+  let data = '0x7f7465737432000000000000000000000000000000000000000000000000000000600057'
+
+  if (createContract){
+    to = undefined
+    data = '0x6080604052348015600f57600080fd5b50603e80601d6000396000f3fe6080604052600080fdfea' +
+           '265627a7a723158204aed884a44fd1747efccba1447a2aa2d9a4b06dd6021c4a3bbb993021e0a909e' +
+           '64736f6c634300050f0032'
+  }
+
   const privateKey = Buffer.from('e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109', 'hex')
   const txParams = {
     nonce: '0x00',
     gasPrice: 100,
     gasLimit: 1000,
-    to: '0x0000000000000000000000000000000000000000',
+    to: to,
     value: value,
-    data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
+    data: data,
     chainId: 3
   }
 

--- a/packages/vm/tests/api/runTx.js
+++ b/packages/vm/tests/api/runTx.js
@@ -86,7 +86,7 @@ tape('should fail when account balance overflows (call)', async t => {
 
   const res = await suite.runTx({ tx })
 
-  t.equal(res.execResult.exceptionError.error, 'Value overflow')
+  t.equal(res.execResult.exceptionError.error, 'value overflow')
   t.equal(vm.stateManager._checkpointCount, 0)
   t.end()
 })
@@ -104,7 +104,7 @@ tape('should fail when account balance overflows (create)', async t => {
 
   const res = await suite.runTx({ tx })
 
-  t.equal(res.execResult.exceptionError.error, 'Value overflow')
+  t.equal(res.execResult.exceptionError.error, 'value overflow')
   t.equal(vm.stateManager._checkpointCount, 0)
   t.end()
 })


### PR DESCRIPTION
**Revival of #676** 

Includes review fixes by @evertonfraga 

Addresses #672.

Have made a minimal reproduction of #672 at [cgewecke/checkpoint-repro][1]. It runs two transactions vs. ganache-core:
 + the first overflows an account balance and errors as expected with `Value overflow`
+ the second fails with `Cannot get state root with uncommitted checkpoints`, indicating that the previous tx has left the vm in an unresolved state.

This happens because the balance overflow error is thrown directly from `evm._executeCall` and `evm._executeCreate` without being handled via the revert/commit steps in the method which calls them ([evm.executeMessage][2])

PR
+ returns `Value overflow` exceptions as part of the vm result (instead of throwing), similar to the way contract creation address collisions are [handled][3]
+ makes `Value overflow` a VMError
+ modifies the existing overflow test to inspect the result error and verify that the checkpoint count is 0 when runTx completes
+ adds a balance overflow test for contract creation txs

**NB:** Looks like [invalid precompiles][4] also trigger an uncontrolled throw ([here][5]). Haven't addressed that but if this PR is the correct approach, perhaps that could be resolved here as well. 

[1]: https://github.com/cgewecke/checkpoint-repro
[2]: https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/vm/lib/evm/evm.ts#L117-L143
[3]: https://github.com/ethereumjs/ethereumjs-vm/blob/fdfdf33d99f59f272e9833bed77b42c19eb2942b/packages/vm/lib/evm/evm.ts#L197-L206
[4]: https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/vm/lib/evm/evm.ts#L338-L341
[5]: https://github.com/ethereumjs/ethereumjs-vm/blob/fdfdf33d99f59f272e9833bed77b42c19eb2942b/packages/vm/lib/evm/evm.ts#L172