### PR TITLE
VM: add testCaseIndex flag to test runner

### DIFF
--- a/packages/vm/tests/GeneralStateTestsRunner.js
+++ b/packages/vm/tests/GeneralStateTestsRunner.js
@@ -132,8 +132,13 @@ module.exports = async function runStateTest(options, testData, t) {
       t.comment(`No ${options.forkConfigTestSuite} post state defined, skip test`)
       return
     }
-    for (let testCase of testCases) {
-      await runTestCase(options, testCase, t)
+    if (options.testCaseIndex !== undefined) {
+      const i = parseInt(options.testCaseIndex, 10)
+      await runTestCase(options, testCases[i], t)
+    } else {
+      for (let testCase of testCases) {
+        await runTestCase(options, testCase, t)
+      }
     }
   } catch (e) {
     console.log(e)

--- a/packages/vm/tests/tester.js
+++ b/packages/vm/tests/tester.js
@@ -43,6 +43,7 @@ function runTests() {
   runnerArgs.gasLimit = argv.gas // GeneralStateTests
   runnerArgs.value = argv.value // GeneralStateTests
   runnerArgs.debug = argv.debug // BlockchainTests
+  runnerArgs.testCaseIndex = argv.testCaseIndex
 
   if (argv.customStateTest) {
     const stateTestRunner = require('./GeneralStateTestsRunner.js')


### PR DESCRIPTION
This is to make debugging failing tests easier. Some tests have many variants, with this flag you can select and run only one of those. E.g.

```bash
npx ts-node ./tests/tester --state --fork='Istanbul' --test='suicideNonConst' --testCaseIndex=0 --jsontrace --debug
```