### PR TITLE
Move EIP Integration to Common

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -162,9 +162,11 @@ export class BlockHeader {
     const blockTs = new BN(this.timestamp)
     const parentTs = new BN(parentBlock.header.timestamp)
     const parentDif = new BN(parentBlock.header.difficulty)
-    const minimumDifficulty = new BN(this._common.param('pow', 'minimumDifficulty', hardfork))
+    const minimumDifficulty = new BN(
+      this._common.paramByHardfork('pow', 'minimumDifficulty', hardfork),
+    )
     const offset = parentDif.div(
-      new BN(this._common.param('pow', 'difficultyBoundDivisor', hardfork)),
+      new BN(this._common.paramByHardfork('pow', 'difficultyBoundDivisor', hardfork)),
     )
     let num = new BN(this.number)
 
@@ -212,7 +214,11 @@ export class BlockHeader {
       dif = parentDif.add(offset.mul(a))
     } else {
       // pre-homestead
-      if (parentTs.addn(this._common.param('pow', 'durationLimit', hardfork)).cmp(blockTs) === 1) {
+      if (
+        parentTs
+          .addn(this._common.paramByHardfork('pow', 'durationLimit', hardfork))
+          .cmp(blockTs) === 1
+      ) {
         dif = offset.add(parentDif)
       } else {
         dif = parentDif.sub(offset)
@@ -252,7 +258,7 @@ export class BlockHeader {
     const hardfork = this._getHardfork()
 
     const a = pGasLimit.div(
-      new BN(this._common.param('gasConfig', 'gasLimitBoundDivisor', hardfork)),
+      new BN(this._common.paramByHardfork('gasConfig', 'gasLimitBoundDivisor', hardfork)),
     )
     const maxGasLimit = pGasLimit.add(a)
     const minGasLimit = pGasLimit.sub(a)
@@ -260,7 +266,7 @@ export class BlockHeader {
     return (
       gasLimit.lt(maxGasLimit) &&
       gasLimit.gt(minGasLimit) &&
-      gasLimit.gte(this._common.param('gasConfig', 'minGasLimit', hardfork))
+      gasLimit.gte(this._common.paramByHardfork('gasConfig', 'minGasLimit', hardfork))
     )
   }
 
@@ -310,7 +316,7 @@ export class BlockHeader {
     }
 
     const hardfork = this._getHardfork()
-    if (this.extraData.length > this._common.param('vm', 'maxExtraDataSize', hardfork)) {
+    if (this.extraData.length > this._common.paramByHardfork('vm', 'maxExtraDataSize', hardfork)) {
       throw new Error('invalid amount of extra data')
     }
   }

--- a/packages/common/src/eips/EIP2537.json
+++ b/packages/common/src/eips/EIP2537.json
@@ -3,6 +3,7 @@
   "comment": "BLS12-381 precompiles",
   "url": "https://eips.ethereum.org/EIPS/eip-2537",
   "status": "Draft",
+  "minimumHardfork": "chainstart",
   "gasConfig": {},
   "gasPrices": {
     "Bls12381G1AddGas": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -22,6 +22,15 @@ export interface CommonOpts {
    * Limit parameter returns to the given hardforks
    */
   supportedHardforks?: Array<string>
+  /**
+   * Selected EIPs which can be activated, please use an array for instantiation
+   * (e.g. `eips: [ 'EIP2537', ])
+   *
+   * Currently supported:
+   *
+   * - [EIP2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS12-381 precompiles
+   */
+  eips?: string[]
 }
 
 interface hardforkOptions {
@@ -37,9 +46,10 @@ interface hardforkOptions {
 export default class Common {
   readonly DEFAULT_HARDFORK: string = 'petersburg'
 
-  private _hardfork: string
-  private _supportedHardforks: Array<string>
   private _chainParams: Chain
+  private _hardfork: string
+  private _supportedHardforks: Array<string> = []
+  private _eips: string[] = []
 
   /**
    * Creates a Common object for a custom chain, based on a standard one. It uses all the [[Chain]]
@@ -91,9 +101,14 @@ export default class Common {
   constructor(opts: CommonOpts) {
     this._chainParams = this.setChain(opts.chain)
     this._hardfork = this.DEFAULT_HARDFORK
-    this._supportedHardforks = opts.supportedHardforks === undefined ? [] : opts.supportedHardforks
+    if (opts.supportedHardforks) {
+      this._supportedHardforks = opts.supportedHardforks
+    }
     if (opts.hardfork) {
       this.setHardfork(opts.hardfork)
+    }
+    if (opts.eips) {
+      this.setEIPs(opts.eips)
     }
   }
 
@@ -207,15 +222,59 @@ export default class Common {
   }
 
   /**
+   * Sets the active EIPs
+   * @param eips
+   */
+  setEIPs(eips: string[] = []) {
+    for (const eip of eips) {
+      if (!(eip in EIPs)) {
+        throw new Error(`${eip} not supported`)
+      }
+      const minHF = this.gteHardfork(EIPs[eip]['minimumHardfork'])
+      if (!minHF) {
+        throw new Error(
+          `${eip} cannot be activated on hardfork ${this.hardfork()}, minimumHardfork: ${minHF}`,
+        )
+      }
+    }
+    this._eips = eips
+  }
+
+  /**
+   * Returns a parameter for the current chain setup
+   *
+   * If the parameter is present in an EIP, the EIP always takes precendence.
+   * Otherwise the parameter if taken from the latest applied HF with
+   * a change on the respective parameter.
+   *
+   * @param topic Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow')
+   * @param name Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic)
+   * @returns The value requested or `null` if not found
+   */
+  param(topic: string, name: string): any {
+    // TODO: consider the case that different active EIPs
+    // can change the same parameter
+    let value = null
+    for (const eip of this._eips) {
+      value = this.paramByEIP(topic, name, eip)
+      if (value !== null) {
+        return value
+      }
+    }
+    return this.paramByHardfork(topic, name, this._hardfork)
+  }
+
+  /**
    * Returns the parameter corresponding to a hardfork
    * @param topic Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow')
    * @param name Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic)
-   * @param hardfork Hardfork name, optional if hardfork set
+   * @param hardfork Hardfork name
+   * @returns The value requested or `null` if not found
    */
-  param(topic: string, name: string, hardfork?: string): any {
+  paramByHardfork(topic: string, name: string, hardfork: string): any {
     hardfork = this._chooseHardfork(hardfork)
 
-    let value
+    let value = null
     for (const hfChanges of hardforkChanges) {
       if (!hfChanges[1][topic]) {
         throw new Error(`Topic ${topic} not defined`)
@@ -225,9 +284,6 @@ export default class Common {
       }
       if (hfChanges[0] === hardfork) break
     }
-    if (value === undefined) {
-      throw new Error(`${topic} value for ${name} not found`)
-    }
     return value
   }
 
@@ -236,6 +292,7 @@ export default class Common {
    * @param topic Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow')
    * @param name Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic)
    * @param eip Name of the EIP (e.g. 'EIP2537')
+   * @returns The value requested or `null` if not found
    */
   paramByEIP(topic: string, name: string, eip: string): any {
     if (!(eip in EIPs)) {
@@ -247,7 +304,7 @@ export default class Common {
       throw new Error(`Topic ${topic} not defined`)
     }
     if (eipParams[topic][name] === undefined) {
-      throw new Error(`${topic} value for ${name} not found`)
+      return null
     }
     let value = eipParams[topic][name].v
     return value
@@ -262,7 +319,7 @@ export default class Common {
   paramByBlock(topic: string, name: string, blockNumber: number): any {
     const activeHfs = this.activeHardforks(blockNumber)
     const hardfork = activeHfs[activeHfs.length - 1]['name']
-    return this.param(topic, name, hardfork)
+    return this.paramByHardfork(topic, name, hardfork)
   }
 
   /**
@@ -555,5 +612,13 @@ export default class Common {
    */
   networkId(): number {
     return (<any>this._chainParams)['networkId']
+  }
+
+  /**
+   * Returns the active EIPs
+   * @returns List of EIPs
+   */
+  eips(): string[] {
+    return this._eips
   }
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -24,7 +24,7 @@ export interface CommonOpts {
   supportedHardforks?: Array<string>
   /**
    * Selected EIPs which can be activated, please use an array for instantiation
-   * (e.g. `eips: [ 'EIP2537', ])
+   * (e.g. `eips: [ 'EIP2537', ]`)
    *
    * Currently supported:
    *

--- a/packages/common/tests/eips.ts
+++ b/packages/common/tests/eips.ts
@@ -1,0 +1,34 @@
+import * as tape from 'tape'
+import Common from '../src/'
+
+tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
+  t.test('Correct initialization', function (st: tape.Test) {
+    const eips = ['EIP2537']
+    const c = new Common({ chain: 'mainnet', eips })
+    st.equal(c.eips(), eips, 'should initialize with supported EIP')
+    st.end()
+  })
+
+  t.test('Initialization errors', function (st: tape.Test) {
+    let eips = ['NOT_SUPPORTED_EIP']
+    let msg = 'should throw on not supported EIP'
+    let f = () => {
+      new Common({ chain: 'mainnet', eips })
+    }
+    st.throws(f, /not supported$/, msg)
+
+    /*
+    // Manual test since no test triggering EIP config available
+    // TODO: recheck on addition of new EIP configs
+    // To run manually change minimumHardfork in EIP2537 config to petersburg
+    eips = [ 'EIP2537', ]
+    msg = 'should throw on not meeting minimum hardfork requirements'
+    f = () => {
+      new Common({ chain: 'mainnet', hardfork: 'byzantium', eips })
+    }
+    st.throws(f, /minimumHardfork/, msg)
+    */
+
+    st.end()
+  })
+})

--- a/packages/common/tests/params.ts
+++ b/packages/common/tests/params.ts
@@ -1,33 +1,40 @@
 import * as tape from 'tape'
 import Common from '../src/'
 
-tape('[Common]: Parameter access', function (t: tape.Test) {
+tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: tape.Test) {
   t.test('Basic usage', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet' })
+    const c = new Common({ chain: 'mainnet', eips: ['EIP2537'] })
     let msg = 'Should return correct value when HF directly provided'
-    st.equal(c.param('gasPrices', 'ecAdd', 'byzantium'), 500, msg)
+    st.equal(c.paramByHardfork('gasPrices', 'ecAdd', 'byzantium'), 500, msg)
 
     c.setHardfork('byzantium')
     msg = 'Should return correct value for HF set in class'
     st.equal(c.param('gasPrices', 'ecAdd'), 500, msg)
 
+    msg = 'Should return null for non-existing value'
+    st.equal(c.param('gasPrices', 'notexistingvalue'), null, msg)
+    st.equal(c.paramByHardfork('gasPrices', 'notexistingvalue', 'byzantium'), null, msg)
+
+    /*
+    // Manual test since no test triggering EIP config available
+    // TODO: recheck on addition of new EIP configs
+    // To run please manually add an "ecAdd" entry with value 12345 to EIP2537 config
+    // and uncomment the test
+    msg = 'EIP config should take precedence over HF config'
+    st.equal(c.param('gasPrices', 'ecAdd'), 12345, msg)
+    */
+
     st.end()
   })
 
-  t.test('Error cases', function (st: tape.Test) {
+  t.test('Error cases for param(), paramByHardfork()', function (st: tape.Test) {
     let c = new Common({ chain: 'mainnet' })
 
     let f = function () {
-      c.param('gasPrizes', 'ecAdd', 'byzantium')
+      c.paramByHardfork('gasPrizes', 'ecAdd', 'byzantium')
     }
     let msg = 'Should throw when called with non-existing topic'
     st.throws(f, /Topic gasPrizes not defined$/, msg)
-
-    f = function () {
-      c.param('gasPrices', 'notexistingvalue', 'byzantium')
-    }
-    msg = 'Should throw when called with non-existing value'
-    st.throws(f, /value for notexistingvalue not found$/, msg)
 
     c.setHardfork('byzantium')
     st.equal(c.param('gasPrices', 'ecAdd'), 500, 'Should return correct value for HF set in class')
@@ -38,7 +45,7 @@ tape('[Common]: Parameter access', function (t: tape.Test) {
       supportedHardforks: ['byzantium', 'constantinople'],
     })
     f = function () {
-      c.param('gasPrices', 'expByte', 'spuriousDragon')
+      c.paramByHardfork('gasPrices', 'expByte', 'spuriousDragon')
     }
     msg = 'Should throw when calling param() with an unsupported hardfork'
     st.throws(f, /supportedHardforks$/, msg)
@@ -54,23 +61,18 @@ tape('[Common]: Parameter access', function (t: tape.Test) {
 
   t.test('Parameter updates', function (st: tape.Test) {
     const c = new Common({ chain: 'mainnet' })
-    const f = function () {
-      c.param('gasPrices', 'ecAdd', 'spuriousDragon')
-    }
-    let msg = 'Should throw for a value set on a later HF'
-    st.throws(f, /value for ecAdd not found$/, msg)
 
-    msg = 'Should return correct value for chain start'
-    st.equal(c.param('pow', 'minerReward', 'chainstart'), '5000000000000000000', msg)
+    let msg = 'Should return correct value for chain start'
+    st.equal(c.paramByHardfork('pow', 'minerReward', 'chainstart'), '5000000000000000000', msg)
 
     msg = 'Should reflect HF update changes'
-    st.equal(c.param('pow', 'minerReward', 'byzantium'), '3000000000000000000', msg)
+    st.equal(c.paramByHardfork('pow', 'minerReward', 'byzantium'), '3000000000000000000', msg)
 
     msg = 'Should return updated sstore gas prices for constantinople'
-    st.equal(c.param('gasPrices', 'netSstoreNoopGas', 'constantinople'), 200, msg)
+    st.equal(c.paramByHardfork('gasPrices', 'netSstoreNoopGas', 'constantinople'), 200, msg)
 
     msg = 'Should nullify SSTORE related values for petersburg'
-    st.equal(c.param('gasPrices', 'netSstoreNoopGas', 'petersburg'), null, msg)
+    st.equal(c.paramByHardfork('gasPrices', 'netSstoreNoopGas', 'petersburg'), null, msg)
 
     st.end()
   })
@@ -89,10 +91,14 @@ tape('[Common]: Parameter access', function (t: tape.Test) {
 
   t.test('EIP param access, paramByEIP()', function (st: tape.Test) {
     const c = new Common({ chain: 'mainnet' })
+
+    let msg = 'Should return null for non-existing value'
+    st.equal(c.paramByEIP('gasPrices', 'notexistingvalue', 'EIP2537'), null, msg)
+
     let f = function () {
       c.paramByEIP('gasPrices', 'Bls12381G1AddGas', 'NOT_SUPPORTED_EIP')
     }
-    let msg = 'Should throw for using paramByEIP() with a not supported EIP'
+    msg = 'Should throw for using paramByEIP() with a not supported EIP'
     st.throws(f, /not supported$/, msg)
 
     f = function () {
@@ -100,12 +106,6 @@ tape('[Common]: Parameter access', function (t: tape.Test) {
     }
     msg = 'Should throw for using paramByEIP() with a not existing topic'
     st.throws(f, /not defined$/, msg)
-
-    f = function () {
-      c.paramByEIP('gasPrices', 'Bls12381G1AddGas_WITH_SPELLING_MISTAKE', 'EIP2537')
-    }
-    msg = 'Should throw for using paramByEIP() if value was not found'
-    st.throws(f, /not found$/, msg)
 
     msg = 'Should return Bls12381G1AddGas gas price for EIP2537'
     st.equal(c.paramByEIP('gasPrices', 'Bls12381G1AddGas', 'EIP2537'), 600, msg)

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -390,7 +390,7 @@ export default class EVM {
    * if no such precompile exists.
    */
   getPrecompile(address: Buffer): PrecompileFunc {
-    return getPrecompile(address.toString('hex'), this._vm._common, this._vm)
+    return getPrecompile(address.toString('hex'), this._vm._common)
   }
 
   /**

--- a/packages/vm/lib/evm/precompiles/index.ts
+++ b/packages/vm/lib/evm/precompiles/index.ts
@@ -132,7 +132,7 @@ const precompileAvailability: PrecompileAvailability = {
   },
 }
 
-function getPrecompile(address: string, common: Common, vm: VM): PrecompileFunc {
+function getPrecompile(address: string, common: Common): PrecompileFunc {
   if (precompiles[address]) {
     const availability = precompileAvailability[address]
     if (
@@ -142,7 +142,7 @@ function getPrecompile(address: string, common: Common, vm: VM): PrecompileFunc 
       return precompiles[address]
     } else if (
       availability.type == PrecompileAvailabilityCheck.EIP &&
-      vm._activatedEIPs.includes(availability.param)
+      common.eips().includes(availability.param)
     ) {
       return precompiles[address]
     }

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -22,7 +22,7 @@
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "node -r ts-node/register --stack-size=1500 ./tests/tester --blockchain",
     "test:blockchain:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin' | xargs -n1 | xargs -I v1 node -r ts-node/register --stack-size=1500 ./tests/tester --blockchain --fork=v1",
-    "test:API": "tape -r ts-node/register --stack-size=1500 ./tests/api/**/*.js",
+    "test:API": "tape -r ts-node/register --stack-size=1500 './tests/api/**/*.js'",
     "test:API:browser": "npm run build && karma start karma.conf.js",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
     "tslint": "ethereumjs-config-tslint",

--- a/packages/vm/tests/BlockchainTestsRunner.js
+++ b/packages/vm/tests/BlockchainTestsRunner.js
@@ -26,11 +26,18 @@ module.exports = async function runBlockchainTest(options, testData, t) {
     validate = true
   }
 
-  const common = (options.forkConfigTestSuite == "HomesteadToDaoAt5") ? getDAOCommon(5) : new Common({ chain: 'mainnet', hardfork: options.forkConfigVM })
-  
   let eips = []
   if (options.forkConfigVM == 'berlin') {
-    eips = ['EIP2537'] // currently, the BLS tests run on the Berlin network, but our VM does not activate EIP2537 if you run the Berlin HF
+    // currently, the BLS tests run on the Berlin network, but our VM does not activate EIP2537 
+    // if you run the Berlin HF
+    eips = ['EIP2537']
+  }
+
+  let common
+  if (options.forkConfigTestSuite == "HomesteadToDaoAt5") {
+    common = getDAOCommon(5)
+  } else {
+    common = new Common({ chain: 'mainnet', hardfork: options.forkConfigVM, eips })
   }
 
   const blockchain = new Blockchain({
@@ -54,8 +61,7 @@ module.exports = async function runBlockchainTest(options, testData, t) {
   const vm = new VM({
     state,
     blockchain,
-    common,
-    eips
+    common
   })
 
   const genesisBlock = new Block(undefined, { common })

--- a/packages/vm/tests/GeneralStateTestsRunner.js
+++ b/packages/vm/tests/GeneralStateTestsRunner.js
@@ -53,14 +53,15 @@ async function runTestCase(options, testData, t) {
 
   let eips = []
   if (options.forkConfigVM == 'berlin') {
-    eips = ['EIP2537'] // currently, the BLS tests run on the Berlin network, but our VM does not activate EIP2537 if you run the Berlin HF
+    // currently, the BLS tests run on the Berlin network, but our VM does not activate EIP2537 
+    // if you run the Berlin HF
+    eips = ['EIP2537'] 
   }
 
-  const common = new Common({ chain: 'mainnet', hardfork: options.forkConfigVM })
+  const common = new Common({ chain: 'mainnet', hardfork: options.forkConfigVM, eips })
   vm = new VM({
     state,
-    common: common,
-    eips
+    common: common
   })
 
   await setupPreConditions(vm.stateManager._trie, testData)

--- a/packages/vm/tests/api/EIPs/EIP2537-BLS-tests.js
+++ b/packages/vm/tests/api/EIPs/EIP2537-BLS-tests.js
@@ -15,8 +15,8 @@ for (let address = precompileAddressStart; address <= precompileAddressEnd; addr
 
 const dir = "./tests/api/berlin/"
 
-tape('Berlin BLS tests', (t) => {
-    t.test('Berlin precompiles not available if EIP2537 is not activated', async (st) => {
+tape('EIP2537 BLS tests', (t) => {
+    t.test('BLS precompiles should not be available if EIP not activated', async (st) => {
         if (isRunningInKarma()) {
             st.skip('BLS does not work in karma')
             return st.end()
@@ -34,25 +34,25 @@ tape('Berlin BLS tests', (t) => {
             })
           
             if (!result.execResult.gasUsed.eq(new BN(0))) {
-                st.fail("BLS precompiles should not use any gas pre-Berlin")
+                st.fail("BLS precompiles should not use any gas if EIP not activated")
             }
 
             if (result.execResult.exceptionError) {
-                st.fail('BLS precompiles should not throw pre-Berlin')
+                st.fail('BLS precompiles should not throw if EIP not activated')
             }
         }
 
-        st.pass("Berlin precompiles unreachable pre-Berlin")
+        st.pass("BLS precompiles unreachable if EIP not activated")
         st.end()
     })
 
-    t.test('Berlin precompiles should throw on empty inputs', async (st) => {
+    t.test('BLS precompiles should throw on empty inputs', async (st) => {
         if (isRunningInKarma()) {
             st.skip('BLS does not work in karma')
             return st.end()
         }
-        const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
-        const vm = new VM({ common: common, eips: ['EIP2537'] })
+        const common = new Common({ chain: 'mainnet', hardfork: 'byzantium', eips: ['EIP2537'] })
+        const vm = new VM({ common: common })
         const gasLimit = new BN(0xffffffffff)
 
         for (let address of precompiles) {
@@ -73,7 +73,7 @@ tape('Berlin BLS tests', (t) => {
             }
         }
 
-        st.pass("Berlin precompiles throw correctly on empty inputs")
+        st.pass("BLS precompiles throw correctly on empty inputs")
         st.end()
     })
 

--- a/packages/vm/tests/api/index.js
+++ b/packages/vm/tests/api/index.js
@@ -71,7 +71,7 @@ tape('VM with default blockchain', (t) => {
       st.skip('BLS does not work in karma')
       return st.end()
     }
-    const common = new Common({ hardfork: 'mainnet', eips: [ 'EIP2537', ] })
+    const common = new Common({ chain: 'mainnet', eips: [ 'EIP2537', ] })
     st.doesNotThrow(() => { new VM({ common }) })
     st.end()
   })

--- a/packages/vm/tests/api/index.js
+++ b/packages/vm/tests/api/index.js
@@ -70,24 +70,9 @@ tape('VM with default blockchain', (t) => {
     if (isRunningInKarma()) {
       st.skip('BLS does not work in karma')
       return st.end()
-  }
-    st.doesNotThrow(() => { new VM({ eips: [ 'EIP2537', ] }) })
-    st.end()
-  })
-
-  t.test('should correctly set _activatedEIPs', async (st) => {
-    if (isRunningInKarma()) {
-      st.skip('BLS does not work in karma')
-      return st.end()
-  }
-    const vm = new VM({ eips: [ 'EIP2537', ] })
-
-    st.deepEqual(vm._activatedEIPs, [ 'EIP2537', ])
-    st.end()
-  })
-
-  t.test('should not accept a not supported EIP', async (st) => {
-    st.throws(() => { new VM({ eips: [ 'NOT_SUPPORTED_EIP', ] }) })
+    }
+    const common = new Common({ hardfork: 'mainnet', eips: [ 'EIP2537', ] })
+    st.doesNotThrow(() => { new VM({ common }) })
     st.end()
   })
 


### PR DESCRIPTION
Follow-up on #856 and #863 

This PR moves EIP integration from the VM to Common to be able to spawn EIP implementations across different libraries touched (as currently possible along hardfork lines). Upon this base integration it updates the EIP2537 integration in the VM.

The Common integration is hopefully somewhat future proof. I already added an additional check for `minimumHardfork` requirements where Common initialization will throw if not met (EIP2537 is currently set to chainstart, let me know if this is too low for some reasons).

Not yet integrated is a possible EIP dependency, e.g. when one EIP depends on one or several others. This could be implemented by adding a parameter `EIPdependencies` or the like to the `EIP*.json` files. Since this comes with some mild extra complexity - e.g. on the param() functionality - I didn't want to integrate directly and eventually overload the PR. Think this can be added once this case occurs.

I also decided to change the semantics of the `param()` function and add changed demarcation lines to the existing `paramByEIP()` and a newly added `paramByHardfork()` function. `param()` removes the `hardfork` parameter and is now the function which just "does the right thing" [tm] - which means it either takes the parameter from the latest hardfork or - if present - from an EIP set. If an EIP is set and contains the parameter, this setting always takes precedence (which I think makes sense and would be expected e.g. on the VM instantiated with a certain HF and an additional EIP changing gas costs e.g.). `paramByEIP()` and `paramByHardfork()` can now be used to explicitly demand for an EIP respectively HF-specific parameter.

This makes use of the`param()` function - especially in the VM - completely transparent and avoids code such as:

```typescript
if (EIP_ACTIVATED) {
  common.paramByEIP(...)
} else {
  common.param()
}
```

Instead the current `param()` usage can stay completely "as is" and the parameter is chosen correctly based on the chain setup in Common.