### PR TITLE
coverage: setting threshold to 1%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto 
+        


### PR DESCRIPTION
Aims to solve some false negative coverage tests, by setting a threshold to 1%.

Finishes one task at https://github.com/ethereumjs/ethereumjs-vm/issues/723