### PR TITLE
common: remove old fields `casper` and `sharding`

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -93,8 +93,6 @@ you can use the following `topics`:
 - `gasPrices`
 - `vm`
 - `pow`
-- `casper`
-- `sharding`
 
 See one of the hardfork files like `byzantium.json` in the `hardforks` directory
 for an overview. For consistency, the chain start (`chainstart`) is considered an own

--- a/packages/common/docs/classes/_index_.common.md
+++ b/packages/common/docs/classes/_index_.common.md
@@ -424,7 +424,7 @@ Returns the parameter corresponding to a hardfork
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`topic` | string | Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow', 'casper', 'sharding') |
+`topic` | string | Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow') |
 `name` | string | Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic) |
 `hardfork?` | undefined &#124; string | Hardfork name, optional if hardfork set  |
 

--- a/packages/common/src/hardforks/berlin.json
+++ b/packages/common/src/hardforks/berlin.json
@@ -8,7 +8,5 @@
   "gasConfig": {},
   "gasPrices": {},
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/byzantium.json
+++ b/packages/common/src/hardforks/byzantium.json
@@ -34,7 +34,5 @@
       "v": "3000000000000000000",
       "d": "the amount a miner get rewarded for mining a block"
     }
-  },
-  "casper": {},
-  "sharding": {}
+  }
 }

--- a/packages/common/src/hardforks/chainstart.json
+++ b/packages/common/src/hardforks/chainstart.json
@@ -205,7 +205,5 @@
       "v": "5000000000000000000",
       "d": "the amount a miner get rewarded for mining a block"
     }
-  },
-  "casper": {},
-  "sharding": {}
+  }
 }

--- a/packages/common/src/hardforks/constantinople.json
+++ b/packages/common/src/hardforks/constantinople.json
@@ -42,7 +42,5 @@
       "v": "2000000000000000000",
       "d": "The amount a miner gets rewarded for mining a block"
     }
-  },
-  "casper": {},
-  "sharding": {}
+  }
 }

--- a/packages/common/src/hardforks/dao.json
+++ b/packages/common/src/hardforks/dao.json
@@ -8,7 +8,5 @@
   "gasConfig": {},
   "gasPrices": {},
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/homestead.json
+++ b/packages/common/src/hardforks/homestead.json
@@ -8,7 +8,5 @@
   "gasConfig": {},
   "gasPrices": {},
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/istanbul.json
+++ b/packages/common/src/hardforks/istanbul.json
@@ -65,7 +65,5 @@
     }
   },
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/muirGlacier.json
+++ b/packages/common/src/hardforks/muirGlacier.json
@@ -8,7 +8,5 @@
   "gasConfig": {},
   "gasPrices": {},
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/petersburg.json
+++ b/packages/common/src/hardforks/petersburg.json
@@ -37,7 +37,5 @@
     }
   },
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/spuriousDragon.json
+++ b/packages/common/src/hardforks/spuriousDragon.json
@@ -18,7 +18,5 @@
       "d": "Maximum length of contract code"
     }
   },
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/hardforks/tangerineWhistle.json
+++ b/packages/common/src/hardforks/tangerineWhistle.json
@@ -17,7 +17,5 @@
     }
   },
   "vm": {},
-  "pow": {},
-  "casper": {},
-  "sharding": {}
+  "pow": {}
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -173,7 +173,7 @@ export default class Common {
 
   /**
    * Returns the parameter corresponding to a hardfork
-   * @param topic Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow', 'casper', 'sharding')
+   * @param topic Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow')
    * @param name Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic)
    * @param hardfork Hardfork name, optional if hardfork set
    */


### PR DESCRIPTION
As per https://github.com/ethereumjs/ethereumjs-vm/pull/758#pullrequestreview-423472672, this PR removes old unused fields `casper` and `sharding`.