### PR TITLE
Update merkle-patricia-tree to v4, move account trie-related methods to StateManager

### DIFF
--- a/packages/account/package-lock.json
+++ b/packages/account/package-lock.json
@@ -176,15 +176,6 @@
         "@types/node": "*"
       }
     },
-    "abstract-leveldown": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-      "dev": true,
-      "requires": {
-        "xtend": "~4.0.0"
-      }
-    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -230,15 +221,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -260,24 +242,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "bn.js": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
@@ -298,30 +262,10 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
-    "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "dev": true,
-      "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
-    "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-modules": {
@@ -429,12 +373,6 @@
         }
       }
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
-    },
     "cp-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
@@ -458,20 +396,6 @@
         "md5.js": "^1.3.4",
         "ripemd160": "^2.0.1",
         "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -522,16 +446,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "deferred-leveldown": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz",
-      "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~5.0.0",
-        "inherits": "^2.0.3"
-      }
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -562,17 +476,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "dev": true,
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "elliptic": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
@@ -599,28 +502,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
-    },
-    "encoding-down": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
-      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "^5.0.0",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -713,22 +594,6 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
-    "evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
-      "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
-    },
     "find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -789,12 +654,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-caller-file": {
@@ -927,12 +786,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-      "dev": true
-    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -1024,12 +877,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -1179,139 +1026,6 @@
         "node-gyp-build": "^4.2.0"
       }
     },
-    "level-codec": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
-      "dev": true
-    },
-    "level-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
-      "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "level-mem": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-3.0.1.tgz",
-      "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
-      "dev": true,
-      "requires": {
-        "level-packager": "~4.0.0",
-        "memdown": "~3.0.0"
-      }
-    },
-    "level-packager": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-      "dev": true,
-      "requires": {
-        "encoding-down": "~5.0.0",
-        "levelup": "^3.0.0"
-      }
-    },
-    "level-ws": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-1.0.0.tgz",
-      "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.8",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "levelup": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-3.1.1.tgz",
-      "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
-      "dev": true,
-      "requires": {
-        "deferred-leveldown": "~4.0.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~3.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -1364,12 +1078,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
-      "dev": true
-    },
     "lunr": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
@@ -1408,28 +1116,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "memdown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~5.0.0",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
-      }
-    },
     "merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -1444,72 +1130,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        }
-      }
-    },
-    "merkle-patricia-tree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-3.0.0.tgz",
-      "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.1",
-        "ethereumjs-util": "^5.2.0",
-        "level-mem": "^3.0.1",
-        "level-ws": "^1.0.0",
-        "readable-stream": "^3.0.6",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
-          "dev": true
-        },
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
         }
       }
     },
@@ -1551,12 +1171,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true
     },
     "neo-async": {
@@ -1777,22 +1391,10 @@
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
@@ -1943,12 +1545,6 @@
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }
-    },
-    "semaphore": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==",
-      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -2445,12 +2041,6 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -48,7 +48,6 @@
     "@types/bn.js": "^4.11.6",
     "@types/node": "^11.13.4",
     "@types/tape": "^4.13.0",
-    "merkle-patricia-tree": "^3.0.0",
     "nyc": "^14.0.0",
     "prettier": "^2.0.5",
     "tape": "^4.10.1",

--- a/packages/account/test/index.spec.ts
+++ b/packages/account/test/index.spec.ts
@@ -1,7 +1,6 @@
 import * as tape from 'tape'
 import * as rlp from 'rlp'
 import Account from '../src/index'
-const SecureTrie = require('merkle-patricia-tree/secure')
 
 tape('empty constructor', function (tester) {
   const it = tester.test
@@ -129,80 +128,6 @@ tape('isContract', function (tester) {
     const account = new Account(raw)
     t.equal(account.isContract(), true)
     t.end()
-  })
-})
-
-tape('setCode && getCode', (tester) => {
-  const it = tester.test
-  it('should set and get code', (t) => {
-    const code = Buffer.from(
-      '73095e7baea6a6c7c4c2dfeb977efac326af552d873173095e7baea6a6c7c4c2dfeb977efac326af552d873157',
-      'hex',
-    )
-
-    const raw = {
-      nonce: '0x0',
-      balance: '0x03e7',
-      stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
-      codeHash: '0xb30fb32201fe0486606ad451e1a61e2ae1748343cd3d411ed992ffcc0774edd4',
-    }
-    const account = new Account(raw)
-    const trie = new SecureTrie()
-
-    account.setCode(trie, code, function (err, codeHash) {
-      account.getCode(trie, function (err, codeRetrieved) {
-        t.equals(Buffer.compare(code, codeRetrieved!), 0)
-        t.end()
-      })
-    })
-  })
-  it('should not get code if is not contract', (t) => {
-    const raw = {
-      nonce: '0x0',
-      balance: '0x03e7',
-    }
-    const account = new Account(raw)
-    const trie = new SecureTrie()
-    account.getCode(trie, function (err, code) {
-      t.equals(Buffer.compare(code!, Buffer.alloc(0)), 0)
-      t.end()
-    })
-  })
-  it('should set empty code', (t) => {
-    const raw = {
-      nonce: '0x0',
-      balance: '0x03e7',
-    }
-    const account = new Account(raw)
-    const trie = new SecureTrie()
-    const code = Buffer.alloc(0)
-    account.setCode(trie, code, function (err, codeHash) {
-      t.equals(Buffer.compare(codeHash, Buffer.alloc(0)), 0)
-      t.end()
-    })
-  })
-})
-
-tape('setStorage && getStorage', (tester) => {
-  const it = tester.test
-  it('should set and get storage', (t) => {
-    const raw = {
-      nonce: '0x0',
-      balance: '0x03e7',
-      stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
-      codeHash: '0xb30fb32201fe0486606ad451e1a61e2ae1748343cd3d411ed992ffcc0774edd4',
-    }
-    const account = new Account(raw)
-    const trie = new SecureTrie()
-    const key = Buffer.from('0000000000000000000000000000000000000000', 'hex')
-    const value = Buffer.from('01', 'hex')
-
-    account.setStorage(trie, key, value, (err) => {
-      account.getStorage(trie, key, (err, valueRetrieved) => {
-        t.equals(Buffer.compare(value, valueRetrieved!), 0)
-        t.end()
-      })
-    })
   })
 })
 

