### PR TITLE
[VM] group opcodes based upon hardfork

### DIFF
--- a/packages/vm/tests/api/runCall.js
+++ b/packages/vm/tests/api/runCall.js
@@ -3,6 +3,7 @@ const BN = require('bn.js')
 const VM = require('../../dist/index').default
 const { createAccount } = require('./utils')
 const { keccak256, padToEven } = require('ethereumjs-util')
+const Common = require('@ethereumjs/common').default
 
 // Non-protected Create2Address generator. Does not check if buffers have the right padding. Returns a 32-byte buffer which contains the address.
 function create2address(sourceAddress, codeHash, salt) {
@@ -76,4 +77,37 @@ tape('Constantinople: EIP-1014 CREATE2 creates the right contract address', asyn
     t.end()
 })
 
+tape('Byzantium cannot access Constantinople opcodes', async (t) => {
+    t.plan(2)
+    // setup the accounts for this test
+    const caller =          Buffer.from('00000000000000000000000000000000000000ee', 'hex')                   // caller addres
+    const contractAddress = Buffer.from('00000000000000000000000000000000000000ff', 'hex')          // contract address 
+    // setup the vm
+    const vmByzantium = new VM({ chain: 'mainnet', hardfork: 'byzantium'})      
+    const vmConstantinople = new VM({ chain: 'mainnet', hardfork: 'constantinople'})                                   
+    const code = "600160011B00"
+    /*
+      code:             remarks: (top of the stack is at the zero index)
+        PUSH1 0x01  
+        PUSH1 0x01
+        SHL
+        STOP
+    */
 
+    await vmByzantium.stateManager.putContractCode(contractAddress, Buffer.from(code, 'hex'))                // setup the contract code
+    await vmConstantinople.stateManager.putContractCode(contractAddress, Buffer.from(code, 'hex'))                // setup the contract code
+
+    const runCallArgs = {
+        caller: caller,                     // call address
+        gasLimit: new BN(0xffffffffff),     // ensure we pass a lot of gas, so we do not run out of gas
+        to: contractAddress,                // call to the contract address
+    }
+
+    const byzantiumResult = await vmByzantium.runCall(runCallArgs)
+    const constantinopleResult = await vmConstantinople.runCall(runCallArgs)
+
+    t.assert(byzantiumResult.execResult.exceptionError && byzantiumResult.execResult.exceptionError.error === 'invalid opcode', 'byzantium cannot accept constantinople opcodes (SHL)')
+    t.assert(!constantinopleResult.execResult.exceptionError, 'constantinople can access the SHL opcode')
+
+    t.end()
+})


### PR DESCRIPTION
Closes #543 

Some notes: I also have grouped pre-byzantium opcodes (homestead, that's `DELEGATECALL`), but `homestead` is not supported by the VM yet.

I have included a very simple test which obviously does not test all cases.

Also per the issue: I think that any gas cost changes should either:

1) should be read every time from the opcode call from common (think about `SLOAD`, `BALANCE`, etc.) 

2) if the call price is fixed (`SLOAD` for instance always charges the same amount of gas) then we should use the `fee` attribute of the opcode and change this fee if the gas price changes (ideally reading this once from common)

I tend to encourage us to use (2) since this does a single call to common for these constant-priced opcodes. (1) keeps calling common every time we use the opcode, though we know the hard fork of the VM is invariant and thus the gas cost is constant in these situations.

I think this gas stuff should be in a different issue?