### PR TITLE
Add common boilerplate for Berlin hardfork

### DIFF
--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -67,6 +67,12 @@
       "block": 1561651,
       "consensus": "poa",
       "finality": null
+    },
+    {
+      "name": "berlin",
+      "block": null,
+      "consensus": "poa",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -67,6 +67,12 @@
       "block": 14111141,
       "consensus": "poa",
       "finality": null
+    },
+    {
+      "name": "berlin",
+      "block": null,
+      "consensus": "poa",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/mainnet.json
+++ b/packages/common/src/chains/mainnet.json
@@ -73,6 +73,12 @@
       "block": 9200000,
       "consensus": "pow",
       "finality": null
+    },
+    {
+      "name": "berlin",
+      "block": null,
+      "consensus": "pow",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/rinkeby.json
+++ b/packages/common/src/chains/rinkeby.json
@@ -67,6 +67,12 @@
       "block": 5435345,
       "consensus": "poa",
       "finality": null
+    },
+    {
+      "name": "berlin",
+      "block": null,
+      "consensus": "poa",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/ropsten.json
+++ b/packages/common/src/chains/ropsten.json
@@ -73,6 +73,12 @@
       "block": 7117117,
       "consensus": "pow",
       "finality": null
+    },
+    {
+      "name": "berlin",
+      "block": null,
+      "consensus": "pow",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/hardforks/berlin.json
+++ b/packages/common/src/hardforks/berlin.json
@@ -1,0 +1,14 @@
+{
+  "name": "berlin",
+  "comment": "HF targeted for July 2020 following the Muir Glacier HF",
+  "eip": {
+    "url": "https://eips.ethereum.org/EIPS/eip-2070",
+    "status": "Draft"
+  },
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {},
+  "casper": {},
+  "sharding": {}
+}

--- a/packages/common/src/hardforks/index.ts
+++ b/packages/common/src/hardforks/index.ts
@@ -9,4 +9,5 @@ export const hardforks = [
   ['petersburg', require('./petersburg.json')],
   ['istanbul', require('./istanbul.json')],
   ['muirGlacier', require('./muirGlacier.json')],
+  ['berlin', require('./berlin.json')],
 ]

--- a/packages/common/tests/hardforks.ts
+++ b/packages/common/tests/hardforks.ts
@@ -13,6 +13,7 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
       'constantinople',
       'petersburg',
       'istanbul',
+      'berlin',
     ]
     let c
 


### PR DESCRIPTION
Part of #736

+ [Berlin Meta: EIP 2070][1]
+ reference PR [ethereumjs-common 51][2]


[1]: https://eips.ethereum.org/EIPS/eip-2070
[2]: https://github.com/ethereumjs/ethereumjs-common/pull/51
