### PR TITLE
Use the latest ethereumjs-util v6 in a new patch version of ethereumjs-blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.4] - 2020-07-16
+
+This release replaces the tiled (`~`) dependency from `ethereumjs-util` for a
+caret (`^`) one, meaning that any update to `ethereumjs-util` v6 will also be
+available for this library.
+
+[4.0.4]: https://github.com/ethereumjs/ethereumjs-vm/compare/@ethereumjs/blockchain@4.0.3...@ethereumjs/blockchain@4.0.4
+
 ## [4.0.3] - 2019-12-19
 
 Supports `MuirGlacier` by updating `ethereumjs-block` to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-blockchain",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "A module to store and interact with blocks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,7 +46,7 @@
     "ethashjs": "~0.0.7",
     "ethereumjs-block": "~2.2.2",
     "ethereumjs-common": "^1.5.0",
-    "ethereumjs-util": "~6.1.0",
+    "ethereumjs-util": "^6.1.0",
     "flow-stoplight": "^1.0.0",
     "level-mem": "^3.0.1",
     "lru-cache": "^5.1.1",


### PR DESCRIPTION
Hey @holgerd77,

I noticed that `ethereumjs-blockchain` had a tilde (`~`) dependency on `ethereumjs-util`, which meant that it didn't get any benefit from the backports you released today.

@evertonfraga already fixed this on `master`, but that change will only land in `@ethereumjs/blockchain` and not `ethereumjs-blockchain`, I created the `blockchain/4.x` the branch here and backported the fix. The branch names follow the new conventions, as instructed by Everton.

As this change is tiny, I also made the preparation of the new release here.

I think this should be the latest backport needed, but will rescan the dependency trees in search for more `~` dependencies.