### PR TITLE
Fixes Karma Firefox test inconsistency

### DIFF
--- a/packages/block/karma.conf.js
+++ b/packages/block/karma.conf.js
@@ -6,8 +6,9 @@ module.exports = function(config) {
     preprocessors: {
       './test-build/**/*.js': ['browserify'],
     },
+    concurrency: 1,
     reporters: ['dots'],
-    browsers: ['ChromeHeadless'],
+    browsers: ['FirefoxHeadless', 'ChromeHeadless'],
     singleRun: true,
   })
 }


### PR DESCRIPTION
This PR will be a sandbox of some different approaches to make FF + Karma work on our CI properly.

Measures:
- [x] Disable other workflows for now, so we can make more tests at once, without further impact on CI
- [x] Isolate FF run from Chrome, to discard timeout due to intensive resource usage

Hypothesis:
- [x] Run Chrome and Firefox in sequence, rather than in parallel

Cleanup:
- [x] Re-enable other workflow files
- [x] Revert Block workflow file to initial state.

Note: The commits will be squashed at the end, so the history will be clean.