### PR TITLE
VM Bugfixes

### DIFF
--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -190,6 +190,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     }
   }
   await state.cleanupTouchedAccounts()
+  await state.clearOriginalStorageCache()
 
   /**
    * The `afterTx` event

--- a/packages/vm/lib/state/interface.ts
+++ b/packages/vm/lib/state/interface.ts
@@ -31,4 +31,5 @@ export interface StateManager {
   accountIsEmpty(address: Buffer): Promise<boolean>
   accountExists(address: Buffer): Promise<boolean>
   cleanupTouchedAccounts(): Promise<void>
+  clearOriginalStorageCache(): void
 }

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -236,6 +236,14 @@ export default class DefaultStateManager implements StateManager {
   }
 
   /**
+   * Clears the original storage cache. Refer to [[getOriginalContractStorage]]
+   * for more explanation. Alias of the internal _clearOriginalStorageCache
+   */
+  clearOriginalStorageCache(): void {
+    this._clearOriginalStorageCache()
+  }
+
+  /**
    * Modifies the storage trie of an account.
    * @private
    * @param address -  Address of the account whose storage is to be modified

--- a/packages/vm/tests/api/runCall.js
+++ b/packages/vm/tests/api/runCall.js
@@ -158,3 +158,50 @@ tape('Ensure that precompile activation creates non-empty accounts', async (t) =
 
     t.end()
 })
+
+tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', async (t) => {
+    // setup the accounts for this test
+    const caller =          Buffer.from('00000000000000000000000000000000000000ee', 'hex')                   // caller addres
+    const address =         Buffer.from('00000000000000000000000000000000000000ff', 'hex')
+    // setup the vm
+    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const vm = new VM({ common: common})                               
+    const code = "61000260005561000160005500"
+    /*
+      idea: store the original value in the storage slot, except it is now a 1-length buffer instead of a 32-length buffer
+      code:             
+        PUSH2 0x0002
+        PUSH1 0x00
+        SSTORE              -> make storage slot 0 "dirty"
+        PUSH2 0x0001
+        PUSH1 0x00          
+        SSTORE              -> -> restore it to the original storage value (refund sstoreCleanRefundEIP2200)
+        STOP
+      gas cost: 
+        4x PUSH                                         12
+        2x SSTORE (slot is nonzero, so charge 5000): 10000
+        net                                          10012
+      gas refund 
+        sstoreCleanRefundEIP2200                      4200
+      gas used
+                                                     10012 - 4200 = 5812
+
+    */
+
+    await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))  
+    await vm.stateManager.putContractStorage(address, Buffer.alloc(32, 0), Buffer.from(("00").repeat(31) + "01", 'hex'))
+
+    // setup the call arguments
+    let runCallArgs = {
+        caller: caller,                     // call address
+        to: address,
+        gasLimit: new BN(0xffffffffff),     // ensure we pass a lot of gas, so we do not run out of gas
+    }
+
+    const result = await vm.runCall(runCallArgs)
+    console.log(result.gasUsed, result.execResult.gasRefund)
+    t.equal(result.gasUsed.toNumber(), 5812, "gas used incorrect")
+    t.equal(result.execResult.gasRefund.toNumber(), 4200, "gas refund incorrect")
+
+    t.end()
+})

--- a/packages/vm/tests/api/runTx.js
+++ b/packages/vm/tests/api/runTx.js
@@ -123,9 +123,9 @@ tape('should clear storage cache after every transaction', async(t) => {
     PUSH1 01
     PUSH1 00
     SSTORE
-    STOP
+    INVALID
   */
-  const code = "600160005500"
+  const code = "6001600055FE"
   const address = Buffer.from("00000000000000000000000000000000000000ff", 'hex')
   await vm.stateManager.putContractCode(Buffer.from(address, 'hex'), Buffer.from(code, 'hex'))
   await vm.stateManager.putContractStorage(address, Buffer.from(("00").repeat(32), 'hex'), Buffer.from(("00").repeat(31) + "01", 'hex'))
@@ -140,7 +140,7 @@ tape('should clear storage cache after every transaction', async(t) => {
 
   await vm.stateManager.putAccount(tx.from, createAccount())
 
-  await vm.runTx({tx})
+  await vm.runTx({tx}) // this tx will fail, but we have to ensure that the cache is cleared
 
   t.equal(vm.stateManager._originalStorageCache.size, 0, 'storage cache should be cleared')
   t.end()


### PR DESCRIPTION
This PR fixes two bugs in the VM which appeared when we ran mainnet blocks in #853

They both have to do with Istanbul SSTORE gas calculation: the first fixes that the storage cache is only wiped after a block (if two txs write the same storage, then this slot is cached and there are some gas refunds which you get in the VM which should not happen). The second is checking if the slot has the same value; they can have the same value, but due to wrongly padded Buffers the VM thinks that the values are different. (i.e. the buffers `0x01` and `0x0001` are semantically in the VM the same value, but the Buffers are obviously not equal).