### PR TITLE
Fix nightly vm blockchain test

### DIFF
--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -43,9 +43,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
+      - uses: actions/checkout@v1
       - run: npx lerna bootstrap --scope ethereumjs-vm --ignore-scripts --include-dependencies --no-ci
       - run: npx lerna run --scope ethereumjs-vm --include-dependencies build
-        working-directory: '${{ env.cwd }}'
       - run: 'npm run test:blockchain'
         env:
           CI: true


### PR DESCRIPTION
This PR fixes the currently failing nightly blockchain test by adding a missing `actions/checkout@v1` step and making sure the lerna cmds run on root.