### PR TITLE
tooling: adding script to inspect TS interface diffs

### DIFF
--- a/scripts/ts-interface-diff.sh
+++ b/scripts/ts-interface-diff.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
+set -o xtrace
+set -e
 
 # Performs a diff between current type definition files and the latest published on npm. 
 # This is useful as a helper to detect interface and API changes, without having to look
-# at source files or performing git diffs.
+# at source files or performing git diffs. 
+# 
+# Note: this script assumes that the d.ts files live under ./dist directory.
 # 
 # Usage: ./scripts/ts-interface-diff.sh ethereumjs-vm packages/vm/
 # Run from repository root
@@ -11,32 +15,49 @@
 # ./scripts/ts-interface-diff.sh ethereumjs-blockchain packages/blockchain/ | code-
 # 
 
-NPM_PACKAGE=$1
-DIST_PATH=$2
+PACKAGE_NAME=$1
+DIST_PATH=$2/dist
+CACHE_PATH=.tmp/$PACKAGE_NAME/cache
 
-# setting up workspace
-rm -rf .tmp/$NPM_PACKAGE
-mkdir -p .tmp/$NPM_PACKAGE
+# A and B are parts of the comparison
+A_PATH=.tmp/$PACKAGE_NAME/A # definition files from npm
+B_PATH=.tmp/$PACKAGE_NAME/B # definition files from repo
+
+# setting up dir tree
+rm -rf .tmp/$PACKAGE_NAME
+mkdir -p $CACHE_PATH $A_PATH $B_PATH
+
+A_FULL_PATH=`realpath $A_PATH`
+B_FULL_PATH=`realpath $B_PATH`
 
 # Downloads latest published pacakge from npm. Stores tarball file name in variable TGZ
-TGZ=`npm pack $NPM_PACKAGE`
+TGZ=`npm pack $PACKAGE_NAME`
 
-# unpacks to .tmp/ethereumjs-vm
-tar -xzf $TGZ --strip-components=1 -C .tmp/$NPM_PACKAGE
-rm $TGZ
+# unpacks to $CACHE_PATH
+tar -xzf $TGZ --strip-components=1 -C $CACHE_PATH
 
-cd .tmp/$NPM_PACKAGE
-RELATIVE_PATHS=`find . -iname "*.d.ts"`
+# # copies definition files recursively from unpacked package
+cd $CACHE_PATH/dist
+pwd -L
+find . | grep -E "\.d\.ts$" | cpio -pvd $A_FULL_PATH
 cd -
 
-echo "TypeScript definition files found in published npm package:"
-echo $RELATIVE_PATHS | tr ' ' '\n'
+# copies definition files recursively to a tmp directory
+cd $DIST_PATH
+find . | grep -E "\.d\.ts$" | cpio -pvd $B_FULL_PATH
+cd -
 
-# echoes the file diffs.
-for FILE in $RELATIVE_PATHS
-do
-    echo "====================================="
-    echo $FILE
-    echo "====================================="
-    diff ".tmp/$NPM_PACKAGE/$FILE" "$DIST_PATH/$FILE"
-done
+# cleanup
+rm -rf $TGZ $CACHE_PATH
+
+git diff --no-index -- $A_PATH $B_PATH
+
+# fin.
+
+###
+# After running this script, you can just run the standalone command:
+# git diff --no-index -- .tmp/ethereumjs-vm/A .tmp/ethereumjs-vm/B
+# 
+# or variations of it:
+# git diff --word-diff=color --no-index -- .tmp/ethereumjs-vm/A .tmp/ethereumjs-vm/B
+###

--- a/scripts/ts-interface-diff.sh
+++ b/scripts/ts-interface-diff.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Performs a diff between current type definition files and the latest published on npm. 
+# This is useful as a helper to detect interface and API changes, without having to look
+# at source files or performing git diffs.
+# 
+# Usage: ./scripts/ts-interface-diff.sh ethereumjs-vm packages/vm/
+# Run from repository root
+# 
+# To send stdout to VS Code to leverage better tools to visualize diff, you can run:
+# ./scripts/ts-interface-diff.sh ethereumjs-blockchain packages/blockchain/ | code-
+# 
+
+NPM_PACKAGE=$1
+DIST_PATH=$2
+
+# setting up workspace
+rm -rf .tmp/$NPM_PACKAGE
+mkdir -p .tmp/$NPM_PACKAGE
+
+# Downloads latest published pacakge from npm. Stores tarball file name in variable TGZ
+TGZ=`npm pack $NPM_PACKAGE`
+
+# unpacks to .tmp/ethereumjs-vm
+tar -xzf $TGZ --strip-components=1 -C .tmp/$NPM_PACKAGE
+rm $TGZ
+
+cd .tmp/$NPM_PACKAGE
+RELATIVE_PATHS=`find . -iname "*.d.ts"`
+cd -
+
+echo "TypeScript definition files found in published npm package:"
+echo $RELATIVE_PATHS | tr ' ' '\n'
+
+# echoes the file diffs.
+for FILE in $RELATIVE_PATHS
+do
+    echo "====================================="
+    echo $FILE
+    echo "====================================="
+    diff ".tmp/$NPM_PACKAGE/$FILE" "$DIST_PATH/$FILE"
+done


### PR DESCRIPTION
My goal is to quickly inspect what interfaces have changed since the packages' latest release. This is specially useful for releases.

Instead of going over `diff` for the source files (which would be chaotic), I chose to perform `diff` on the `.d.ts` files. They are generated at build time, therefore not part of this repo, so I can't use `git` to compare such files.

The `ts-interface-diff.sh` script downloads the latest published package, and compares the `.d.ts` files recursively to the ones found in the local `dist` directory, printing the diff to `stdout`. I made it generic enough to be used with any other package, so feel free to test it elsewhere, if you want.

Basic instructions on the script file itself.

### How to test this PR
1. make sure to have dist files for the package you want to inspect
```sh
# install deps, links packages
npm i 

# build all packages
lerna run build

```

2. Run script
```sh
# Run script
./scripts/ts-interface-diff.sh ethereumjs-vm packages/vm/ 

```

Real-life output:
```diff
125c105
<     getContractStorage(address: Buffer, key: Buffer, cb: any): void;
---
>     getContractStorage(address: Buffer, key: Buffer): Promise<Buffer>;
134c114
<     getOriginalContractStorage(address: Buffer, key: Buffer, cb: any): void;
---
>     getOriginalContractStorage(address: Buffer, key: Buffer): Promise<Buffer>;
156c134
<     clearContractStorage(address: Buffer, cb: any): void;
---
>     clearContractStorage(address: Buffer): Promise<void>;

```