### PR TITLE
Handles new Buffer() deprecation

### DIFF
--- a/packages/tx/examples/custom-chain-tx.ts
+++ b/packages/tx/examples/custom-chain-tx.ts
@@ -31,7 +31,7 @@ const tx = new Transaction(
 // Once we created the transaction using the custom Common object, we can use it as a normal tx.
 
 // Here we sign it and validate its signature
-const privateKey = new Buffer(
+const privateKey = Buffer.from(
   'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
   'hex',
 )

--- a/packages/tx/examples/transactions.ts
+++ b/packages/tx/examples/transactions.ts
@@ -16,7 +16,7 @@ const tx = new Transaction({
 })
 
 // We sign the transaction with this private key
-const privateKey = new Buffer(
+const privateKey = Buffer.from(
   'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
   'hex',
 )

--- a/packages/tx/src/transaction.ts
+++ b/packages/tx/src/transaction.ts
@@ -91,57 +91,57 @@ export default class Transaction {
         name: 'nonce',
         length: 32,
         allowLess: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'gasPrice',
         length: 32,
         allowLess: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'gasLimit',
         alias: 'gas',
         length: 32,
         allowLess: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'to',
         allowZero: true,
         length: 20,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'value',
         length: 32,
         allowLess: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'data',
         alias: 'input',
         allowZero: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'v',
         allowZero: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 'r',
         length: 32,
         allowZero: true,
         allowLess: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
       {
         name: 's',
         length: 32,
         allowZero: true,
         allowLess: true,
-        default: new Buffer([]),
+        default: Buffer.from([]),
       },
     ]
 
@@ -262,9 +262,9 @@ export default class Transaction {
   sign(privateKey: Buffer) {
     // We clear any previous signature before signing it. Otherwise, _implementsEIP155's can give
     // different results if this tx was already signed.
-    this.v = new Buffer([])
-    this.s = new Buffer([])
-    this.r = new Buffer([])
+    this.v = Buffer.from([])
+    this.s = Buffer.from([])
+    this.r = Buffer.from([])
 
     const msgHash = this.hash(false)
     const sig = ecsign(msgHash, privateKey)

--- a/packages/tx/test/api.ts
+++ b/packages/tx/test/api.ts
@@ -41,15 +41,15 @@ tape('[Transaction]: Basic functions', function(t) {
     const tx = new Transaction(txFixtures[3].raw)
     st.deepEqual(
       tx.hash(),
-      new Buffer('375a8983c9fc56d7cfd118254a80a8d7403d590a6c9e105532b67aca1efb97aa', 'hex'),
+      Buffer.from('375a8983c9fc56d7cfd118254a80a8d7403d590a6c9e105532b67aca1efb97aa', 'hex'),
     )
     st.deepEqual(
       tx.hash(false),
-      new Buffer('61e1ec33764304dddb55348e7883d4437426f44ab3ef65e6da1e025734c03ff0', 'hex'),
+      Buffer.from('61e1ec33764304dddb55348e7883d4437426f44ab3ef65e6da1e025734c03ff0', 'hex'),
     )
     st.deepEqual(
       tx.hash(true),
-      new Buffer('375a8983c9fc56d7cfd118254a80a8d7403d590a6c9e105532b67aca1efb97aa', 'hex'),
+      Buffer.from('375a8983c9fc56d7cfd118254a80a8d7403d590a6c9e105532b67aca1efb97aa', 'hex'),
     )
     st.end()
   })
@@ -106,7 +106,7 @@ tape('[Transaction]: Basic functions', function(t) {
   t.test('should sign tx', function(st) {
     transactions.forEach(function(tx, i) {
       if (txFixtures[i].privateKey) {
-        const privKey = new Buffer(txFixtures[i].privateKey, 'hex')
+        const privKey = Buffer.from(txFixtures[i].privateKey, 'hex')
         tx.sign(privKey)
       }
     })
@@ -127,7 +127,7 @@ tape('[Transaction]: Basic functions', function(t) {
       if (txFixtures[i].privateKey) {
         st.equals(
           tx.getSenderPublicKey().toString('hex'),
-          privateToPublic(new Buffer(txFixtures[i].privateKey, 'hex')).toString('hex'),
+          privateToPublic(Buffer.from(txFixtures[i].privateKey, 'hex')).toString('hex'),
         )
       }
     })
@@ -280,7 +280,7 @@ tape('[Transaction]: Basic functions', function(t) {
   t.test('sign tx with chainId specified in params', function(st) {
     const tx = new Transaction({}, { chain: 42 })
     st.equal(tx.getChainId(), 42)
-    const privKey = new Buffer(txFixtures[0].privateKey, 'hex')
+    const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
     tx.sign(privKey)
     const serialized = tx.serialize()
     const reTx = new Transaction(serialized, { chain: 42 })
@@ -294,7 +294,7 @@ tape('[Transaction]: Basic functions', function(t) {
   ) {
     const tx = new Transaction({}, { chain: 42 })
     st.equal(tx.getChainId(), 42)
-    const privKey = new Buffer(txFixtures[0].privateKey, 'hex')
+    const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
     tx.sign(privKey)
     const serialized = tx.serialize()
     st.throws(() => new Transaction(serialized))
@@ -322,7 +322,7 @@ tape('[Transaction]: Basic functions', function(t) {
     st,
   ) {
     const tx = new Transaction({}, { chain: 42 })
-    const privKey = new Buffer(txFixtures[0].privateKey, 'hex')
+    const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
     tx.sign(privKey)
 
     st.throws(() => (tx.v = toBuffer(1)))
@@ -337,7 +337,7 @@ tape('[Transaction]: Basic functions', function(t) {
     txFixtures.slice(0, 3).forEach(function(txData) {
       const tx = new Transaction(txData.raw.slice(0, 6), { chain: 1 })
 
-      const privKey = new Buffer(txData.privateKey, 'hex')
+      const privKey = Buffer.from(txData.privateKey, 'hex')
       tx.sign(privKey)
 
       st.equal(


### PR DESCRIPTION
This PR simply gets rid of the deprecated `new Buffer(…)` statements, in favor of `Buffer.from(…)`.

**How to validate it**
Test suite should not fire any warning.

Example of warning: https://github.com/ethereumjs/ethereumjs-vm/runs/572001912?check_suite_focus=true#step:5:17

