### PR TITLE
Temporarily disabling FF karma testing on Block

### DIFF
--- a/packages/block/karma.conf.js
+++ b/packages/block/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       './test-build/**/*.js': ['browserify'],
     },
     reporters: ['dots'],
-    browsers: ['FirefoxHeadless', 'ChromeHeadless'],
+    browsers: ['ChromeHeadless'],
     singleRun: true,
   })
 }


### PR DESCRIPTION
If you guys recall reading The Pragmatic Programmer, you'll immediately know what I'm doing :)

Let's quarantine the FF issue to a single branch, so its side-effects do not affect orthogonal PRs. Until we fix the root cause, we can't guarantee correctness of our code in FF (Blink) engine anyway, so it at least do not affect every other PR build (including master).