### PR TITLE
TangerineWhistle HF Support

### DIFF
--- a/packages/vm/lib/evm/eei.ts
+++ b/packages/vm/lib/evm/eei.ts
@@ -576,7 +576,7 @@ export default class EEI {
   }
 
   /**
-   * Returns true if account is empty (according to EIP-161).
+   * Returns true if account is empty or non-existent (according to EIP-161).
    * @param address - Address of account
    */
   async isAccountEmpty(address: Buffer): Promise<boolean> {

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -221,7 +221,10 @@ export default class EVM {
     await this._vm._emit('newContract', newContractEvent)
 
     toAccount = await this._state.getAccount(message.to)
-    toAccount.nonce = new BN(toAccount.nonce).addn(1).toArrayLike(Buffer)
+    // EIP-161 on account creation and CREATE execution
+    if (this._vm._common.gteHardfork('spuriousDragon')) {
+      toAccount.nonce = new BN(toAccount.nonce).addn(1).toArrayLike(Buffer)
+    }
 
     // Add tx value to the `to` account
     let errorMessage

--- a/packages/vm/lib/evm/opFns.ts
+++ b/packages/vm/lib/evm/opFns.ts
@@ -662,12 +662,12 @@ export const handlers: { [k: string]: OpHandler } = {
     }
     subMemUsage(runState, inOffset, inLength)
     subMemUsage(runState, outOffset, outLength)
-    
-    if (!value.isZero()){
+
+    if (!value.isZero()) {
       runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callValueTransfer')))
     }
     gasLimit = maxCallGas(gasLimit, runState.eei.getGasLeft())
-    
+
     let data = Buffer.alloc(0)
     if (!inLength.isZero()) {
       data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
@@ -676,10 +676,10 @@ export const handlers: { [k: string]: OpHandler } = {
     if (runState._common.gteHardfork('spuriousDragon')) {
       // We are at or after Spurious Dragon
       // Call new account gas: account is DEAD and we transfer nonzero value
-      if (runState.stateManager.accountIsEmpty(toAddressBuf) && !value.isZero()) {
+      if ((await runState.stateManager.accountIsEmpty(toAddressBuf)) && !value.isZero()) {
         runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
       }
-    } else if ( !(await runState.stateManager.accountExists(toAddressBuf))){
+    } else if (!(await runState.stateManager.accountExists(toAddressBuf))) {
       // We are before Spurious Dragon
       // Call new account gas: account does not exist (it is not in the state trie, not even as an "empty" account)
       const accountDoesNotExist = !(await runState.stateManager.accountExists(toAddressBuf))

--- a/packages/vm/lib/evm/opFns.ts
+++ b/packages/vm/lib/evm/opFns.ts
@@ -663,19 +663,24 @@ export const handlers: { [k: string]: OpHandler } = {
 
     subMemUsage(runState, inOffset, inLength)
     subMemUsage(runState, outOffset, outLength)
-    if (!value.isZero()) {
+    
+    if (!value.isZero()){
       runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callValueTransfer')))
     }
     gasLimit = maxCallGas(gasLimit, runState.eei.getGasLeft())
-
+    
     let data = Buffer.alloc(0)
     if (!inLength.isZero()) {
       data = runState.memory.read(inOffset.toNumber(), inLength.toNumber())
     }
 
     const empty = await runState.eei.isAccountEmpty(toAddressBuf)
+    const forkGteSpuriousDragon = runState._common.gteHardfork('spuriousDragon')
+
     if (empty) {
-      if (!value.isZero()) {
+      if (!forkGteSpuriousDragon) {
+        runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
+      } else if (!value.isZero()) {
         runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
       }
     }

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -110,6 +110,7 @@ export default class VM extends AsyncEventEmitter {
       const chain = opts.chain ? opts.chain : 'mainnet'
       const hardfork = opts.hardfork ? opts.hardfork : 'petersburg'
       const supportedHardforks = [
+        'tangerineWhistle',
         'spuriousDragon',
         'byzantium',
         'constantinople',

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -184,7 +184,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (results.execResult.selfdestruct) {
     const keys = Object.keys(results.execResult.selfdestruct)
     for (const k of keys) {
-      await state.putAccount(Buffer.from(k, 'hex'), new Account())
+      await state.deleteAccount(Buffer.from(k, 'hex'))
     }
   }
   await state.cleanupTouchedAccounts()

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -174,9 +174,12 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const minerAccount = await state.getAccount(block.header.coinbase)
   // add the amount spent on gas to the miner's account
   minerAccount.balance = toBuffer(new BN(minerAccount.balance).add(results.amountSpent))
-  if (!new BN(minerAccount.balance).isZero()) {
-    await state.putAccount(block.header.coinbase, minerAccount)
-  }
+
+  // Put the miner account into the state. If the balance of the miner account remains zero, note that
+  // the state.putAccount function puts this into the "touched" accounts. This will thus be removed when
+  // we clean the touched accounts below in case we are in a fork >= SpuriousDragon
+  await state.putAccount(block.header.coinbase, minerAccount)
+  
 
   /*
    * Cleanup accounts

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -179,7 +179,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // the state.putAccount function puts this into the "touched" accounts. This will thus be removed when
   // we clean the touched accounts below in case we are in a fork >= SpuriousDragon
   await state.putAccount(block.header.coinbase, minerAccount)
-  
 
   /*
    * Cleanup accounts

--- a/packages/vm/lib/state/cache.ts
+++ b/packages/vm/lib/state/cache.ts
@@ -54,24 +54,30 @@ export default class Cache {
   /**
    * Looks up address in underlying trie.
    * @param address - Address of account
+   * @param create - Create emtpy account if non-existent
    */
-  async _lookupAccount(address: Buffer): Promise<Account> {
+  async _lookupAccount(address: Buffer, create: boolean = true): Promise<Account | undefined> {
     const raw = await this._trie.get(address)
-    const account = new Account(raw)
-    return account
+    if (raw || create) {
+      const account = new Account(raw)
+      return account
+    }
   }
 
   /**
    * Looks up address in cache, if not found, looks it up
    * in the underlying trie.
    * @param key - Address of account
+   * @param create - Create emtpy account if non-existent
    */
-  async getOrLoad(key: Buffer): Promise<Account> {
+  async getOrLoad(key: Buffer, create: boolean = true): Promise<Account | undefined> {
     let account = this.lookup(key)
 
     if (!account) {
-      account = await this._lookupAccount(key)
-      this._update(key, account, false, false)
+      account = await this._lookupAccount(key, create)
+      if (account) {
+        this._update(key, account as Account, false, false)
+      }
     }
 
     return account
@@ -87,7 +93,7 @@ export default class Cache {
       if (addressHex) {
         const address = Buffer.from(addressHex, 'hex')
         const account = await this._lookupAccount(address)
-        this._update(address, account, false, false)
+        this._update(address, account as Account, false, false)
       }
     }
   }

--- a/packages/vm/lib/state/interface.ts
+++ b/packages/vm/lib/state/interface.ts
@@ -28,5 +28,6 @@ export interface StateManager {
   generateCanonicalGenesis(): Promise<void>
   generateGenesis(initState: any): Promise<void>
   accountIsEmpty(address: Buffer): Promise<boolean>
+  accountExists(address: Buffer): Promise<boolean>
   cleanupTouchedAccounts(): Promise<void>
 }

--- a/packages/vm/lib/state/interface.ts
+++ b/packages/vm/lib/state/interface.ts
@@ -10,7 +10,8 @@ export interface StorageDump {
 export interface StateManager {
   copy(): StateManager
   getAccount(address: Buffer): Promise<Account>
-  putAccount(address: Buffer, account: Account): Promise<void>
+  putAccount(address: Buffer, account: Account | null): Promise<void>
+  deleteAccount(address: Buffer): Promise<void>
   touchAccount(address: Buffer): void
   putContractCode(address: Buffer, value: Buffer): Promise<void>
   getContractCode(address: Buffer): Promise<Buffer>

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -115,7 +115,7 @@ export default class DefaultStateManager implements StateManager {
     const codeHash = keccak256(value)
 
     if (codeHash.equals(KECCAK256_NULL)) {
-      return
+      //return
     }
 
     const account = await this.getAccount(address)
@@ -479,7 +479,6 @@ export default class DefaultStateManager implements StateManager {
    */
   async accountIsEmpty(address: Buffer): Promise<boolean> {
     const account = await this.getAccount(address)
-    console.log(account.isEmpty())
     return account.isEmpty()
   }
 
@@ -489,8 +488,14 @@ export default class DefaultStateManager implements StateManager {
    * @param address - Address of the `account` to check
    */
   async accountExists(address: Buffer): Promise<boolean> {
-    const account = await this._trie.get(address)
-    return account ? true : false
+    const account = await this._cache.lookup(address)
+    if (account) {
+      return true;
+    }
+    if (await this._cache._trie.get(address)) {
+      return true;
+    }
+    return false
   }
 
   /**

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -88,7 +88,7 @@ export default class DefaultStateManager implements StateManager {
     this._cache.put(address, account)
     this.touchAccount(address)
   }
-  
+
   async deleteAccount(address: Buffer) {
     this._cache.del(address)
     this.touchAccount(address)
@@ -490,10 +490,10 @@ export default class DefaultStateManager implements StateManager {
   async accountExists(address: Buffer): Promise<boolean> {
     const account = await this._cache.lookup(address)
     if (account) {
-      return true;
+      return true
     }
     if (await this._cache._trie.get(address)) {
-      return true;
+      return true
     }
     return false
   }

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -71,7 +71,7 @@ export default class DefaultStateManager implements StateManager {
    * @param address - Address of the `account` to get
    */
   async getAccount(address: Buffer): Promise<Account> {
-    const account = await this._cache.getOrLoad(address)
+    const account = (await this._cache.getOrLoad(address)) as Account
     return account
   }
 
@@ -468,13 +468,24 @@ export default class DefaultStateManager implements StateManager {
   }
 
   /**
-   * Checks if the `account` corresponding to `address` is empty as defined in
+   * Checks if the `account` corresponding to `address`
+   * is empty or non-existent as defined in
    * EIP-161 (https://eips.ethereum.org/EIPS/eip-161).
    * @param address - Address to check
    */
   async accountIsEmpty(address: Buffer): Promise<boolean> {
     const account = await this.getAccount(address)
     return account.isEmpty()
+  }
+
+  /**
+   * Checks if the `account` corresponding to `address`
+   * exists
+   * @param address - Address of the `account` to check
+   */
+  async accountExists(address: Buffer): Promise<boolean> {
+    const account = await this._cache.getOrLoad(address, false)
+    return account ? true : false
   }
 
   /**

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -87,7 +87,11 @@ export default class DefaultStateManager implements StateManager {
     // if they have money or a non-zero nonce or code, then write to tree
     this._cache.put(address, account)
     this.touchAccount(address)
-    // this._trie.put(addressHex, account.serialize(), cb)
+  }
+  
+  async deleteAccount(address: Buffer) {
+    this._cache.del(address)
+    this.touchAccount(address)
   }
 
   /**
@@ -475,6 +479,7 @@ export default class DefaultStateManager implements StateManager {
    */
   async accountIsEmpty(address: Buffer): Promise<boolean> {
     const account = await this.getAccount(address)
+    console.log(account.isEmpty())
     return account.isEmpty()
   }
 
@@ -484,7 +489,7 @@ export default class DefaultStateManager implements StateManager {
    * @param address - Address of the `account` to check
    */
   async accountExists(address: Buffer): Promise<boolean> {
-    const account = await this._cache.getOrLoad(address, false)
+    const account = await this._trie.get(address)
     return account ? true : false
   }
 

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -482,12 +482,14 @@ export default class DefaultStateManager implements StateManager {
    * as defined in EIP-161 (https://eips.ethereum.org/EIPS/eip-161).
    */
   async cleanupTouchedAccounts(): Promise<void> {
-    const touchedArray = Array.from(this._touched)
-    for (const addressHex of touchedArray) {
-      const address = Buffer.from(addressHex, 'hex')
-      const empty = await this.accountIsEmpty(address)
-      if (empty) {
-        this._cache.del(address)
+    if (this._common.gteHardfork('spuriousDragon')) {
+      const touchedArray = Array.from(this._touched)
+      for (const addressHex of touchedArray) {
+        const address = Buffer.from(addressHex, 'hex')
+        const empty = await this.accountIsEmpty(address)
+        if (empty) {
+          this._cache.del(address)
+        }
       }
     }
     this._touched.clear()

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -14,7 +14,7 @@
     "coverage:test": "npm run build && tape './tests/api/**/*.js' ./tests/tester.js --state --dist",
     "docs:build": "typedoc --options typedoc.js",
     "test:state": "ts-node ./tests/tester --state",
-    "test:state:allForks": "npm run test:state -- --fork=SpuriousDragon && npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
+    "test:state:allForks": "npm run test:state -- --fork=TangerineWhistle && npm run test:state -- --fork=SpuriousDragon && npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
     "test:state:selectedForks": "npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=TangerineWhistle",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -15,7 +15,7 @@
     "docs:build": "typedoc --options typedoc.js",
     "test:state": "ts-node ./tests/tester --state",
     "test:state:allForks": "npm run test:state -- --fork=SpuriousDragon && npm run test:state -- --fork=Byzantium && npm run test:state -- --fork=Constantinople && npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=Istanbul && npm run test:state -- --fork=MuirGlacier",
-    "test:state:selectedForks": "npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=SpuriousDragon",
+    "test:state:selectedForks": "npm run test:state -- --fork=Petersburg && npm run test:state -- --fork=TangerineWhistle",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "node -r ts-node/register --stack-size=1500 ./tests/tester --blockchain",

--- a/packages/vm/tests/api/state/stateManager.js
+++ b/packages/vm/tests/api/state/stateManager.js
@@ -114,6 +114,37 @@ tape('StateManager', (t) => {
   )
 
   t.test(
+    'should return false for a non-existent account',
+    async (st) => {
+      const stateManager = new DefaultStateManager()
+      const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
+
+      let res = await stateManager.accountExists(address)
+
+      st.notOk(res)
+
+      st.end()
+    },
+  )
+
+  t.test(
+    'should return true for an existent account',
+    async (st) => {
+      const stateManager = new DefaultStateManager()
+      const account = createAccount('0x1', '0x1')
+      const address = Buffer.from('a94f5374fce5edbc8e2a8697c15331677e6ebf0b', 'hex')
+
+      await stateManager.putAccount(address, account)
+
+      let res = await stateManager.accountExists(address)
+
+      st.ok(res)
+
+      st.end()
+    },
+  )
+
+  t.test(
     'should call the callback with a false boolean representing non-emptiness when the account is not empty',
     async (st) => {
       const stateManager = new DefaultStateManager()

--- a/packages/vm/tests/config.js
+++ b/packages/vm/tests/config.js
@@ -119,6 +119,11 @@ const SKIP_VM = [
  * @returns {String} Either an alias of the forkConfig param, or the forkConfig param itself
  */
 function getRequiredForkConfigAlias(forkConfig) {
+  // TangerineWhistle is named EIP150 (attention: misleading name)
+  // in the client-independent consensus test suite
+  if (String(forkConfig).match(/^tangerineWhistle$/i)) {
+    return 'EIP150'
+  }
   // SpuriousDragon is named EIP158 (attention: misleading name)
   // in the client-independent consensus test suite
   if (String(forkConfig).match(/^spuriousDragon$/i)) {


### PR DESCRIPTION
Initial push on `TangerineWhistle` support, I would assume that only the changes from [EIP-161](https://eips.ethereum.org/EIPS/eip-161) need to be separated for this to work.

Initial test run:

```shell
1..1096
# tests 1096
# pass  832
# fail  264
```

Feel free to pick things up and continue on this.