### PR TITLE
common: remove old fields `consensus` and `finality`

### DIFF
--- a/packages/common/docs/README.md
+++ b/packages/common/docs/README.md
@@ -6,6 +6,6 @@
 
 ### Modules
 
-- ["genesisStates/index"](modules/_genesisstates_index_.md)
-- ["index"](modules/_index_.md)
-- ["types"](modules/_types_.md)
+* ["genesisStates/index"](modules/_genesisstates_index_.md)
+* ["index"](modules/_index_.md)
+* ["types"](modules/_types_.md)

--- a/packages/common/docs/classes/_index_.common.md
+++ b/packages/common/docs/classes/_index_.common.md
@@ -6,548 +6,506 @@ Common class to access chain and hardfork parameters
 
 ## Hierarchy
 
-- **Common**
+* **Common**
 
 ## Index
 
 ### Constructors
 
-- [constructor](_index_.common.md#constructor)
+* [constructor](_index_.common.md#constructor)
 
 ### Methods
 
-- [\_chooseHardfork](_index_.common.md#_choosehardfork)
-- [\_getHardfork](_index_.common.md#_gethardfork)
-- [\_isSupportedHardfork](_index_.common.md#_issupportedhardfork)
-- [activeHardfork](_index_.common.md#activehardfork)
-- [activeHardforks](_index_.common.md#activehardforks)
-- [activeOnBlock](_index_.common.md#activeonblock)
-- [bootstrapNodes](_index_.common.md#bootstrapnodes)
-- [chainId](_index_.common.md#chainid)
-- [chainName](_index_.common.md#chainname)
-- [consensus](_index_.common.md#consensus)
-- [finality](_index_.common.md#finality)
-- [genesis](_index_.common.md#genesis)
-- [gteHardfork](_index_.common.md#gtehardfork)
-- [hardfork](_index_.common.md#hardfork)
-- [hardforkBlock](_index_.common.md#hardforkblock)
-- [hardforkGteHardfork](_index_.common.md#hardforkgtehardfork)
-- [hardforkIsActiveOnBlock](_index_.common.md#hardforkisactiveonblock)
-- [hardforkIsActiveOnChain](_index_.common.md#hardforkisactiveonchain)
-- [hardforks](_index_.common.md#hardforks)
-- [isHardforkBlock](_index_.common.md#ishardforkblock)
-- [networkId](_index_.common.md#networkid)
-- [param](_index_.common.md#param)
-- [paramByBlock](_index_.common.md#parambyblock)
-- [setChain](_index_.common.md#setchain)
-- [setHardfork](_index_.common.md#sethardfork)
-- [forCustomChain](_index_.common.md#static-forcustomchain)
+* [_chooseHardfork](_index_.common.md#_choosehardfork)
+* [_getHardfork](_index_.common.md#_gethardfork)
+* [_isSupportedHardfork](_index_.common.md#_issupportedhardfork)
+* [activeHardfork](_index_.common.md#activehardfork)
+* [activeHardforks](_index_.common.md#activehardforks)
+* [activeOnBlock](_index_.common.md#activeonblock)
+* [bootstrapNodes](_index_.common.md#bootstrapnodes)
+* [chainId](_index_.common.md#chainid)
+* [chainName](_index_.common.md#chainname)
+* [genesis](_index_.common.md#genesis)
+* [gteHardfork](_index_.common.md#gtehardfork)
+* [hardfork](_index_.common.md#hardfork)
+* [hardforkBlock](_index_.common.md#hardforkblock)
+* [hardforkGteHardfork](_index_.common.md#hardforkgtehardfork)
+* [hardforkIsActiveOnBlock](_index_.common.md#hardforkisactiveonblock)
+* [hardforkIsActiveOnChain](_index_.common.md#hardforkisactiveonchain)
+* [hardforks](_index_.common.md#hardforks)
+* [isHardforkBlock](_index_.common.md#ishardforkblock)
+* [networkId](_index_.common.md#networkid)
+* [param](_index_.common.md#param)
+* [paramByBlock](_index_.common.md#parambyblock)
+* [setChain](_index_.common.md#setchain)
+* [setHardfork](_index_.common.md#sethardfork)
+* [forCustomChain](_index_.common.md#static-forcustomchain)
 
 ## Constructors
 
-### constructor
+###  constructor
 
-\+ **new Common**(`chain`: string | number | object, `hardfork?`: string | null, `supportedHardforks?`: Array‹string›): _[Common](\_index_.common.md)\_
+\+ **new Common**(`chain`: string | number | object, `hardfork?`: string | null, `supportedHardforks?`: Array‹string›): *[Common](_index_.common.md)*
 
-_Defined in [index.ts:62](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L62)_
+*Defined in [index.ts:62](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L62)*
 
-**`constructor`**
+**`constructor`** 
 
 **Parameters:**
 
-| Name                  | Type                               | Description                                               |
-| --------------------- | ---------------------------------- | --------------------------------------------------------- |
-| `chain`               | string &#124; number &#124; object | String ('mainnet') or Number (1) chain                    |
-| `hardfork?`           | string &#124; null                 | String identifier ('byzantium') for hardfork (optional)   |
-| `supportedHardforks?` | Array‹string›                      | Limit parameter returns to the given hardforks (optional) |
+Name | Type | Description |
+------ | ------ | ------ |
+`chain` | string &#124; number &#124; object | String ('mainnet') or Number (1) chain |
+`hardfork?` | string &#124; null | String identifier ('byzantium') for hardfork (optional) |
+`supportedHardforks?` | Array‹string› | Limit parameter returns to the given hardforks (optional)  |
 
-**Returns:** _[Common](\_index_.common.md)\_
+**Returns:** *[Common](_index_.common.md)*
 
 ## Methods
 
-### \_chooseHardfork
+###  _chooseHardfork
 
-▸ **\_chooseHardfork**(`hardfork?`: string | null, `onlySupported?`: undefined | false | true): _string_
+▸ **_chooseHardfork**(`hardfork?`: string | null, `onlySupported?`: undefined | false | true): *string*
 
-_Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L131)_
+*Defined in [index.ts:131](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L131)*
 
 Internal helper function to choose between hardfork set and hardfork provided as param
 
 **Parameters:**
 
-| Name             | Type                               | Description                               |
-| ---------------- | ---------------------------------- | ----------------------------------------- |
-| `hardfork?`      | string &#124; null                 | Hardfork given to function as a parameter |
-| `onlySupported?` | undefined &#124; false &#124; true | -                                         |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork?` | string &#124; null | Hardfork given to function as a parameter |
+`onlySupported?` | undefined &#124; false &#124; true | - |
 
-**Returns:** _string_
+**Returns:** *string*
 
 Hardfork chosen to be used
 
----
+___
 
-### \_getHardfork
+###  _getHardfork
 
-▸ **\_getHardfork**(`hardfork`: string): _any_
+▸ **_getHardfork**(`hardfork`: string): *any*
 
-_Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L150)_
+*Defined in [index.ts:150](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L150)*
 
 Internal helper function, returns the params for the given hardfork for the chain set
 
 **Parameters:**
 
-| Name       | Type   | Description   |
-| ---------- | ------ | ------------- |
-| `hardfork` | string | Hardfork name |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork` | string | Hardfork name |
 
-**Returns:** _any_
+**Returns:** *any*
 
 Dictionary with hardfork params
 
----
+___
 
-### \_isSupportedHardfork
+###  _isSupportedHardfork
 
-▸ **\_isSupportedHardfork**(`hardfork`: string | null): _boolean_
+▸ **_isSupportedHardfork**(`hardfork`: string | null): *boolean*
 
-_Defined in [index.ts:163](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L163)_
+*Defined in [index.ts:163](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L163)*
 
 Internal helper function to check if a hardfork is set to be supported by the library
 
 **Parameters:**
 
-| Name       | Type               | Description   |
-| ---------- | ------------------ | ------------- |
-| `hardfork` | string &#124; null | Hardfork name |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork` | string &#124; null | Hardfork name |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if hardfork is supported
 
----
+___
 
-### activeHardfork
+###  activeHardfork
 
-▸ **activeHardfork**(`blockNumber?`: number | null, `opts?`: hardforkOptions): _string_
+▸ **activeHardfork**(`blockNumber?`: number | null, `opts?`: hardforkOptions): *string*
 
-_Defined in [index.ts:327](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L327)_
+*Defined in [index.ts:327](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L327)*
 
 Returns the latest active hardfork name for chain or block or throws if unavailable
 
 **Parameters:**
 
-| Name           | Type               | Description                                            |
-| -------------- | ------------------ | ------------------------------------------------------ |
-| `blockNumber?` | number &#124; null | up to block if provided, otherwise for the whole chain |
-| `opts?`        | hardforkOptions    | Hardfork options (onlyActive unused)                   |
+Name | Type | Description |
+------ | ------ | ------ |
+`blockNumber?` | number &#124; null | up to block if provided, otherwise for the whole chain |
+`opts?` | hardforkOptions | Hardfork options (onlyActive unused) |
 
-**Returns:** _string_
+**Returns:** *string*
 
 Hardfork name
 
----
+___
 
-### activeHardforks
+###  activeHardforks
 
-▸ **activeHardforks**(`blockNumber?`: number | null, `opts?`: hardforkOptions): _Array‹any›_
+▸ **activeHardforks**(`blockNumber?`: number | null, `opts?`: hardforkOptions): *Array‹any›*
 
-_Defined in [index.ts:307](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L307)_
+*Defined in [index.ts:307](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L307)*
 
 Returns the active hardfork switches for the current chain
 
 **Parameters:**
 
-| Name           | Type               | Description                                            |
-| -------------- | ------------------ | ------------------------------------------------------ |
-| `blockNumber?` | number &#124; null | up to block if provided, otherwise for the whole chain |
-| `opts?`        | hardforkOptions    | Hardfork options (onlyActive unused)                   |
+Name | Type | Description |
+------ | ------ | ------ |
+`blockNumber?` | number &#124; null | up to block if provided, otherwise for the whole chain |
+`opts?` | hardforkOptions | Hardfork options (onlyActive unused) |
 
-**Returns:** _Array‹any›_
+**Returns:** *Array‹any›*
 
 Array with hardfork arrays
 
----
+___
 
-### activeOnBlock
+###  activeOnBlock
 
-▸ **activeOnBlock**(`blockNumber`: number, `opts?`: hardforkOptions): _boolean_
+▸ **activeOnBlock**(`blockNumber`: number, `opts?`: hardforkOptions): *boolean*
 
-_Defined in [index.ts:237](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L237)_
+*Defined in [index.ts:237](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L237)*
 
 Alias to hardforkIsActiveOnBlock when hardfork is set
 
 **Parameters:**
 
-| Name          | Type            | Description                          |
-| ------------- | --------------- | ------------------------------------ |
-| `blockNumber` | number          | -                                    |
-| `opts?`       | hardforkOptions | Hardfork options (onlyActive unused) |
+Name | Type | Description |
+------ | ------ | ------ |
+`blockNumber` | number | - |
+`opts?` | hardforkOptions | Hardfork options (onlyActive unused) |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if HF is active on block number
 
----
+___
 
-### bootstrapNodes
+###  bootstrapNodes
 
-▸ **bootstrapNodes**(): _any_
+▸ **bootstrapNodes**(): *any*
 
-_Defined in [index.ts:402](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L402)_
+*Defined in [index.ts:382](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L382)*
 
 Returns bootstrap nodes for the current chain
 
-**Returns:** _any_
+**Returns:** *any*
 
 Dict with bootstrap nodes
 
----
+___
 
-### chainId
+###  chainId
 
-▸ **chainId**(): _number_
+▸ **chainId**(): *number*
 
-_Defined in [index.ts:418](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L418)_
+*Defined in [index.ts:398](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L398)*
 
 Returns the Id of current chain
 
-**Returns:** _number_
+**Returns:** *number*
 
 chain Id
 
----
+___
 
-### chainName
+###  chainName
 
-▸ **chainName**(): _string_
+▸ **chainName**(): *string*
 
-_Defined in [index.ts:426](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L426)_
+*Defined in [index.ts:406](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L406)*
 
 Returns the name of current chain
 
-**Returns:** _string_
+**Returns:** *string*
 
 chain name (lower case)
 
----
+___
 
-### consensus
+###  genesis
 
-▸ **consensus**(`hardfork?`: undefined | string): _string_
+▸ **genesis**(): *any*
 
-_Defined in [index.ts:367](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L367)_
-
-Provide the consensus type for the hardfork set or provided as param
-
-**Parameters:**
-
-| Name        | Type                    | Description                             |
-| ----------- | ----------------------- | --------------------------------------- |
-| `hardfork?` | undefined &#124; string | Hardfork name, optional if hardfork set |
-
-**Returns:** _string_
-
-Consensus type (e.g. 'pow', 'poa')
-
----
-
-### finality
-
-▸ **finality**(`hardfork?`: undefined | string): _string_
-
-_Defined in [index.ts:377](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L377)_
-
-Provide the finality type for the hardfork set or provided as param
-
-**Parameters:**
-
-| Name        | Type                    | Description                             |
-| ----------- | ----------------------- | --------------------------------------- |
-| `hardfork?` | undefined &#124; string | Hardfork name, optional if hardfork set |
-
-**Returns:** _string_
-
-Finality type (e.g. 'pos', null of no finality)
-
----
-
-### genesis
-
-▸ **genesis**(): _any_
-
-_Defined in [index.ts:386](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L386)_
+*Defined in [index.ts:366](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L366)*
 
 Returns the Genesis parameters of current chain
 
-**Returns:** _any_
+**Returns:** *any*
 
 Genesis dictionary
 
----
+___
 
-### gteHardfork
+###  gteHardfork
 
-▸ **gteHardfork**(`hardfork`: string, `opts?`: hardforkOptions): _boolean_
+▸ **gteHardfork**(`hardfork`: string, `opts?`: hardforkOptions): *boolean*
 
-_Defined in [index.ts:281](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L281)_
+*Defined in [index.ts:281](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L281)*
 
 Alias to hardforkGteHardfork when hardfork is set
 
 **Parameters:**
 
-| Name       | Type            | Description      |
-| ---------- | --------------- | ---------------- |
-| `hardfork` | string          | Hardfork name    |
-| `opts?`    | hardforkOptions | Hardfork options |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork` | string | Hardfork name |
+`opts?` | hardforkOptions | Hardfork options |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if hardfork set is greater than hardfork provided
 
----
+___
 
-### hardfork
+###  hardfork
 
-▸ **hardfork**(): _string | null_
+▸ **hardfork**(): *string | null*
 
-_Defined in [index.ts:410](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L410)_
+*Defined in [index.ts:390](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L390)*
 
 Returns the hardfork set
 
-**Returns:** _string | null_
+**Returns:** *string | null*
 
 Hardfork name
 
----
+___
 
-### hardforkBlock
+###  hardforkBlock
 
-▸ **hardforkBlock**(`hardfork?`: undefined | string): _number_
+▸ **hardforkBlock**(`hardfork?`: undefined | string): *number*
 
-_Defined in [index.ts:342](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L342)_
+*Defined in [index.ts:342](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L342)*
 
 Returns the hardfork change block for hardfork provided or set
 
 **Parameters:**
 
-| Name        | Type                    | Description                       |
-| ----------- | ----------------------- | --------------------------------- |
-| `hardfork?` | undefined &#124; string | Hardfork name, optional if HF set |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork?` | undefined &#124; string | Hardfork name, optional if HF set |
 
-**Returns:** _number_
+**Returns:** *number*
 
 Block number
 
----
+___
 
-### hardforkGteHardfork
+###  hardforkGteHardfork
 
-▸ **hardforkGteHardfork**(`hardfork1`: string | null, `hardfork2`: string, `opts?`: hardforkOptions): _boolean_
+▸ **hardforkGteHardfork**(`hardfork1`: string | null, `hardfork2`: string, `opts?`: hardforkOptions): *boolean*
 
-_Defined in [index.ts:248](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L248)_
+*Defined in [index.ts:248](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L248)*
 
 Sequence based check if given or set HF1 is greater than or equal HF2
 
 **Parameters:**
 
-| Name        | Type               | Description                    |
-| ----------- | ------------------ | ------------------------------ |
-| `hardfork1` | string &#124; null | Hardfork name or null (if set) |
-| `hardfork2` | string             | Hardfork name                  |
-| `opts?`     | hardforkOptions    | Hardfork options               |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork1` | string &#124; null | Hardfork name or null (if set) |
+`hardfork2` | string | Hardfork name |
+`opts?` | hardforkOptions | Hardfork options |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if HF1 gte HF2
 
----
+___
 
-### hardforkIsActiveOnBlock
+###  hardforkIsActiveOnBlock
 
-▸ **hardforkIsActiveOnBlock**(`hardfork`: string | null, `blockNumber`: number, `opts?`: hardforkOptions): _boolean_
+▸ **hardforkIsActiveOnBlock**(`hardfork`: string | null, `blockNumber`: number, `opts?`: hardforkOptions): *boolean*
 
-_Defined in [index.ts:218](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L218)_
+*Defined in [index.ts:218](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L218)*
 
 Checks if set or provided hardfork is active on block number
 
 **Parameters:**
 
-| Name          | Type               | Description                          |
-| ------------- | ------------------ | ------------------------------------ |
-| `hardfork`    | string &#124; null | Hardfork name or null (for HF set)   |
-| `blockNumber` | number             | -                                    |
-| `opts?`       | hardforkOptions    | Hardfork options (onlyActive unused) |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork` | string &#124; null | Hardfork name or null (for HF set) |
+`blockNumber` | number | - |
+`opts?` | hardforkOptions | Hardfork options (onlyActive unused) |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if HF is active on block number
 
----
+___
 
-### hardforkIsActiveOnChain
+###  hardforkIsActiveOnChain
 
-▸ **hardforkIsActiveOnChain**(`hardfork?`: string | null, `opts?`: hardforkOptions): _boolean_
+▸ **hardforkIsActiveOnChain**(`hardfork?`: string | null, `opts?`: hardforkOptions): *boolean*
 
-_Defined in [index.ts:291](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L291)_
+*Defined in [index.ts:291](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L291)*
 
 Checks if given or set hardfork is active on the chain
 
 **Parameters:**
 
-| Name        | Type               | Description                          |
-| ----------- | ------------------ | ------------------------------------ |
-| `hardfork?` | string &#124; null | Hardfork name, optional if HF set    |
-| `opts?`     | hardforkOptions    | Hardfork options (onlyActive unused) |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork?` | string &#124; null | Hardfork name, optional if HF set |
+`opts?` | hardforkOptions | Hardfork options (onlyActive unused) |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if hardfork is active on the chain
 
----
+___
 
-### hardforks
+###  hardforks
 
-▸ **hardforks**(): _any_
+▸ **hardforks**(): *any*
 
-_Defined in [index.ts:394](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L394)_
+*Defined in [index.ts:374](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L374)*
 
 Returns the hardforks for current chain
 
-**Returns:** _any_
+**Returns:** *any*
 
 Array with arrays of hardforks
 
----
+___
 
-### isHardforkBlock
+###  isHardforkBlock
 
-▸ **isHardforkBlock**(`blockNumber`: number, `hardfork?`: undefined | string): _boolean_
+▸ **isHardforkBlock**(`blockNumber`: number, `hardfork?`: undefined | string): *boolean*
 
-_Defined in [index.ts:353](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L353)_
+*Defined in [index.ts:353](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L353)*
 
 True if block number provided is the hardfork (given or set) change block of the current chain
 
 **Parameters:**
 
-| Name          | Type                    | Description                       |
-| ------------- | ----------------------- | --------------------------------- |
-| `blockNumber` | number                  | Number of the block to check      |
-| `hardfork?`   | undefined &#124; string | Hardfork name, optional if HF set |
+Name | Type | Description |
+------ | ------ | ------ |
+`blockNumber` | number | Number of the block to check |
+`hardfork?` | undefined &#124; string | Hardfork name, optional if HF set |
 
-**Returns:** _boolean_
+**Returns:** *boolean*
 
 True if blockNumber is HF block
 
----
+___
 
-### networkId
+###  networkId
 
-▸ **networkId**(): _number_
+▸ **networkId**(): *number*
 
-_Defined in [index.ts:434](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L434)_
+*Defined in [index.ts:414](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L414)*
 
 Returns the Id of current network
 
-**Returns:** _number_
+**Returns:** *number*
 
 network Id
 
----
+___
 
-### param
+###  param
 
-▸ **param**(`topic`: string, `name`: string, `hardfork?`: undefined | string): _any_
+▸ **param**(`topic`: string, `name`: string, `hardfork?`: undefined | string): *any*
 
-_Defined in [index.ts:180](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L180)_
+*Defined in [index.ts:180](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L180)*
 
 Returns the parameter corresponding to a hardfork
 
 **Parameters:**
 
-| Name        | Type                    | Description                                                                   |
-| ----------- | ----------------------- | ----------------------------------------------------------------------------- |
-| `topic`     | string                  | Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow', 'casper', 'sharding') |
-| `name`      | string                  | Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic)                     |
-| `hardfork?` | undefined &#124; string | Hardfork name, optional if hardfork set                                       |
+Name | Type | Description |
+------ | ------ | ------ |
+`topic` | string | Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow', 'casper', 'sharding') |
+`name` | string | Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic) |
+`hardfork?` | undefined &#124; string | Hardfork name, optional if hardfork set  |
 
-**Returns:** _any_
+**Returns:** *any*
 
----
+___
 
-### paramByBlock
+###  paramByBlock
 
-▸ **paramByBlock**(`topic`: string, `name`: string, `blockNumber`: number): _any_
+▸ **paramByBlock**(`topic`: string, `name`: string, `blockNumber`: number): *any*
 
-_Defined in [index.ts:205](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L205)_
+*Defined in [index.ts:205](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L205)*
 
 Returns a parameter for the hardfork active on block number
 
 **Parameters:**
 
-| Name          | Type   | Description     |
-| ------------- | ------ | --------------- |
-| `topic`       | string | Parameter topic |
-| `name`        | string | Parameter name  |
-| `blockNumber` | number | Block number    |
+Name | Type | Description |
+------ | ------ | ------ |
+`topic` | string | Parameter topic |
+`name` | string | Parameter name |
+`blockNumber` | number | Block number  |
 
-**Returns:** _any_
+**Returns:** *any*
 
----
+___
 
-### setChain
+###  setChain
 
-▸ **setChain**(`chain`: string | number | object): _any_
+▸ **setChain**(`chain`: string | number | object): *any*
 
-_Defined in [index.ts:89](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L89)_
+*Defined in [index.ts:89](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L89)*
 
 Sets the chain
 
 **Parameters:**
 
-| Name    | Type                               | Description                                                                                                        |
-| ------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `chain` | string &#124; number &#124; object | String ('mainnet') or Number (1) chain representation. Or, a Dictionary of chain parameters for a private network. |
+Name | Type | Description |
+------ | ------ | ------ |
+`chain` | string &#124; number &#124; object | String ('mainnet') or Number (1) chain     representation. Or, a Dictionary of chain parameters for a private network. |
 
-**Returns:** _any_
+**Returns:** *any*
 
 The dictionary with parameters set as chain
 
----
+___
 
-### setHardfork
+###  setHardfork
 
-▸ **setHardfork**(`hardfork`: string | null): _void_
+▸ **setHardfork**(`hardfork`: string | null): *void*
 
-_Defined in [index.ts:110](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L110)_
+*Defined in [index.ts:110](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L110)*
 
 Sets the hardfork to get params for
 
 **Parameters:**
 
-| Name       | Type               | Description                     |
-| ---------- | ------------------ | ------------------------------- |
-| `hardfork` | string &#124; null | String identifier ('byzantium') |
+Name | Type | Description |
+------ | ------ | ------ |
+`hardfork` | string &#124; null | String identifier ('byzantium')  |
 
-**Returns:** _void_
+**Returns:** *void*
 
----
+___
 
 ### `Static` forCustomChain
 
-▸ **forCustomChain**(`baseChain`: string | number, `customChainParams`: Partial‹[Chain](../interfaces/_types_.chain.md)›, `hardfork?`: string | null, `supportedHardforks?`: Array‹string›): _[Common](\_index_.common.md)\_
+▸ **forCustomChain**(`baseChain`: string | number, `customChainParams`: Partial‹[Chain](../interfaces/_types_.chain.md)›, `hardfork?`: string | null, `supportedHardforks?`: Array‹string›): *[Common](_index_.common.md)*
 
-_Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L30)_
+*Defined in [index.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/index.ts#L30)*
 
 Creates a Common object for a custom chain, based on a standard one. It uses all the [Chain](../interfaces/_types_.chain.md)
 params from [[baseChain]] except the ones overridden in [[customChainParams]].
 
 **Parameters:**
 
-| Name                  | Type                                             | Description                                                                                   |
-| --------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `baseChain`           | string &#124; number                             | The name (`mainnet`) or id (`1`) of a standard chain used to base the custom chain params on. |
-| `customChainParams`   | Partial‹[Chain](../interfaces/_types_.chain.md)› | The custom parameters of the chain.                                                           |
-| `hardfork?`           | string &#124; null                               | String identifier ('byzantium') for hardfork (optional)                                       |
-| `supportedHardforks?` | Array‹string›                                    | Limit parameter returns to the given hardforks (optional)                                     |
+Name | Type | Description |
+------ | ------ | ------ |
+`baseChain` | string &#124; number | The name (`mainnet`) or id (`1`) of a standard chain used to base the custom chain params on. |
+`customChainParams` | Partial‹[Chain](../interfaces/_types_.chain.md)› | The custom parameters of the chain. |
+`hardfork?` | string &#124; null | String identifier ('byzantium') for hardfork (optional) |
+`supportedHardforks?` | Array‹string› | Limit parameter returns to the given hardforks (optional)  |
 
-**Returns:** _[Common](\_index_.common.md)\_
+**Returns:** *[Common](_index_.common.md)*

--- a/packages/common/docs/interfaces/_types_.bootstrapnode.md
+++ b/packages/common/docs/interfaces/_types_.bootstrapnode.md
@@ -4,72 +4,72 @@
 
 ## Hierarchy
 
-- **BootstrapNode**
+* **BootstrapNode**
 
 ## Index
 
 ### Properties
 
-- [chainId](_types_.bootstrapnode.md#optional-chainid)
-- [comment](_types_.bootstrapnode.md#comment)
-- [id](_types_.bootstrapnode.md#id)
-- [ip](_types_.bootstrapnode.md#ip)
-- [location](_types_.bootstrapnode.md#location)
-- [network](_types_.bootstrapnode.md#optional-network)
-- [port](_types_.bootstrapnode.md#port)
+* [chainId](_types_.bootstrapnode.md#optional-chainid)
+* [comment](_types_.bootstrapnode.md#comment)
+* [id](_types_.bootstrapnode.md#id)
+* [ip](_types_.bootstrapnode.md#ip)
+* [location](_types_.bootstrapnode.md#location)
+* [network](_types_.bootstrapnode.md#optional-network)
+* [port](_types_.bootstrapnode.md#port)
 
 ## Properties
 
 ### `Optional` chainId
 
-• **chainId**? : _undefined | number_
+• **chainId**? : *undefined | number*
 
-_Defined in [types.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L47)_
+*Defined in [types.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L45)*
 
----
+___
 
-### comment
+###  comment
 
-• **comment**: _string_
+• **comment**: *string*
 
-_Defined in [types.ts:50](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L50)_
+*Defined in [types.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L48)*
 
----
+___
 
-### id
+###  id
 
-• **id**: _string_
+• **id**: *string*
 
-_Defined in [types.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L48)_
+*Defined in [types.ts:46](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L46)*
 
----
+___
 
-### ip
+###  ip
 
-• **ip**: _string_
+• **ip**: *string*
 
-_Defined in [types.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L44)_
+*Defined in [types.ts:42](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L42)*
 
----
+___
 
-### location
+###  location
 
-• **location**: _string_
+• **location**: *string*
 
-_Defined in [types.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L49)_
+*Defined in [types.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L47)*
 
----
+___
 
 ### `Optional` network
 
-• **network**? : _undefined | string_
+• **network**? : *undefined | string*
 
-_Defined in [types.ts:46](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L46)_
+*Defined in [types.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L44)*
 
----
+___
 
-### port
+###  port
 
-• **port**: _number | string_
+• **port**: *number | string*
 
-_Defined in [types.ts:45](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L45)_
+*Defined in [types.ts:43](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L43)*

--- a/packages/common/docs/interfaces/_types_.chain.md
+++ b/packages/common/docs/interfaces/_types_.chain.md
@@ -4,81 +4,81 @@
 
 ## Hierarchy
 
-- **Chain**
+* **Chain**
 
 ## Index
 
 ### Properties
 
-- [bootstrapNodes](_types_.chain.md#bootstrapnodes)
-- [chainId](_types_.chain.md#chainid)
-- [comment](_types_.chain.md#comment)
-- [genesis](_types_.chain.md#genesis)
-- [hardforks](_types_.chain.md#hardforks)
-- [name](_types_.chain.md#name)
-- [networkId](_types_.chain.md#networkid)
-- [url](_types_.chain.md#url)
+* [bootstrapNodes](_types_.chain.md#bootstrapnodes)
+* [chainId](_types_.chain.md#chainid)
+* [comment](_types_.chain.md#comment)
+* [genesis](_types_.chain.md#genesis)
+* [hardforks](_types_.chain.md#hardforks)
+* [name](_types_.chain.md#name)
+* [networkId](_types_.chain.md#networkid)
+* [url](_types_.chain.md#url)
 
 ## Properties
 
-### bootstrapNodes
+###  bootstrapNodes
 
-• **bootstrapNodes**: _[BootstrapNode](\_types_.bootstrapnode.md)[]\_
+• **bootstrapNodes**: *[BootstrapNode](_types_.bootstrapnode.md)[]*
 
-_Defined in [types.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L23)_
+*Defined in [types.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L23)*
 
----
+___
 
-### chainId
+###  chainId
 
-• **chainId**: _number_
+• **chainId**: *number*
 
-_Defined in [types.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L17)_
+*Defined in [types.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L17)*
 
----
+___
 
-### comment
+###  comment
 
-• **comment**: _string_
+• **comment**: *string*
 
-_Defined in [types.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L19)_
+*Defined in [types.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L19)*
 
----
+___
 
-### genesis
+###  genesis
 
-• **genesis**: _[GenesisBlock](\_types_.genesisblock.md)\_
+• **genesis**: *[GenesisBlock](_types_.genesisblock.md)*
 
-_Defined in [types.ts:21](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L21)_
+*Defined in [types.ts:21](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L21)*
 
----
+___
 
-### hardforks
+###  hardforks
 
-• **hardforks**: _[Hardfork](\_types_.hardfork.md)[]\_
+• **hardforks**: *[Hardfork](_types_.hardfork.md)[]*
 
-_Defined in [types.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L22)_
+*Defined in [types.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L22)*
 
----
+___
 
-### name
+###  name
 
-• **name**: _string_
+• **name**: *string*
 
-_Defined in [types.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L16)_
+*Defined in [types.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L16)*
 
----
+___
 
-### networkId
+###  networkId
 
-• **networkId**: _number_
+• **networkId**: *number*
 
-_Defined in [types.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L18)_
+*Defined in [types.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L18)*
 
----
+___
 
-### url
+###  url
 
-• **url**: _string_
+• **url**: *string*
 
-_Defined in [types.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L20)_
+*Defined in [types.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L20)*

--- a/packages/common/docs/interfaces/_types_.chainstype.md
+++ b/packages/common/docs/interfaces/_types_.chainstype.md
@@ -4,26 +4,26 @@
 
 ## Hierarchy
 
-- **chainsType**
+* **chainsType**
 
 ## Indexable
 
-- \[ **key**: _string_\]: any
+* \[ **key**: *string*\]: any
 
 ## Index
 
 ### Properties
 
-- [names](_types_.chainstype.md#names)
+* [names](_types_.chainstype.md#names)
 
 ## Properties
 
-### names
+###  names
 
-• **names**: _object_
+• **names**: *object*
 
-_Defined in [types.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L9)_
+*Defined in [types.ts:9](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L9)*
 
 #### Type declaration:
 
-- \[ **key**: _string_\]: string
+* \[ **key**: *string*\]: string

--- a/packages/common/docs/interfaces/_types_.genesisblock.md
+++ b/packages/common/docs/interfaces/_types_.genesisblock.md
@@ -4,72 +4,72 @@
 
 ## Hierarchy
 
-- **GenesisBlock**
+* **GenesisBlock**
 
 ## Index
 
 ### Properties
 
-- [difficulty](_types_.genesisblock.md#difficulty)
-- [extraData](_types_.genesisblock.md#extradata)
-- [gasLimit](_types_.genesisblock.md#gaslimit)
-- [hash](_types_.genesisblock.md#hash)
-- [nonce](_types_.genesisblock.md#nonce)
-- [stateRoot](_types_.genesisblock.md#stateroot)
-- [timestamp](_types_.genesisblock.md#timestamp)
+* [difficulty](_types_.genesisblock.md#difficulty)
+* [extraData](_types_.genesisblock.md#extradata)
+* [gasLimit](_types_.genesisblock.md#gaslimit)
+* [hash](_types_.genesisblock.md#hash)
+* [nonce](_types_.genesisblock.md#nonce)
+* [stateRoot](_types_.genesisblock.md#stateroot)
+* [timestamp](_types_.genesisblock.md#timestamp)
 
 ## Properties
 
-### difficulty
+###  difficulty
 
-• **difficulty**: _number_
+• **difficulty**: *number*
 
-_Defined in [types.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L30)_
+*Defined in [types.ts:30](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L30)*
 
----
+___
 
-### extraData
+###  extraData
 
-• **extraData**: _string_
+• **extraData**: *string*
 
-_Defined in [types.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L32)_
+*Defined in [types.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L32)*
 
----
+___
 
-### gasLimit
+###  gasLimit
 
-• **gasLimit**: _number_
+• **gasLimit**: *number*
 
-_Defined in [types.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L29)_
+*Defined in [types.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L29)*
 
----
+___
 
-### hash
+###  hash
 
-• **hash**: _string_
+• **hash**: *string*
 
-_Defined in [types.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L27)_
+*Defined in [types.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L27)*
 
----
+___
 
-### nonce
+###  nonce
 
-• **nonce**: _string_
+• **nonce**: *string*
 
-_Defined in [types.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L31)_
+*Defined in [types.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L31)*
 
----
+___
 
-### stateRoot
+###  stateRoot
 
-• **stateRoot**: _string_
+• **stateRoot**: *string*
 
-_Defined in [types.ts:33](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L33)_
+*Defined in [types.ts:33](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L33)*
 
----
+___
 
-### timestamp
+###  timestamp
 
-• **timestamp**: _string | null_
+• **timestamp**: *string | null*
 
-_Defined in [types.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L28)_
+*Defined in [types.ts:28](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L28)*

--- a/packages/common/docs/interfaces/_types_.genesisstatestype.md
+++ b/packages/common/docs/interfaces/_types_.genesisstatestype.md
@@ -4,26 +4,26 @@
 
 ## Hierarchy
 
-- **genesisStatesType**
+* **genesisStatesType**
 
 ## Indexable
 
-- \[ **key**: _string_\]: object
+* \[ **key**: *string*\]: object
 
 ## Index
 
 ### Properties
 
-- [names](_types_.genesisstatestype.md#names)
+* [names](_types_.genesisstatestype.md#names)
 
 ## Properties
 
-### names
+###  names
 
-• **names**: _object_
+• **names**: *object*
 
-_Defined in [types.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L2)_
+*Defined in [types.ts:2](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L2)*
 
 #### Type declaration:
 
-- \[ **key**: _string_\]: string
+* \[ **key**: *string*\]: string

--- a/packages/common/docs/interfaces/_types_.hardfork.md
+++ b/packages/common/docs/interfaces/_types_.hardfork.md
@@ -4,45 +4,27 @@
 
 ## Hierarchy
 
-- **Hardfork**
+* **Hardfork**
 
 ## Index
 
 ### Properties
 
-- [block](_types_.hardfork.md#block)
-- [consensus](_types_.hardfork.md#consensus)
-- [finality](_types_.hardfork.md#finality)
-- [name](_types_.hardfork.md#name)
+* [block](_types_.hardfork.md#block)
+* [name](_types_.hardfork.md#name)
 
 ## Properties
 
-### block
+###  block
 
-• **block**: _number | null_
+• **block**: *number | null*
 
-_Defined in [types.ts:38](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L38)_
+*Defined in [types.ts:38](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L38)*
 
----
+___
 
-### consensus
+###  name
 
-• **consensus**: _string_
+• **name**: *string*
 
-_Defined in [types.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L39)_
-
----
-
-### finality
-
-• **finality**: _any_
-
-_Defined in [types.ts:40](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L40)_
-
----
-
-### name
-
-• **name**: _string_
-
-_Defined in [types.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L37)_
+*Defined in [types.ts:37](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/types.ts#L37)*

--- a/packages/common/docs/modules/_genesisstates_index_.md
+++ b/packages/common/docs/modules/_genesisstates_index_.md
@@ -6,45 +6,45 @@
 
 ### Functions
 
-- [genesisStateById](_genesisstates_index_.md#genesisstatebyid)
-- [genesisStateByName](_genesisstates_index_.md#genesisstatebyname)
+* [genesisStateById](_genesisstates_index_.md#genesisstatebyid)
+* [genesisStateByName](_genesisstates_index_.md#genesisstatebyname)
 
 ## Functions
 
-### genesisStateById
+###  genesisStateById
 
-▸ **genesisStateById**(`id`: number): _any_
+▸ **genesisStateById**(`id`: number): *any*
 
-_Defined in [genesisStates/index.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/genesisStates/index.ts#L23)_
+*Defined in [genesisStates/index.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/genesisStates/index.ts#L23)*
 
 Returns the genesis state by network ID
 
 **Parameters:**
 
-| Name | Type   | Description                |
-| ---- | ------ | -------------------------- |
-| `id` | number | ID of the network (e.g. 1) |
+Name | Type | Description |
+------ | ------ | ------ |
+`id` | number | ID of the network (e.g. 1) |
 
-**Returns:** _any_
+**Returns:** *any*
 
 Dictionary with genesis accounts
 
----
+___
 
-### genesisStateByName
+###  genesisStateByName
 
-▸ **genesisStateByName**(`name`: string): _any_
+▸ **genesisStateByName**(`name`: string): *any*
 
-_Defined in [genesisStates/index.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/genesisStates/index.ts#L32)_
+*Defined in [genesisStates/index.ts:32](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/genesisStates/index.ts#L32)*
 
 Returns the genesis state by network name
 
 **Parameters:**
 
-| Name   | Type   | Description                          |
-| ------ | ------ | ------------------------------------ |
-| `name` | string | Name of the network (e.g. 'mainnet') |
+Name | Type | Description |
+------ | ------ | ------ |
+`name` | string | Name of the network (e.g. 'mainnet') |
 
-**Returns:** _any_
+**Returns:** *any*
 
 Dictionary with genesis accounts

--- a/packages/common/docs/modules/_index_.md
+++ b/packages/common/docs/modules/_index_.md
@@ -6,4 +6,4 @@
 
 ### Classes
 
-- [Common](../classes/_index_.common.md)
+* [Common](../classes/_index_.common.md)

--- a/packages/common/docs/modules/_types_.md
+++ b/packages/common/docs/modules/_types_.md
@@ -6,9 +6,9 @@
 
 ### Interfaces
 
-- [BootstrapNode](../interfaces/_types_.bootstrapnode.md)
-- [Chain](../interfaces/_types_.chain.md)
-- [GenesisBlock](../interfaces/_types_.genesisblock.md)
-- [Hardfork](../interfaces/_types_.hardfork.md)
-- [chainsType](../interfaces/_types_.chainstype.md)
-- [genesisStatesType](../interfaces/_types_.genesisstatestype.md)
+* [BootstrapNode](../interfaces/_types_.bootstrapnode.md)
+* [Chain](../interfaces/_types_.chain.md)
+* [GenesisBlock](../interfaces/_types_.genesisblock.md)
+* [Hardfork](../interfaces/_types_.hardfork.md)
+* [chainsType](../interfaces/_types_.chainstype.md)
+* [genesisStatesType](../interfaces/_types_.genesisstatestype.md)

--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -16,63 +16,43 @@
   "hardforks": [
     {
       "name": "chainstart",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "homestead",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "dao",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "tangerineWhistle",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "spuriousDragon",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "byzantium",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "constantinople",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "petersburg",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "istanbul",
-      "block": 1561651,
-      "consensus": "poa",
-      "finality": null
+      "block": 1561651
     },
     {
       "name": "berlin",
-      "block": null,
-      "consensus": "poa",
-      "finality": null
+      "block": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -16,63 +16,43 @@
   "hardforks": [
     {
       "name": "chainstart",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "homestead",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "dao",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "tangerineWhistle",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "spuriousDragon",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "byzantium",
-      "block": 5067000,
-      "consensus": "poa",
-      "finality": null
+      "block": 5067000
     },
     {
       "name": "constantinople",
-      "block": 9200000,
-      "consensus": "poa",
-      "finality": null
+      "block": 9200000
     },
     {
       "name": "petersburg",
-      "block": 10255201,
-      "consensus": "poa",
-      "finality": null
+      "block": 10255201
     },
     {
       "name": "istanbul",
-      "block": 14111141,
-      "consensus": "poa",
-      "finality": null
+      "block": 14111141
     },
     {
       "name": "berlin",
-      "block": null,
-      "consensus": "poa",
-      "finality": null
+      "block": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/mainnet.json
+++ b/packages/common/src/chains/mainnet.json
@@ -16,69 +16,47 @@
   "hardforks": [
     {
       "name": "chainstart",
-      "block": 0,
-      "consensus": "pow",
-      "finality": null
+      "block": 0
     },
     {
       "name": "homestead",
-      "block": 1150000,
-      "consensus": "pow",
-      "finality": null
+      "block": 1150000
     },
     {
       "name": "dao",
-      "block": 1920000,
-      "consensus": "pow",
-      "finality": null
+      "block": 1920000
     },
     {
       "name": "tangerineWhistle",
-      "block": 2463000,
-      "consensus": "pow",
-      "finality": null
+      "block": 2463000
     },
     {
       "name": "spuriousDragon",
-      "block": 2675000,
-      "consensus": "pow",
-      "finality": null
+      "block": 2675000
     },
     {
       "name": "byzantium",
-      "block": 4370000,
-      "consensus": "pow",
-      "finality": null
+      "block": 4370000
     },
     {
       "name": "constantinople",
-      "block": 7280000,
-      "consensus": "pow",
-      "finality": null
+      "block": 7280000
     },
     {
       "name": "petersburg",
-      "block": 7280000,
-      "consensus": "pow",
-      "finality": null
+      "block": 7280000
     },
     {
       "name": "istanbul",
-      "block": 9069000,
-      "consensus": "pow",
-      "finality": null
+      "block": 9069000
     },
     {
       "name": "muirGlacier",
-      "block": 9200000,
-      "consensus": "pow",
-      "finality": null
+      "block": 9200000
     },
     {
       "name": "berlin",
-      "block": null,
-      "consensus": "pow",
-      "finality": null
+      "block": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/rinkeby.json
+++ b/packages/common/src/chains/rinkeby.json
@@ -16,63 +16,43 @@
   "hardforks": [
     {
       "name": "chainstart",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "homestead",
-      "block": 1,
-      "consensus": "poa",
-      "finality": null
+      "block": 1
     },
     {
       "name": "dao",
-      "block": null,
-      "consensus": "poa",
-      "finality": null
+      "block": null
     },
     {
       "name": "tangerineWhistle",
-      "block": 2,
-      "consensus": "poa",
-      "finality": null
+      "block": 2
     },
     {
       "name": "spuriousDragon",
-      "block": 3,
-      "consensus": "poa",
-      "finality": null
+      "block": 3
     },
     {
       "name": "byzantium",
-      "block": 1035301,
-      "consensus": "poa",
-      "finality": null
+      "block": 1035301
     },
     {
       "name": "constantinople",
-      "block": 3660663,
-      "consensus": "poa",
-      "finality": null
+      "block": 3660663
     },
     {
       "name": "petersburg",
-      "block": 4321234,
-      "consensus": "poa",
-      "finality": null
+      "block": 4321234
     },
     {
       "name": "istanbul",
-      "block": 5435345,
-      "consensus": "poa",
-      "finality": null
+      "block": 5435345
     },
     {
       "name": "berlin",
-      "block": null,
-      "consensus": "poa",
-      "finality": null
+      "block": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/ropsten.json
+++ b/packages/common/src/chains/ropsten.json
@@ -16,69 +16,47 @@
   "hardforks": [
     {
       "name": "chainstart",
-      "block": 0,
-      "consensus": "pow",
-      "finality": null
+      "block": 0
     },
     {
       "name": "homestead",
-      "block": 0,
-      "consensus": "pow",
-      "finality": null
+      "block": 0
     },
     {
       "name": "dao",
-      "block": null,
-      "consensus": "pow",
-      "finality": null
+      "block": null
     },
     {
       "name": "tangerineWhistle",
-      "block": 0,
-      "consensus": "pow",
-      "finality": null
+      "block": 0
     },
     {
       "name": "spuriousDragon",
-      "block": 10,
-      "consensus": "pow",
-      "finality": null
+      "block": 10
     },
     {
       "name": "byzantium",
-      "block": 1700000,
-      "consensus": "pow",
-      "finality": null
+      "block": 1700000
     },
     {
       "name": "constantinople",
-      "block": 4230000,
-      "consensus": "pow",
-      "finality": null
+      "block": 4230000
     },
     {
       "name": "petersburg",
-      "block": 4939394,
-      "consensus": "pow",
-      "finality": null
+      "block": 4939394
     },
     {
       "name": "istanbul",
-      "block": 6485846,
-      "consensus": "pow",
-      "finality": null
+      "block": 6485846
     },
     {
       "name": "muirGlacier",
-      "block": 7117117,
-      "consensus": "pow",
-      "finality": null
+      "block": 7117117
     },
     {
       "name": "berlin",
-      "block": null,
-      "consensus": "pow",
-      "finality": null
+      "block": null
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -360,26 +360,6 @@ export default class Common {
   }
 
   /**
-   * Provide the consensus type for the hardfork set or provided as param
-   * @param hardfork Hardfork name, optional if hardfork set
-   * @returns Consensus type (e.g. 'pow', 'poa')
-   */
-  consensus(hardfork?: string): string {
-    hardfork = this._chooseHardfork(hardfork)
-    return this._getHardfork(hardfork)['consensus']
-  }
-
-  /**
-   * Provide the finality type for the hardfork set or provided as param
-   * @param {String} hardfork Hardfork name, optional if hardfork set
-   * @returns {String} Finality type (e.g. 'pos', null of no finality)
-   */
-  finality(hardfork?: string): string {
-    hardfork = this._chooseHardfork(hardfork)
-    return this._getHardfork(hardfork)['finality']
-  }
-
-  /**
    * Returns the Genesis parameters of current chain
    * @returns Genesis dictionary
    */

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -36,8 +36,6 @@ export interface GenesisBlock {
 export interface Hardfork {
   name: string
   block: number | null
-  consensus: string
-  finality: any
 }
 
 export interface BootstrapNode {

--- a/packages/common/tests/hardforks.ts
+++ b/packages/common/tests/hardforks.ts
@@ -222,14 +222,4 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
     st.end()
   })
-
-  t.test('consensus()/finality()', function(st: tape.Test) {
-    const c = new Common('mainnet')
-    st.equal(c.consensus('byzantium'), 'pow', 'should return pow for byzantium consensus')
-    st.equal(c.consensus('constantinople'), 'pow', 'should return pow for constantinople consensus')
-    st.equal(c.finality('byzantium'), null, 'should return null for byzantium finality')
-
-    st.comment('-----------------------------------------------------------------')
-    st.end()
-  })
 })

--- a/packages/common/tests/testnet.json
+++ b/packages/common/tests/testnet.json
@@ -15,33 +15,23 @@
   "hardforks": [
     {
       "name": "chainstart",
-      "block": 0,
-      "consensus": "poa",
-      "finality": null
+      "block": 0
     },
     {
       "name": "homestead",
-      "block": 1,
-      "consensus": "poa",
-      "finality": null
+      "block": 1
     },
     {
       "name": "tangerineWhistle",
-      "block": 2,
-      "consensus": "poa",
-      "finality": null
+      "block": 2
     },
     {
       "name": "spuriousDragon",
-      "block": 3,
-      "consensus": "poa",
-      "finality": null
+      "block": 3
     },
     {
       "name": "byzantium",
-      "block": 4,
-      "consensus": "poa",
-      "finality": null
+      "block": 4
     }
   ],
   "bootstrapNodes": [


### PR DESCRIPTION
As per https://github.com/ethereumjs/ethereumjs-vm/pull/755#discussion_r431622116, this PR removes old unused fields `consensus` and `finality`.

Please see [this commit](https://github.com/ethereumjs/ethereumjs-vm/pull/758/commits/e8c831b626c9408b4f9473bd3e18704dbb34fe03) for a clean diff prior to rebuilding docs.