### PR TITLE
Use native EventEmitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:fix": "lerna run lint:fix --stream --parallel",
     "test": "lerna exec npm run test --parallel",
     "coverage": "lerna run coverage --stream",
-    "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash"
+    "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash",
+    "clean": "git clean -fXd packages"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "lint:fix": "lerna run lint:fix --stream --parallel",
     "test": "lerna exec npm run test --parallel",
     "coverage": "lerna run coverage --stream",
-    "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash",
-    "clean": "git clean -fXd packages"
+    "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash"
   }
 }

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -122,7 +122,7 @@ export default class EVM {
    * if an exception happens during the message execution.
    */
   async executeMessage(message: Message): Promise<EVMResult> {
-    await this._vm._emit('beforeMessage', message)
+    this._vm.emit('beforeMessage', message)
 
     await this._state.checkpoint()
 
@@ -150,7 +150,7 @@ export default class EVM {
       await this._state.commit()
     }
 
-    await this._vm._emit('afterMessage', result)
+    this._vm.emit('afterMessage', result)
 
     return result
   }
@@ -232,7 +232,7 @@ export default class EVM {
       code: message.code,
     }
 
-    await this._vm._emit('newContract', newContractEvent)
+    this._vm.emit('newContract', newContractEvent)
 
     toAccount = await this._state.getAccount(message.to)
     // EIP-161 on account creation and CREATE execution

--- a/packages/vm/lib/evm/interpreter.ts
+++ b/packages/vm/lib/evm/interpreter.ts
@@ -206,7 +206,7 @@ export default class Interpreter {
      * @property {StateManager} stateManager a [`StateManager`](stateManager.md) instance (Beta API)
      * @property {Buffer} codeAddress the address of the code which is currently being ran (this differs from `address` in a `DELEGATECALL` and `CALLCODE` call)
      */
-    return this._vm._emit('step', eventObj)
+    return this._vm.emit('step', eventObj)
   }
 
   // Returns all valid jump and jumpsub destinations.

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -126,7 +126,7 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
    * @type {Object}
    * @property {Block} block emits the block that is about to be processed
    */
-  await this._emit('beforeBlock', opts.block)
+  this.emit('beforeBlock', opts.block)
 
   // Set state root if provided
   if (opts.root) {
@@ -186,7 +186,7 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
    * @type {Object}
    * @property {Object} result emits the results of processing a block
    */
-  await this._emit('afterBlock', {
+  this.emit('afterBlock', {
     receipts: result.receipts,
     results: result.results,
   })

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -113,7 +113,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       `sender doesn't have enough funds to send tx. The upfront cost is: ${tx
         .getUpfrontCost()
         .toString()}` +
-      ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
+        ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
     )
   } else if (!opts.skipNonce && !new BN(fromAccount.nonce).eq(new BN(tx.nonce))) {
     throw new Error(

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -96,7 +96,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    * @type {Object}
    * @property {Transaction} tx emits the Transaction that is about to be processed
    */
-  await this._emit('beforeTx', tx)
+  this.emit('beforeTx', tx)
 
   // Validate gas limit against base fee
   const basefee = tx.getBaseFee()
@@ -113,7 +113,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       `sender doesn't have enough funds to send tx. The upfront cost is: ${tx
         .getUpfrontCost()
         .toString()}` +
-        ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
+      ` and the sender's account only has: ${new BN(fromAccount.balance).toString()}`,
     )
   } else if (!opts.skipNonce && !new BN(fromAccount.nonce).eq(new BN(tx.nonce))) {
     throw new Error(
@@ -198,7 +198,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    * @type {Object}
    * @property {Object} result result of the transaction
    */
-  await this._emit('afterTx', results)
+  this.emit('afterTx', results)
 
   return results
 }

--- a/packages/vm/package-lock.json
+++ b/packages/vm/package-lock.json
@@ -1196,9 +1196,9 @@
 					}
 				},
 				"lodash": {
-					"version": "4.17.19",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-					"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 					"dev": true
 				},
 				"longest": {

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -43,7 +43,6 @@
     "VM"
   ],
   "dependencies": {
-    "async-eventemitter": "^0.2.4",
     "core-js-pure": "^3.0.1",
     "@ethereumjs/account": "^3.0.0",
     "@ethereumjs/block": "^3.0.0",

--- a/packages/vm/tests/api/runBlock.js
+++ b/packages/vm/tests/api/runBlock.js
@@ -17,7 +17,6 @@ function setup(vm = null) {
     vm = {
       stateManager,
       emit: (e, val, cb) => cb(),
-      _emit: (e, val) => new Promise((resolve, reject) => resolve()),
       runTx: (opts) => new Promise((resolve, reject) => reject(new Error('test'))),
       _common: new Common('mainnet', 'byzantium'),
     }

--- a/packages/vm/tests/api/runTx.js
+++ b/packages/vm/tests/api/runTx.js
@@ -11,9 +11,7 @@ function setup(vm = null) {
     const stateManager = new DefaultStateManager({})
     vm = {
       stateManager,
-      emit: (e, val, cb) => {
-        cb()
-      },
+      emit: () => {},
     }
   }
 

--- a/packages/vm/tests/api/runTx.js
+++ b/packages/vm/tests/api/runTx.js
@@ -14,7 +14,6 @@ function setup(vm = null) {
       emit: (e, val, cb) => {
         cb()
       },
-      _emit: (e, val) => new Promise((resolve, reject) => resolve()),
     }
   }
 


### PR DESCRIPTION
This PR updates the VM to use node's native EventEmitter rather than `async-eventemitter`, as noted in https://github.com/ethereumjs/ethereumjs-vm/issues/775#issuecomment-650145740 and https://github.com/ethereumjs/organization/issues/64#issuecomment-679939357.

I didn't find any use of async functionality with the package to need to await any emits since it looks like we are only emitting objects, so I've converted all `emit`s to synchronous.