### PR TITLE
Update blockchain readme example

### DIFF
--- a/packages/blockchain/README.md
+++ b/packages/blockchain/README.md
@@ -24,29 +24,24 @@ The following is an example to iterate through an existing Geth DB (needs `level
 
 This module performs write operations. Making a backup of your data before trying it is recommended. Otherwise, you can end up with a compromised DB state.
 
-```javascript
-const level = require('level')
-const Blockchain = require('@ethereumjs/blockchain').default
-const utils = require('ethereumjs-util')
+```typescript
+import Blockchain from '@ethereumjs/blockchain'
+import { bufferToInt } from 'ethereumjs-util'
+import level from 'level'
 
 const gethDbPath = './chaindata' // Add your own path here. It will get modified, see remarks.
-const db = level(gethDbPath)
 
-new Blockchain({ db: db }).iterator(
-  'i',
-  (block, reorg, cb) => {
-    const blockNumber = utils.bufferToInt(block.header.number)
-    const blockHash = block.hash().toString('hex')
-    console.log(`BLOCK ${blockNumber}: ${blockHash}`)
-    cb()
-  },
-  (err) => console.log(err || 'Done.'),
-)
+const db = level(gethDbPath)
+const blockchain = new Blockchain({ db })
+
+blockchain.iterator('i', (block) => {
+  const blockNumber = bufferToInt(block.header.number)
+  const blockHash = block.hash().toString('hex')
+  console.log(`Block ${blockNumber}: ${blockHash}`)
+})
 ```
 
-**WARNING**: Since `@ethereumjs/blockchain` is also doing write operations
-on the DB for safety reasons only run this on a copy of your database, otherwise this might lead
-to a compromised DB state.
+**WARNING**: Since `@ethereumjs/blockchain` is also doing write operations on the DB for safety reasons only run this on a copy of your database, otherwise this might lead to a compromised DB state.
 
 # EthereumJS
 


### PR DESCRIPTION
This PR updates the blockchain example in the readme after the changes in #833.

Note: the geth example may not be working anymore due to changes to the geth db structure (see #745), so we may want to consider using another example here.