--- a/packages/block/package-lock.json
+++ b/packages/block/package-lock.json
@@ -219,6 +219,11 @@
       "integrity": "sha512-3Z6M16l20rDRptCOFuKxsn9uypkdNE+5S768ICSbe5KgoyPLjPiHRaSdo76FkFwK5JO6X1Cx5+3tbyDUMBb1jA==",
       "dev": true
     },
+    "@types/abstract-leveldown": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
+      "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ=="
+    },
     "@types/bn.js": {
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -232,6 +237,15 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
           "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
         }
+      }
+    },
+    "@types/levelup": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-3.1.1.tgz",
+      "integrity": "sha512-LjvlfctJYj23Xuqq3jCT8ZPSUSSgDcRJg8+XFDBasoYzefFbB4cHzlDmBVjc2rBOYvklpYHJRayD0jBsbJLD9w==",
+      "requires": {
+        "@types/abstract-leveldown": "*",
+        "@types/node": "*"
       }
     },
     "@types/lru-cache": {
@@ -249,8 +263,7 @@
     "@types/node": {
       "version": "11.15.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.16.tgz",
-      "integrity": "sha512-QUb2Wgrw0aq7Pfk9LhjOXrnm8E7CmwHSa5fy0IYvxWSujNVV0wDkaGxnAsu2WZcdYRBerYqnf6e6Qiq1FkBxGw==",
-      "dev": true
+      "integrity": "sha512-QUb2Wgrw0aq7Pfk9LhjOXrnm8E7CmwHSa5fy0IYvxWSujNVV0wDkaGxnAsu2WZcdYRBerYqnf6e6Qiq1FkBxGw=="
     },
     "@types/tape": {
       "version": "4.13.0",
@@ -278,17 +291,25 @@
       "dev": true
     },
     "abstract-leveldown": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
       "requires": {
+        "buffer": "^5.5.0",
+        "immediate": "^3.2.3",
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       },
       "dependencies": {
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
         }
       }
     },
@@ -456,7 +477,8 @@
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -529,8 +551,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -552,22 +573,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "blob": {
       "version": "0.0.5",
@@ -765,6 +770,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -882,7 +888,8 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1166,7 +1173,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cp-file": {
       "version": "6.2.0",
@@ -1215,6 +1223,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -1324,11 +1333,35 @@
       }
     },
     "deferred-leveldown": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "requires": {
-        "abstract-leveldown": "~2.6.0"
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
       }
     },
     "define-properties": {
@@ -1451,16 +1484,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
-      }
-    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -1546,6 +1569,17 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
+    },
+    "encoding-down": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+      "requires": {
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      }
     },
     "engine.io": {
       "version": "3.2.1",
@@ -1785,6 +1819,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -1807,11 +1842,6 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
       "dev": true
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2162,8 +2192,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "immediate": {
       "version": "3.3.0",
@@ -2353,11 +2382,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
       "version": "3.0.3",
@@ -2710,98 +2734,79 @@
       }
     },
     "level-codec": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
+    },
+    "level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
     },
     "level-errors": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "requires": {
         "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-        }
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "level-mem": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
+      "requires": {
+        "level-packager": "^5.0.3",
+        "memdown": "^5.0.0"
+      }
+    },
+    "level-packager": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+      "requires": {
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
+      }
+    },
+    "level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "requires": {
+        "xtend": "^4.0.2"
       }
     },
     "level-ws": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-      "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
+      "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
       "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.0",
+        "xtend": "^4.0.1"
       }
     },
     "levelup": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
+      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
       "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-        }
       }
     },
     "levn": {
@@ -2960,35 +2965,43 @@
       "dev": true
     },
     "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
       "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
         "inherits": "~2.0.1",
         "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "~5.2.0"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
           "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
           }
         },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
         },
-        "xtend": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
         }
       }
     },
@@ -3010,106 +3023,17 @@
       }
     },
     "merkle-patricia-tree": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.0.0.tgz",
+      "integrity": "sha512-OnI0iUvc5G66ZJgSB7PnuU6Pnk9QADMcBgua7YhNm8gbQJq5Hbiv9U9hQRe3mEM1KEfbqrdTC+x33bTewF+oCA==",
       "requires": {
-        "async": "^1.4.2",
-        "ethereumjs-util": "^5.0.0",
-        "level-ws": "0.0.0",
-        "levelup": "^1.2.1",
-        "memdown": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.9",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-        },
-        "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        }
+        "@types/levelup": "^3.1.1",
+        "ethereumjs-util": "^7.0.2",
+        "level-mem": "^5.0.1",
+        "level-ws": "^2.0.0",
+        "readable-stream": "^3.6.0",
+        "rlp": "^2.2.4",
+        "semaphore-async-await": "^1.5.1"
       }
     },
     "miller-rabin": {
@@ -3264,11 +3188,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -3407,11 +3326,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
       }
-    },
-    "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -3714,7 +3628,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -4045,15 +3960,16 @@
         "node-gyp-build": "^4.2.0"
       }
     },
-    "semaphore": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+    "semaphore-async-await": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
+      "integrity": "sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -5172,12 +5088,9 @@
       "dev": true
     },
     "xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-      "requires": {
-        "object-keys": "~0.4.0"
-      }
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -43,7 +43,7 @@
     "@ethereumjs/tx": "^2.1.2",
     "@types/bn.js": "^4.11.6",
     "ethereumjs-util": "^7.0.2",
