### PR TITLE
Remove unneeded `for await`s

### DIFF
--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -184,7 +184,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    */
   if (results.execResult.selfdestruct) {
     const keys = Object.keys(results.execResult.selfdestruct)
-    for await (const k of keys) {
+    for (const k of keys) {
       await state.putAccount(Buffer.from(k, 'hex'), new Account())
     }
   }

--- a/packages/vm/lib/state/cache.ts
+++ b/packages/vm/lib/state/cache.ts
@@ -88,7 +88,7 @@ export default class Cache {
    * @param addresses - Array of addresses
    */
   async warm(addresses: string[]): Promise<void> {
-    for await (let addressHex of addresses) {
+    for (const addressHex of addresses) {
       if (addressHex) {
         const address = Buffer.from(addressHex, 'hex')
         const account = await this._lookupAccount(address)

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -459,7 +459,7 @@ export default class StateManager {
     const triePut = promisify(this._trie.put.bind(this._trie))
 
     const addresses = Object.keys(initState)
-    for await (let address of addresses) {
+    for (const address of addresses) {
       const account = new Account()
       if (initState[address].slice(0, 2) === '0x') {
         account.balance = new BN(initState[address].slice(2), 16).toArrayLike(Buffer)
@@ -493,7 +493,7 @@ export default class StateManager {
    */
   async cleanupTouchedAccounts(): Promise<void> {
     const touchedArray = Array.from(this._touched)
-    for await (let addressHex of touchedArray) {
+    for (const addressHex of touchedArray) {
       const address = Buffer.from(addressHex, 'hex')
       const empty = await this.accountIsEmpty(address)
       if (empty) {

--- a/packages/vm/tests/api/istanbul/eip-1884.js
+++ b/packages/vm/tests/api/istanbul/eip-1884.js
@@ -20,7 +20,7 @@ tape('Istanbul: EIP-1884: SELFBALANCE', async t => {
     address: addr,
   }
 
-  for await (const testCase of testCases) {
+  for (const testCase of testCases) {
     const common = new Common(testCase.chain, testCase.hardfork)
     const vm = new VM({ common })
     const account = createAccount('0x00', testCase.selfbalance)

--- a/packages/vm/tests/api/istanbul/eip-2200.js
+++ b/packages/vm/tests/api/istanbul/eip-2200.js
@@ -38,7 +38,7 @@ tape('Istanbul: EIP-2200: net-metering SSTORE', async t => {
   const caller = Buffer.from('0000000000000000000000000000000000000000', 'hex')
   const addr = Buffer.from('00000000000000000000000000000000000000ff', 'hex')
   const key = new BN(0).toArrayLike(Buffer, 'be', 32)
-  for await (const testCase of testCases) {
+  for (const testCase of testCases) {
     const common = new Common('mainnet', 'istanbul')
     const vm = new VM({ common })
 

--- a/packages/vm/tests/api/state/stateManager.js
+++ b/packages/vm/tests/api/state/stateManager.js
@@ -171,7 +171,7 @@ tape('StateManager', t => {
   t.test('should generate the genesis state root correctly for all other chains', async st => {
     const chains = ['ropsten', 'rinkeby', 'kovan', 'goerli']
 
-    for await (const chain of chains) {
+    for (const chain of chains) {
       const common = new Common(chain, 'petersburg')
       const expectedStateRoot = Buffer.from(common.genesis().stateRoot.slice(2), 'hex')
       const stateManager = new StateManager({ common: common })


### PR DESCRIPTION
This PR is a quick fixup that removes the `await` in several `for await...of` loops that were in my latest promisification effort (#719). @kumavis [noted](https://github.com/ethereumjs/ethereumjs-vm/pull/719#discussion_r414815928) `for await` is for async iterators and thus is unneeded in these contexts.