### PR TITLE
Update to ethereumjs-testing v1.3.1 (pre-Berlin HF release) / Fix test runs

### DIFF
--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -67,7 +67,7 @@
     "@types/node": "^11.13.4",
     "@types/tape": "^4.2.33",
     "browserify": "^16.5.1",
-    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.3.0",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.3.1",
     "karma": "^4.0.1",
     "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/packages/vm/tests/BlockchainTestsRunner.js
+++ b/packages/vm/tests/BlockchainTestsRunner.js
@@ -86,8 +86,11 @@ module.exports = async function runBlockchainTest(options, testData, t) {
 
   for (const raw of testData.blocks) {
     const paramFork = `expectException${options.forkConfigTestSuite}`
-    const paramAll = 'expectExceptionALL'
-    const expectException = raw[paramFork] ? raw[paramFork] : raw[paramAll]
+    // Two naming conventions in ethereum/tests to indicate "exception occurs on all HFs" semantics
+    // Last checked: ethereumjs-testing v1.3.1 (2020-05-11)
+    const paramAll1 = 'expectExceptionALL'
+    const paramAll2 = 'expectException'
+    const expectException = raw[paramFork] ? raw[paramFork] : (raw[paramAll1] || raw[paramAll2])
 
     try { 
       const block = new Block(Buffer.from(raw.rlp.slice(2), 'hex'), {

--- a/packages/vm/tests/config.js
+++ b/packages/vm/tests/config.js
@@ -10,6 +10,7 @@ const SKIP_BROKEN = [
   'ForkStressTest', // Only BlockchainTest, temporary till fixed (2020-05-23)
   'dynamicAccountOverwriteEmpty', // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
   'ChainAtoChainB', // Only BlockchainTest, temporary, along expectException fixes (2020-05-23)
+  'BLOCK_timestamp_TooLarge', // Only BlockchainTest, temporary, along expectException fixes (2020-05-27)
 ]
 
 /**

--- a/packages/vm/tests/config.js
+++ b/packages/vm/tests/config.js
@@ -11,6 +11,10 @@ const SKIP_BROKEN = [
   'dynamicAccountOverwriteEmpty', // temporary till fixed (2019-01-30), skipped along constantinopleFix work time constraints
   'ChainAtoChainB', // Only BlockchainTest, temporary, along expectException fixes (2020-05-23)
   'BLOCK_timestamp_TooLarge', // Only BlockchainTest, temporary, along expectException fixes (2020-05-27)
+  'sha3_bigOffset', // SHA3: Only BlockchainTest, unclear SHA3 test situation (2020-05-28)
+  'sha3_memSizeNoQuadraticCost', // SHA3: See also:
+  'sha3_memSizeQuadraticCost', // SHA3: https://github.com/ethereumjs/ethereumjs-vm/pull/743#issuecomment-635116418
+  'sha3_bigSize', // SHA3
 ]
 
 /**

--- a/packages/vm/tests/config.js
+++ b/packages/vm/tests/config.js
@@ -65,6 +65,15 @@ const SKIP_SLOW = [
     'QuadraticComplexitySolidity_CallDataCopy',
     'CALLBlake2f_MaxRounds',
     'randomStatetest94_Istanbul',
+    // vmPerformance tests
+    'ackermann',
+    'fibonacci',
+    'loop-add-10M',
+    'loop-divadd-10M',
+    'loop-divadd-unr100-10M',
+    'loop-exp',
+    'loop-mul',
+    'manyFunctions100',
   ]
 
 /**


### PR DESCRIPTION
This is a test run of the updated [v1.3.1](https://github.com/ethereumjs/ethereumjs-testing/releases/tag/v1.3.1) consensus tests referencing a state of `ethereum/tests` in a pre-Berlin HF state. Check is mainly for a first impression on how the tests behave.

See v7.0.0 pre-Berlin HF release PR https://github.com/ethereum/tests/pull/687 on the `ethereum/tests`repo for hints on what has changed there and what tests have been added.

[ DO NOT MERGE ]