-    "merkle-patricia-tree": "^2.3.2"
+    "merkle-patricia-tree": "^4.0.0"
   },
   "devDependencies": {
     "@ethereumjs/config-nyc": "^1.1.1",

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -1,11 +1,9 @@
+import { BaseTrie as Trie } from 'merkle-patricia-tree'
 import Common from '@ethereumjs/common'
-import { rlp, keccak256, KECCAK256_RLP, baToJSON } from 'ethereumjs-util'
+import { BN, rlp, keccak256, KECCAK256_RLP, baToJSON } from 'ethereumjs-util'
 import { Transaction, TransactionOptions } from '@ethereumjs/tx'
 import { BlockHeader } from './header'
 import { Blockchain, BlockData, ChainOptions } from './types'
-
-const Trie = require('merkle-patricia-tree')
-const { BN } = require('ethereumjs-util')
 
 /**
  * An object that represents the block
@@ -254,15 +252,7 @@ export class Block {
   }
 
   private async _putTxInTrie(txIndex: number, tx: Transaction) {
-    await new Promise((resolve, reject) => {
-      this.txTrie.put(rlp.encode(txIndex), tx.serialize(), (err: any) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
-    })
+    await this.txTrie.put(rlp.encode(txIndex), tx.serialize())
   }
 
   private _validateUncleHeader(uncleHeader: BlockHeader, blockchain: Blockchain) {

--- a/packages/vm/examples/run-solidity-contract/index.ts
+++ b/packages/vm/examples/run-solidity-contract/index.ts
@@ -4,7 +4,6 @@ import * as assert from 'assert'
 import * as path from 'path'
 import * as fs from 'fs'
 import { privateToAddress, bufferToHex } from 'ethereumjs-util'
-import { promisify } from 'util'
 import Account from '@ethereumjs/account'
 import { Transaction } from '@ethereumjs/tx'
 
@@ -78,10 +77,7 @@ function getGreeterDeploymentBytecode(solcOutput: any): any {
 }
 
 async function getAccountNonce(vm: VM, accountPrivateKey: Buffer) {
-  const account = (await promisify(vm.stateManager.getAccount.bind(vm.stateManager))(
-    privateToAddress(accountPrivateKey),
-  )) as Account
-
+  const account = await vm.stateManager.getAccount(privateToAddress(accountPrivateKey))
   return account.nonce
 }
 
@@ -170,7 +166,7 @@ async function main() {
   const account = new Account({ balance: 1e18 })
 
   const vm = new VM()
-  await promisify(vm.stateManager.putAccount.bind(vm.stateManager))(accountAddress, account)
+  await vm.stateManager.putAccount(accountAddress, account)
 
   console.log('Set account a balance of 1 ETH')
 

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -1,4 +1,5 @@
 import BN = require('bn.js')
+import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import Account from '@ethereumjs/account'
 import Blockchain from '@ethereumjs/blockchain'
 import Common from '@ethereumjs/common'
@@ -12,7 +13,6 @@ import { OpcodeList, getOpcodesForHF } from './evm/opcodes'
 import { precompiles } from './evm/precompiles'
 import runBlockchain from './runBlockchain'
 const AsyncEventEmitter = require('async-eventemitter')
-const Trie = require('merkle-patricia-tree/secure.js')
 const promisify = require('util.promisify')
 
 /**

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -1,12 +1,10 @@
-import BN = require('bn.js')
-import { toBuffer, bufferToInt } from 'ethereumjs-util'
+import { BaseTrie as Trie } from 'merkle-patricia-tree'
+import { BN, toBuffer, bufferToInt } from 'ethereumjs-util'
 import { encode } from 'rlp'
 import VM from './index'
 import Bloom from './bloom'
 import { RunTxResult } from './runTx'
 import { StateManager } from './state/index'
-const Trie = require('merkle-patricia-tree')
-const promisify = require('util.promisify')
 
 /**
  * Options for running a block.
@@ -230,10 +228,7 @@ async function applyTransactions(this: VM, block: any, opts: RunBlockOpts) {
     receipts.push(txReceipt)
 
     // Add receipt to trie to later calculate receipt root
-    await promisify(receiptTrie.put).bind(receiptTrie)(
-      encode(txIdx),
-      encode(Object.values(txReceipt)),
-    )
+    await receiptTrie.put(encode(txIdx), encode(Object.values(txReceipt)))
   }
 
   return {

--- a/packages/vm/package-lock.json
+++ b/packages/vm/package-lock.json
@@ -173,6 +173,11 @@
 			"integrity": "sha512-3Z6M16l20rDRptCOFuKxsn9uypkdNE+5S768ICSbe5KgoyPLjPiHRaSdo76FkFwK5JO6X1Cx5+3tbyDUMBb1jA==",
 			"dev": true
 		},
+		"@types/abstract-leveldown": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz",
+			"integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ=="
+		},
 		"@types/bn.js": {
 			"version": "4.11.6",
 			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
@@ -194,6 +199,15 @@
 			"integrity": "sha512-F9RHpjuPSit4dCCRXgi7XcqA01DAjy9QY+v9yICoxXsjXD9cgQpyZyL2eSZnTkBGXGaQnea8waZOZTogLDB+rA==",
 			"dev": true
 		},
+		"@types/levelup": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-3.1.1.tgz",
+			"integrity": "sha512-LjvlfctJYj23Xuqq3jCT8ZPSUSSgDcRJg8+XFDBasoYzefFbB4cHzlDmBVjc2rBOYvklpYHJRayD0jBsbJLD9w==",
+			"requires": {
+				"@types/abstract-leveldown": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/lru-cache": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
@@ -209,8 +223,7 @@
 		"@types/node": {
 			"version": "11.15.16",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.16.tgz",
-			"integrity": "sha512-QUb2Wgrw0aq7Pfk9LhjOXrnm8E7CmwHSa5fy0IYvxWSujNVV0wDkaGxnAsu2WZcdYRBerYqnf6e6Qiq1FkBxGw==",
-			"dev": true
+			"integrity": "sha512-QUb2Wgrw0aq7Pfk9LhjOXrnm8E7CmwHSa5fy0IYvxWSujNVV0wDkaGxnAsu2WZcdYRBerYqnf6e6Qiq1FkBxGw=="
 		},
 		"@types/tape": {
 			"version": "4.13.0",
@@ -232,17 +245,25 @@
 			}
 		},
 		"abstract-leveldown": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-			"integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+			"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
 			"requires": {
+				"buffer": "^5.5.0",
+				"immediate": "^3.2.3",
+				"level-concat-iterator": "~2.0.0",
+				"level-supports": "~1.0.0",
 				"xtend": "~4.0.0"
 			},
 			"dependencies": {
-				"xtend": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
 				}
 			}
 		},
@@ -613,8 +634,7 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"base64id": {
 			"version": "1.0.0",
@@ -636,22 +656,6 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
 			"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
 			"dev": true
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -849,6 +853,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
 			"requires": {
 				"buffer-xor": "^1.0.3",
 				"cipher-base": "^1.0.0",
@@ -972,7 +977,8 @@
 		"buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -1298,7 +1304,8 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
 		},
 		"cp-file": {
 			"version": "6.2.0",
@@ -1347,6 +1354,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.3",
 				"create-hash": "^1.1.0",
@@ -1469,14 +1477,6 @@
 			"dev": true,
 			"requires": {
 				"strip-bom": "^3.0.0"
-			}
-		},
-		"deferred-leveldown": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-			"integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-			"requires": {
-				"abstract-leveldown": "~2.6.0"
 			}
 		},
 		"define-properties": {
@@ -1620,16 +1620,6 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
-		},
 		"duplexer": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -1726,7 +1716,6 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
 			"integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-			"dev": true,
 			"requires": {
 				"abstract-leveldown": "^6.2.1",
 				"inherits": "^2.0.3",
@@ -1738,7 +1727,6 @@
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
 					"integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
-					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
 						"immediate": "^3.2.3",
@@ -1751,7 +1739,6 @@
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -1760,14 +1747,12 @@
 				"level-codec": {
 					"version": "9.0.1",
 					"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-					"integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
-					"dev": true
+					"integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
 				},
 				"level-errors": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
 					"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-					"dev": true,
 					"requires": {
 						"errno": "~0.1.1"
 					}
@@ -1775,8 +1760,7 @@
 				"xtend": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-					"dev": true
+					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 				}
 			}
 		},
@@ -2425,6 +2409,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
@@ -2490,11 +2475,6 @@
 				"flat-cache": "^1.2.1",
 				"object-assign": "^4.0.1"
 			}
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -2938,8 +2918,7 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -3260,11 +3239,6 @@
 				"is-docker": "^2.0.0"
 			}
 		},
-		"isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-		},
 		"isbinaryfile": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
@@ -3581,58 +3555,10 @@
 				"leveldown": "^5.4.0"
 			}
 		},
-		"level-codec": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-			"integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-		},
 		"level-concat-iterator": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-			"integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
-			"dev": true
-		},
-		"level-errors": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-			"integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-			"requires": {
-				"errno": "~0.1.1"
-			}
-		},
-		"level-iterator-stream": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-			"integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-			"requires": {
-				"inherits": "^2.0.1",
-				"level-errors": "^1.0.3",
-				"readable-stream": "^1.0.33",
-				"xtend": "^4.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"xtend": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-				}
-			}
+			"integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
 		},
 		"level-js": {
 			"version": "5.0.2",
@@ -3835,7 +3761,6 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
 			"integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-			"dev": true,
 			"requires": {
 				"encoding-down": "^6.3.0",
 				"levelup": "^4.3.2"
@@ -3845,7 +3770,6 @@
 					"version": "6.2.3",
 					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
 					"integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
 						"immediate": "^3.2.3",
@@ -3858,7 +3782,6 @@
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -3868,7 +3791,6 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
 					"integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-					"dev": true,
 					"requires": {
 						"abstract-leveldown": "~6.2.1",
 						"inherits": "^2.0.3"
@@ -3878,7 +3800,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
 					"integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-					"dev": true,
 					"requires": {
 						"errno": "~0.1.1"
 					}
@@ -3887,7 +3808,6 @@
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
 					"integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.4",
 						"readable-stream": "^3.4.0",
@@ -3898,7 +3818,6 @@
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
 					"integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-					"dev": true,
 					"requires": {
 						"deferred-leveldown": "~5.3.0",
 						"level-errors": "~2.0.0",
@@ -3910,8 +3829,7 @@
 				"xtend": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-					"dev": true
+					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 				}
 			}
 		},
@@ -3919,7 +3837,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
 			"integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-			"dev": true,
 			"requires": {
 				"xtend": "^4.0.2"
 			},
@@ -3927,36 +3844,18 @@
 				"xtend": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-					"dev": true
+					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 				}
 			}
 		},
 		"level-ws": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
-			"integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
+			"integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
 			"requires": {
-				"readable-stream": "~1.0.15",
-				"xtend": "~2.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.0",
+				"xtend": "^4.0.1"
 			}
 		},
 		"leveldown": {
@@ -4004,27 +3903,6 @@
 					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 					"dev": true
-				}
-			}
-		},
-		"levelup": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-			"integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-			"requires": {
-				"deferred-leveldown": "~1.2.1",
-				"level-codec": "~7.0.0",
-				"level-errors": "~1.0.3",
-				"level-iterator-stream": "~1.3.0",
-				"prr": "~1.0.1",
-				"semver": "~5.4.1",
-				"xtend": "~4.0.0"
-			},
-			"dependencies": {
-				"xtend": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 				}
 			}
 		},
@@ -4189,35 +4067,22 @@
 			"dev": true
 		},
 		"memdown": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-			"integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+			"integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
 			"requires": {
-				"abstract-leveldown": "~2.7.1",
-				"functional-red-black-tree": "^1.0.1",
-				"immediate": "^3.2.3",
+				"abstract-leveldown": "~6.2.1",
+				"functional-red-black-tree": "~1.0.1",
+				"immediate": "~3.2.3",
 				"inherits": "~2.0.1",
 				"ltgt": "~2.2.0",
-				"safe-buffer": "~5.1.1"
+				"safe-buffer": "~5.2.0"
 			},
 			"dependencies": {
-				"abstract-leveldown": {
-					"version": "2.7.2",
-					"resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-					"integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-					"requires": {
-						"xtend": "~4.0.0"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				},
-				"xtend": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+				"immediate": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+					"integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
 				}
 			}
 		},
@@ -4239,109 +4104,26 @@
 			}
 		},
 		"merkle-patricia-tree": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
-			"integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.0.0.tgz",
+			"integrity": "sha512-OnI0iUvc5G66ZJgSB7PnuU6Pnk9QADMcBgua7YhNm8gbQJq5Hbiv9U9hQRe3mEM1KEfbqrdTC+x33bTewF+oCA==",
 			"requires": {
-				"async": "^1.4.2",
-				"ethereumjs-util": "^5.0.0",
-				"level-ws": "0.0.0",
-				"levelup": "^1.2.1",
-				"memdown": "^1.0.0",
-				"readable-stream": "^2.0.0",
-				"rlp": "^2.0.0",
-				"semaphore": ">=1.0.1"
+				"@types/levelup": "^3.1.1",
+				"ethereumjs-util": "^7.0.2",
+				"level-mem": "^5.0.1",
+				"level-ws": "^2.0.0",
+				"readable-stream": "^3.6.0",
+				"rlp": "^2.2.4",
+				"semaphore-async-await": "^1.5.1"
 			},
 			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"bn.js": {
-					"version": "4.11.9",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-				},
-				"ethereumjs-util": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-					"integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+				"level-mem": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
+					"integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
 					"requires": {
-						"bn.js": "^4.11.0",
-						"create-hash": "^1.1.2",
-						"ethjs-util": "^0.1.3",
-						"keccak": "^1.0.2",
-						"rlp": "^2.0.0",
-						"safe-buffer": "^5.1.1",
-						"secp256k1": "^3.0.1"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"keccak": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-					"requires": {
-						"bindings": "^1.2.1",
-						"inherits": "^2.0.3",
-						"nan": "^2.2.1",
-						"safe-buffer": "^5.1.0"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					},
-					"dependencies": {
-						"safe-buffer": {
-							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-						}
-					}
-				},
-				"secp256k1": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-					"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-					"requires": {
-						"bindings": "^1.5.0",
-						"bip66": "^1.1.5",
-						"bn.js": "^4.11.8",
-						"create-hash": "^1.2.0",
-						"drbg.js": "^1.0.1",
-						"elliptic": "^6.5.2",
-						"nan": "^2.14.0",
-						"safe-buffer": "^5.1.2"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					},
-					"dependencies": {
-						"safe-buffer": {
-							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-						}
+						"level-packager": "^5.0.3",
+						"memdown": "^5.0.0"
 					}
 				}
 			}
@@ -4504,11 +4286,6 @@
 			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"napi-macros": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
@@ -4670,11 +4447,6 @@
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.5"
 			}
-		},
-		"object-keys": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-			"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
 		},
 		"object.assign": {
 			"version": "4.1.0",
@@ -5138,7 +4910,8 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"progress": {
 			"version": "1.1.8",
@@ -5557,15 +5330,16 @@
 				"node-gyp-build": "^4.2.0"
 			}
 		},
-		"semaphore": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-			"integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
+		"semaphore-async-await": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
+			"integrity": "sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo="
 		},
 		"semver": {
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+			"integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -7066,12 +6840,9 @@
 			"dev": true
 		},
 		"xtend": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-			"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-			"requires": {
-				"object-keys": "~0.4.0"
-			}
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -50,7 +50,7 @@
     "@ethereumjs/tx": "^2.1.2",
     "ethereumjs-util": "^7.0.2",
     "functional-red-black-tree": "^1.0.1",
-    "merkle-patricia-tree": "^2.3.2",
+    "merkle-patricia-tree": "^4.0.0",
     "rustbn.js": "~0.2.0",
     "safe-buffer": "^5.1.1",
     "util.promisify": "^1.0.1",

--- a/packages/vm/tests/GeneralStateTestsRunner.js
+++ b/packages/vm/tests/GeneralStateTestsRunner.js
@@ -1,9 +1,7 @@
-const util = require('util')
-const testUtil = require('./util')
-const Trie = require('merkle-patricia-tree/secure')
-const ethUtil = require('ethereumjs-util')
+const { setupPreConditions, makeTx, makeBlockFromEnv } = require('./util')
+const Trie = require('merkle-patricia-tree').SecureTrie
+const { BN } = require('ethereumjs-util')
 const Account = require('@ethereumjs/account').default
-const BN = ethUtil.BN
 
 function parseTestCases(forkConfigTestSuite, testData, data, gasLimit, value) {
   let testCases = []
@@ -56,10 +54,10 @@ async function runTestCase(options, testData, t) {
     hardfork: options.forkConfigVM,
   })
 
-  await testUtil.setupPreConditions(state, testData)
+  await setupPreConditions(vm.stateManager._trie, testData)
 
-  let tx = testUtil.makeTx(testData.transaction, options.forkConfigVM)
-  block = testUtil.makeBlockFromEnv(testData.env)
+  let tx = makeTx(testData.transaction, options.forkConfigVM)
+  block = makeBlockFromEnv(testData.env)
   tx._homestead = true
   tx.enableHomestead = true
   block.isHomestead = function () {
@@ -98,8 +96,8 @@ async function runTestCase(options, testData, t) {
   }
 
   try {
-    await vm.runTx({ tx , block })
-  } catch(e) {
+    await vm.runTx({ tx, block })
+  } catch (e) {
     // If tx is invalid and coinbase is empty, the test harness
     // expects the coinbase account to be deleted from state.
     // Without this ecmul_0-3_5616_28000_96 would fail.

--- a/packages/vm/tests/api/index.js
+++ b/packages/vm/tests/api/index.js
@@ -3,34 +3,34 @@ const promisify = require('util.promisify')
 const util = require('ethereumjs-util')
 const { Block } = require('@ethereumjs/block')
 const Common = require('@ethereumjs/common').default
-const Trie = require('merkle-patricia-tree/secure')
+const Trie = require('merkle-patricia-tree').SecureTrie
 const VM = require('../../dist/index').default
 const { setupVM } = require('./utils')
 const { setupPreConditions } = require('../util')
 const testData = require('./testdata.json')
 
-tape('VM with default blockchain', t => {
-  t.test('should instantiate without params', st => {
+tape('VM with default blockchain', (t) => {
+  t.test('should instantiate without params', (st) => {
     const vm = new VM()
     st.ok(vm.stateManager)
     st.deepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has default trie')
     st.end()
   })
 
-  t.test('should be able to activate precompiles', async st => {
+  t.test('should be able to activate precompiles', async (st) => {
     let vm = new VM({ activatePrecompiles: true })
     await vm.init()
     st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.end()
   })
 
-  t.test('should instantiate with async constructor', async st => {
+  t.test('should instantiate with async constructor', async (st) => {
     let vm = await VM.create({ activatePrecompiles: true })
     st.notDeepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has different root')
     st.end()
   })
 
-  t.test('should work with trie (state) provided', async st => {
+  t.test('should work with trie (state) provided', async (st) => {
     let trie = new Trie()
     trie.isTestTrie = true
     let vm = new VM({ state: trie, activatePrecompiles: true })
@@ -40,7 +40,7 @@ tape('VM with default blockchain', t => {
     st.end()
   })
 
-  t.test('should only accept common or chain and fork', st => {
+  t.test('should only accept common or chain and fork', (st) => {
     const common = new Common('mainnet')
 
     st.throws(() => new VM({ chain: 'a', common }))
@@ -50,7 +50,7 @@ tape('VM with default blockchain', t => {
     st.end()
   })
 
-  t.test('should accept a common object as option', async st => {
+  t.test('should accept a common object as option', async (st) => {
     const common = new Common('mainnet', 'istanbul')
 
     const vm = new VM({ common })
@@ -60,7 +60,7 @@ tape('VM with default blockchain', t => {
     st.end()
   })
 
-  t.test('should only accept valid chain and fork', async st => {
+  t.test('should only accept valid chain and fork', async (st) => {
     let vm = new VM({ chain: 'ropsten', hardfork: 'byzantium' })
     await vm.init()
     st.equal(vm.stateManager._common.param('gasPrices', 'ecAdd'), 500)
@@ -75,28 +75,28 @@ tape('VM with default blockchain', t => {
     st.end()
   })
 
-  t.test('should run blockchain without blocks', async st => {
+  t.test('should run blockchain without blocks', async (st) => {
     const vm = new VM()
     await vm.runBlockchain()
     st.end()
   })
 })
 
-tape('VM with blockchain', t => {
-  t.test('should instantiate', async st => {
+tape('VM with blockchain', (t) => {
+  t.test('should instantiate', async (st) => {
     const vm = setupVM()
     await vm.init()
     st.deepEqual(vm.stateManager._trie.root, util.KECCAK256_RLP, 'it has default trie')
     st.end()
   })
 
-  t.test('should run blockchain without blocks', async st => {
+  t.test('should run blockchain without blocks', async (st) => {
     const vm = setupVM()
     await vm.runBlockchain()
     st.end()
   })
 
-  t.test('should run blockchain with mocked runBlock', async st => {
+  t.test('should run blockchain with mocked runBlock', async (st) => {
     const vm = setupVM({ chain: 'goerli' })
     await vm.init()
 
@@ -116,16 +116,16 @@ tape('VM with blockchain', t => {
 
     await setupPreConditions(vm.stateManager._trie, testData)
 
-    vm.runBlock = block => new Promise((resolve, reject) => reject(new Error('test')))
+    vm.runBlock = (block) => new Promise((resolve, reject) => reject(new Error('test')))
     vm.runBlockchain()
       .then(() => st.fail("it hasn't returned any errors"))
-      .catch(e => {
+      .catch((e) => {
         st.equal(e.message, 'test', "it has correctly propagated runBlock's error")
         st.end()
       })
   })
 
-  t.test('should run blockchain with blocks', async st => {
+  t.test('should run blockchain with blocks', async (st) => {
     const vm = setupVM({ chain: 'goerli' })
     await vm.init()
     const genesis = new Block(Buffer.from(testData.genesisRLP.slice(2), 'hex'), {
@@ -149,7 +149,7 @@ tape('VM with blockchain', t => {
     st.end()
   })
 
-  t.test('should pass the correct Common object when copying the VM', async st => {
+  t.test('should pass the correct Common object when copying the VM', async (st) => {
     const vm = setupVM({ chain: 'goerli', hardfork: 'byzantium' })
     await vm.init()
 
@@ -167,4 +167,4 @@ tape('VM with blockchain', t => {
 const putGenesisP = (blockchain, genesis) =>
   promisify(blockchain.putGenesis.bind(blockchain))(genesis)
 const putBlockP = (blockchain, block) => promisify(blockchain.putBlock.bind(blockchain))(block)
-const getHeadP = blockchain => promisify(blockchain.getHead.bind(blockchain))()
+const getHeadP = (blockchain) => promisify(blockchain.getHead.bind(blockchain))()

--- a/packages/vm/tests/api/runBlock.js
+++ b/packages/vm/tests/api/runBlock.js
@@ -1,5 +1,4 @@
 const tape = require('tape')
-const promisify = require('util.promisify')
 const { Block } = require('@ethereumjs/block')
 const Common = require('@ethereumjs/common').default
 const util = require('ethereumjs-util')
@@ -90,7 +89,9 @@ tape('should fail when block validation fails', async (t) => {
   const suite = setup()
 
   const block = new Block(util.rlp.decode(suite.data.blocks[0].rlp))
-  block.validate = async () => { throw new Error('test') }
+  block.validate = async () => {
+    throw new Error('test')
+  }
 
   await suite.p
     .runBlock({ block })

--- a/packages/vm/tests/api/state/cache.js
+++ b/packages/vm/tests/api/state/cache.js
@@ -1,6 +1,5 @@
 const tape = require('tape')
-const promisify = require('util.promisify')
-const Trie = require('merkle-patricia-tree/secure.js')
+const Trie = require('merkle-patricia-tree').SecureTrie
 const Account = require('@ethereumjs/account').default
 const Cache = require('../../../dist/state/cache').default
 const utils = require('../utils')
@@ -17,7 +16,6 @@ tape('cache initialization', (t) => {
 tape('cache put and get account', (t) => {
   const trie = new Trie()
   const cache = new Cache(trie)
-  const trieGetP = promisify(trie.get.bind(trie))
 
   const addr = Buffer.from('cd2a3d9f938e13cd947ec05abc7fe734df8dd826', 'hex')
   const acc = utils.createAccount('0x00', '0xff11')
@@ -36,7 +34,7 @@ tape('cache put and get account', (t) => {
   })
 
   t.test('should not have flushed to trie', async (st) => {
-    const res = await trieGetP(addr)
+    const res = await trie.get(addr)
     st.notOk(res)
     st.end()
   })
@@ -47,7 +45,7 @@ tape('cache put and get account', (t) => {
   })
 
   t.test('trie should contain flushed account', async (st) => {
-    const raw = await trieGetP(addr)
+    const raw = await trie.get(addr)
     const res = new Account(raw)
     st.ok(res.balance.equals(acc.balance))
     st.end()
@@ -74,7 +72,7 @@ tape('cache put and get account', (t) => {
     cache.put(addr, updatedAcc)
     await cache.flush()
 
-    const raw = await trieGetP(addr)
+    const raw = await trie.get(addr)
     const res = new Account(raw)
     st.ok(res.balance.equals(updatedAcc.balance))
     st.end()

--- a/packages/vm/tests/api/state/stateManager.js
+++ b/packages/vm/tests/api/state/stateManager.js
@@ -2,12 +2,13 @@ const tape = require('tape')
 const { parallel } = require('async')
 const { toBuffer, keccak256, KECCAK256_RLP } = require('ethereumjs-util')
 const Common = require('@ethereumjs/common').default
+const Account = require('@ethereumjs/account').default
 const { DefaultStateManager } = require('../../../dist/state')
 const { createAccount } = require('../utils')
 const { isRunningInKarma } = require('../../util')
 
-tape('StateManager', t => {
-  t.test('should instantiate', async st => {
+tape('StateManager', (t) => {
+  t.test('should instantiate', async (st) => {
     const stateManager = new DefaultStateManager()
 
     st.deepEqual(stateManager._trie.root, KECCAK256_RLP, 'it has default root')
@@ -17,7 +18,7 @@ tape('StateManager', t => {
     st.end()
   })
 
-  t.test('should clear the cache when the state root is set', async st => {
+  t.test('should clear the cache when the state root is set', async (st) => {
     const stateManager = new DefaultStateManager()
     const addressBuffer = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
     const account = createAccount()
@@ -77,21 +78,22 @@ tape('StateManager', t => {
 
   t.test(
     'should put and get account, and add to the underlying cache if the account is not found',
-    async st => {
+    async (st) => {
       const stateManager = new DefaultStateManager()
       const account = createAccount()
+      const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
 
-      await stateManager.putAccount('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', account)
+      await stateManager.putAccount(address, account)
 
-      let res = await stateManager.getAccount('a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+      let res = await stateManager.getAccount(address)
 
       st.equal(res.balance.toString('hex'), 'fff384')
 
       stateManager._cache.clear()
 
-      res = await stateManager.getAccount('a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+      res = await stateManager.getAccount(address)
 
-      st.equal(stateManager._cache._cache.keys[0], 'a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+      st.equal(stateManager._cache._cache.keys[0], address.toString('hex'))
 
       st.end()
     },
@@ -99,10 +101,11 @@ tape('StateManager', t => {
 
   t.test(
     'should call the callback with a boolean representing emptiness, when the account is empty',
-    async st => {
+    async (st) => {
       const stateManager = new DefaultStateManager()
+      const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
 
-      let res = await stateManager.accountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+      let res = await stateManager.accountIsEmpty(address)
 
       st.ok(res)
 
@@ -112,13 +115,14 @@ tape('StateManager', t => {
 
   t.test(
     'should call the callback with a false boolean representing non-emptiness when the account is not empty',
-    async st => {
+    async (st) => {
       const stateManager = new DefaultStateManager()
       const account = createAccount('0x1', '0x1')
+      const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
 
-      await stateManager.putAccount('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', account)
+      await stateManager.putAccount(address, account)
 
-      let res = await stateManager.accountIsEmpty('a94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+      let res = await stateManager.accountIsEmpty(address)
 
       st.notOk(res)
 
@@ -126,7 +130,7 @@ tape('StateManager', t => {
     },
   )
 
-  t.test('should generate the genesis state root correctly for mainnet', async st => {
+  t.test('should generate the genesis state root correctly for mainnet', async (st) => {
     if (isRunningInKarma()) {
       st.skip('skip slow test when running in karma')
       return st.end()
@@ -168,7 +172,7 @@ tape('StateManager', t => {
     ])
   })
 
-  t.test('should generate the genesis state root correctly for all other chains', async st => {
+  t.test('should generate the genesis state root correctly for all other chains', async (st) => {
     const chains = ['ropsten', 'rinkeby', 'kovan', 'goerli']
 
     for (const chain of chains) {
@@ -187,7 +191,7 @@ tape('StateManager', t => {
     st.end()
   })
 
-  t.test('should dump storage', async st => {
+  t.test('should dump storage', async (st) => {
     const stateManager = new DefaultStateManager()
     const addressBuffer = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
     const account = createAccount()
@@ -205,7 +209,7 @@ tape('StateManager', t => {
     st.end()
   })
 
-  t.test('should pass Common object when copying the state manager', st => {
+  t.test('should pass Common object when copying the state manager', (st) => {
     const stateManager = new DefaultStateManager({
       common: new Common('goerli', 'byzantium'),
     })
@@ -220,7 +224,7 @@ tape('StateManager', t => {
     st.end()
   })
 
-  t.test("should validate the key's length when modifying a contract's storage", async st => {
+  t.test("should validate the key's length when modifying a contract's storage", async (st) => {
     const stateManager = new DefaultStateManager()
     const addressBuffer = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
     try {
@@ -235,7 +239,7 @@ tape('StateManager', t => {
     st.end()
   })
 
-  t.test("should validate the key's length when reading a contract's storage", async st => {
+  t.test("should validate the key's length when reading a contract's storage", async (st) => {
     const stateManager = new DefaultStateManager()
     const addressBuffer = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
     try {
@@ -251,7 +255,7 @@ tape('StateManager', t => {
   })
 })
 
-tape('Original storage cache', async t => {
+tape('Original storage cache', async (t) => {
   const stateManager = new DefaultStateManager()
 
   const address = 'a94f5374fce5edbc8e2a8697c15331677e6ebf0b'
@@ -262,7 +266,7 @@ tape('Original storage cache', async t => {
   const key = Buffer.from('1234567890123456789012345678901234567890123456789012345678901234', 'hex')
   const value = Buffer.from('1234', 'hex')
 
-  t.test('should initially have empty storage value', async st => {
+  t.test('should initially have empty storage value', async (st) => {
     await stateManager.checkpoint()
     const res = await stateManager.getContractStorage(addressBuffer, key)
     st.deepEqual(res, Buffer.alloc(0))
@@ -275,7 +279,7 @@ tape('Original storage cache', async t => {
     st.end()
   })
 
-  t.test('should set original storage value', async st => {
+  t.test('should set original storage value', async (st) => {
     await stateManager.putContractStorage(addressBuffer, key, value)
     const res = await stateManager.getContractStorage(addressBuffer, key)
     st.deepEqual(res, value)
@@ -283,13 +287,13 @@ tape('Original storage cache', async t => {
     st.end()
   })
 
-  t.test('should get original storage value', async st => {
+  t.test('should get original storage value', async (st) => {
     const res = await stateManager.getOriginalContractStorage(addressBuffer, key)
     st.deepEqual(res, value)
     st.end()
   })
 
-  t.test('should return correct original value after modification', async st => {
+  t.test('should return correct original value after modification', async (st) => {
     const newValue = Buffer.from('1235', 'hex')
     await stateManager.putContractStorage(addressBuffer, key, newValue)
     const res = await stateManager.getContractStorage(addressBuffer, key)
@@ -300,7 +304,7 @@ tape('Original storage cache', async t => {
     st.end()
   })
 
-  t.test('should cache keys separately', async st => {
+  t.test('should cache keys separately', async (st) => {
     const key2 = Buffer.from(
       '0000000000000000000000000000000000000000000000000000000000000012',
       'hex',
@@ -330,7 +334,7 @@ tape('Original storage cache', async t => {
     st.end()
   })
 
-  t.test("getOriginalContractStorage should validate the key's length", async st => {
+  t.test("getOriginalContractStorage should validate the key's length", async (st) => {
     try {
       await stateManager.getOriginalContractStorage(addressBuffer, Buffer.alloc(12))
     } catch (e) {
@@ -341,5 +345,60 @@ tape('Original storage cache', async t => {
 
     st.fail('Should have failed')
     st.end()
+  })
+})
+
+tape('StateManager - Contract code', (tester) => {
+  const it = tester.test
+
+  it('should set and get code', async (t) => {
+    const stateManager = new DefaultStateManager()
+    const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
+    const code = Buffer.from(
+      '73095e7baea6a6c7c4c2dfeb977efac326af552d873173095e7baea6a6c7c4c2dfeb977efac326af552d873157',
+      'hex',
+    )
+    const raw = {
+      nonce: '0x0',
+      balance: '0x03e7',
+      stateRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+      codeHash: '0xb30fb32201fe0486606ad451e1a61e2ae1748343cd3d411ed992ffcc0774edd4',
+    }
+    const account = new Account(raw)
+    await stateManager.putAccount(address, account)
+    await stateManager.putContractCode(address, code)
+    const codeRetrieved = await stateManager.getContractCode(address)
+    t.equals(Buffer.compare(code, codeRetrieved), 0)
+    t.end()
+  })
+
+  it('should not get code if is not contract', async (t) => {
+    const stateManager = new DefaultStateManager()
+    const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
+    const raw = {
+      nonce: '0x0',
+      balance: '0x03e7',
+    }
+    const account = new Account(raw)
+    await stateManager.putAccount(address, account)
+    const code = await stateManager.getContractCode(address)
+    t.equals(Buffer.compare(code, Buffer.alloc(0)), 0)
+    t.end()
+  })
+
+  it('should set empty code', async (t) => {
+    const stateManager = new DefaultStateManager()
+    const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
+    const raw = {
+      nonce: '0x0',
+      balance: '0x03e7',
+    }
+    const account = new Account(raw)
+    const code = Buffer.alloc(0)
+    await stateManager.putAccount(address, account)
+    await stateManager.putContractCode(address, code)
+    const codeRetrieved = await stateManager.getContractCode(address)
+    t.equals(Buffer.compare(codeRetrieved, Buffer.alloc(0)), 0)
+    t.end()
   })
 })

--- a/packages/vm/tests/tester.js
+++ b/packages/vm/tests/tester.js
@@ -2,7 +2,6 @@
 
 const argv = require('minimist')(process.argv.slice(2))
 const tape = require('tape')
-const util = require('util')
 const testing = require('ethereumjs-testing')
 const config = require('./config')
 


### PR DESCRIPTION
This PR:
* Updates `merkle-patricia-tree` to v4
* Moves account trie-related methods to StateManager: `getCode`, `setCode`, `getStorage`, `setStorage`
   * this was a suggestion from @s1na since he believes the vm was the only consumer of these methods
* Removes various unneeded `promisify`s