### PR TITLE
Add nonce option for runCall

### DIFF
--- a/packages/vm/lib/evm/eei.ts
+++ b/packages/vm/lib/evm/eei.ts
@@ -402,7 +402,7 @@ export default class EEI {
       data: data,
       isStatic: this._env.isStatic,
       depth: this._env.depth + 1,
-      nonce: new BN(this._env.contract.nonce)
+      nonce: new BN(this._env.contract.nonce),
     })
 
     return this._baseCall(msg)
@@ -421,7 +421,7 @@ export default class EEI {
       data: data,
       isStatic: this._env.isStatic,
       depth: this._env.depth + 1,
-      nonce: new BN(this._env.contract.nonce)
+      nonce: new BN(this._env.contract.nonce),
     })
 
     return this._baseCall(msg)
@@ -441,7 +441,7 @@ export default class EEI {
       data: data,
       isStatic: true,
       depth: this._env.depth + 1,
-      nonce: new BN(this._env.contract.nonce)
+      nonce: new BN(this._env.contract.nonce),
     })
 
     return this._baseCall(msg)
@@ -462,7 +462,7 @@ export default class EEI {
       isStatic: this._env.isStatic,
       delegatecall: true,
       depth: this._env.depth + 1,
-      nonce: new BN(this._env.contract.nonce)
+      nonce: new BN(this._env.contract.nonce),
     })
 
     return this._baseCall(msg)
@@ -524,7 +524,7 @@ export default class EEI {
       salt: salt,
       depth: this._env.depth + 1,
       selfdestruct: selfdestruct,
-      nonce: new BN(this._env.contract.nonce)
+      nonce: new BN(this._env.contract.nonce),
     })
 
     // empty the return data buffer

--- a/packages/vm/lib/evm/eei.ts
+++ b/packages/vm/lib/evm/eei.ts
@@ -402,6 +402,7 @@ export default class EEI {
       data: data,
       isStatic: this._env.isStatic,
       depth: this._env.depth + 1,
+      nonce: new BN(this._env.contract.nonce)
     })
 
     return this._baseCall(msg)
@@ -420,6 +421,7 @@ export default class EEI {
       data: data,
       isStatic: this._env.isStatic,
       depth: this._env.depth + 1,
+      nonce: new BN(this._env.contract.nonce)
     })
 
     return this._baseCall(msg)
@@ -439,6 +441,7 @@ export default class EEI {
       data: data,
       isStatic: true,
       depth: this._env.depth + 1,
+      nonce: new BN(this._env.contract.nonce)
     })
 
     return this._baseCall(msg)
@@ -459,6 +462,7 @@ export default class EEI {
       isStatic: this._env.isStatic,
       delegatecall: true,
       depth: this._env.depth + 1,
+      nonce: new BN(this._env.contract.nonce)
     })
 
     return this._baseCall(msg)
@@ -520,6 +524,7 @@ export default class EEI {
       salt: salt,
       depth: this._env.depth + 1,
       selfdestruct: selfdestruct,
+      nonce: new BN(this._env.contract.nonce)
     })
 
     // empty the return data buffer

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -380,9 +380,7 @@ export default class EVM {
     if (message.salt) {
       addr = generateAddress2(message.caller, message.salt, message.code as Buffer)
     } else {
-      const acc = await this._state.getAccount(message.caller)
-      const newNonce = new BN(acc.nonce).subn(1)
-      addr = generateAddress(message.caller, newNonce.toArrayLike(Buffer))
+      addr = generateAddress(message.caller, message.nonce.toArrayLike(Buffer))
     }
     return addr
   }

--- a/packages/vm/lib/evm/message.ts
+++ b/packages/vm/lib/evm/message.ts
@@ -7,6 +7,7 @@ export default class Message {
   caller: Buffer
   gasLimit: BN
   data: Buffer
+  nonce: BN
   depth: number
   code: Buffer | PrecompileFunc
   _codeAddress: Buffer
@@ -30,6 +31,7 @@ export default class Message {
     this.salt = opts.salt // For CREATE2, TODO: Move from here
     this.selfdestruct = opts.selfdestruct // TODO: Move from here
     this.delegatecall = opts.delegatecall || false
+    this.nonce = opts.nonce ? new BN(opts.nonce) : new BN(0)
   }
 
   get codeAddress(): Buffer {

--- a/packages/vm/lib/runCall.ts
+++ b/packages/vm/lib/runCall.ts
@@ -18,6 +18,7 @@ export interface RunCallOpts {
   to?: Buffer
   value?: Buffer
   data?: Buffer
+  nonce?: BN
   /**
    * This is for CALLCODE where the code to load is different than the code from the to account
    */
@@ -53,6 +54,7 @@ export default function runCall(this: VM, opts: RunCallOpts): Promise<EVMResult>
     salt: opts.salt || null,
     selfdestruct: opts.selfdestruct || {},
     delegatecall: opts.delegatecall || false,
+    nonce: opts.nonce
   })
 
   const evm = new EVM(this, txContext, block)

--- a/packages/vm/lib/runCall.ts
+++ b/packages/vm/lib/runCall.ts
@@ -54,7 +54,7 @@ export default function runCall(this: VM, opts: RunCallOpts): Promise<EVMResult>
     salt: opts.salt || null,
     selfdestruct: opts.selfdestruct || {},
     delegatecall: opts.delegatecall || false,
-    nonce: opts.nonce
+    nonce: opts.nonce,
   })
 
   const evm = new EVM(this, txContext, block)


### PR DESCRIPTION
Closes #613. 

This adds the `nonce` option for runCall. It adds a test which explicitly checks that the created addresses are the expected ones and also creates collisions by trying to re-deploy transactions with equal nonces. 

For a discussion why I think it does make no sense to add this option to `runCode`, see #613. 