### PR TITLE
Add clean script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Installs dependencies for all sub-packages, and links them to create an integrat
 
 #### `npm run build`
 
-Produces `dist` files for all sub-packages. This command can be scoped
+Produces `dist` files for all sub-packages. This command can be scoped.
 
 #### `npm run build:tree -- --scope @ethereumjs/blockchain`
 
@@ -95,15 +95,15 @@ Generates package documentation and outputs it to `./packages/<name>/docs`.
 
 #### `npm run lint`
 
-Checks code style, according to the rules defined in [ethereumjs-config](https://github.com/ethereumjs/ethereumjs-config).
+Checks code style according to the rules defined in [ethereumjs-config](https://github.com/ethereumjs/ethereumjs-config).
 
 #### `npm run lint:fix`
 
-Fixes code style, according to the rules 
+Fixes code style according to the rules.
 
 #### `npm run test`
 
-Runs all package tests. Note that the VM have several test scopes. Refer to their package.json for more info.
+Runs all package tests. Note that the VM has several test scopes - refer to [packages/vm/package.json](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/vm/package.json) for more info.
 
 #### `npm run clean`
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Fixes code style, according to the rules
 
 Runs all package tests. Note that the VM have several test scopes. Refer to their package.json for more info.
 
+#### `npm run clean`
+
+Removes root and package `node_modules` directories. Useful to run before `npm i` for a fresh install.
+
 ### Going further
 
 As this project is powered by Lerna, you can install it globally to enjoy lots more options. Refer to [Lerna docs](https://github.com/lerna/lerna/tree/master/commands/run) for additional commands.
@@ -112,7 +116,10 @@ As this project is powered by Lerna, you can install it globally to enjoy lots m
 - `npm install -g lerna`
 - `lerna run`
 - `lerna exec`
-- `lerna clean`
+
+#### Cleaning `node_modules`
+
+Hoisting is enabled so shared dependencies across packages are symlinked to the root `node_modules`. `lerna clean` [does not remove the root `node_modules`](https://github.com/lerna/lerna/issues/1304) so for convenience you can use the project script `npm run clean`.
 
 # EthereumJS
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lint:fix": "lerna run lint:fix --stream --parallel",
     "test": "lerna exec npm run test --parallel",
     "coverage": "lerna run coverage --stream",
-    "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash"
+    "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash",
+    "clean": "lerna exec -- rm -rf node_modules && rm -rf node_modules"
   }
 }


### PR DESCRIPTION
Since `lerna clean` [does not remove the root `node_modules`](https://github.com/lerna/lerna/issues/1304), this PR adds project script `npm run clean` to remove root and package `node_modules` directories, useful before running `npm i` for a fresh install.