### PR TITLE
Index `eips` by `number` instead of `string`

### DIFF
--- a/packages/common/src/eips/index.ts
+++ b/packages/common/src/eips/index.ts
@@ -1,5 +1,5 @@
 import { eipsType } from './../types'
 
 export const EIPs: eipsType = {
-  EIP2537: require('./EIP2537.json'),
+  2537: require('./EIP2537.json'),
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -24,13 +24,13 @@ export interface CommonOpts {
   supportedHardforks?: Array<string>
   /**
    * Selected EIPs which can be activated, please use an array for instantiation
-   * (e.g. `eips: [ 'EIP2537', ]`)
+   * (e.g. `eips: [ 2537, ]`)
    *
    * Currently supported:
    *
-   * - [EIP2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS12-381 precompiles
+   * - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS12-381 precompiles
    */
-  eips?: string[]
+  eips?: number[]
 }
 
 interface hardforkOptions {
@@ -49,7 +49,7 @@ export default class Common {
   private _chainParams: Chain
   private _hardfork: string
   private _supportedHardforks: Array<string> = []
-  private _eips: string[] = []
+  private _eips: number[] = []
 
   /**
    * Creates a Common object for a custom chain, based on a standard one. It uses all the [[Chain]]
@@ -225,7 +225,7 @@ export default class Common {
    * Sets the active EIPs
    * @param eips
    */
-  setEIPs(eips: string[] = []) {
+  setEIPs(eips: number[] = []) {
     for (const eip of eips) {
       if (!(eip in EIPs)) {
         throw new Error(`${eip} not supported`)
@@ -291,10 +291,10 @@ export default class Common {
    * Returns a parameter corresponding to an EIP
    * @param topic Parameter topic ('gasConfig', 'gasPrices', 'vm', 'pow')
    * @param name Parameter name (e.g. 'minGasLimit' for 'gasConfig' topic)
-   * @param eip Name of the EIP (e.g. 'EIP2537')
+   * @param eip Number of the EIP
    * @returns The value requested or `null` if not found
    */
-  paramByEIP(topic: string, name: string, eip: string): any {
+  paramByEIP(topic: string, name: string, eip: number): any {
     if (!(eip in EIPs)) {
       throw new Error(`${eip} not supported`)
     }
@@ -618,7 +618,7 @@ export default class Common {
    * Returns the active EIPs
    * @returns List of EIPs
    */
-  eips(): string[] {
+  eips(): number[] {
     return this._eips
   }
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -24,7 +24,7 @@ export interface Chain {
 }
 
 export interface eipsType {
-  [key: string]: any
+  [key: number]: any
 }
 
 export interface GenesisBlock {

--- a/packages/common/tests/eips.ts
+++ b/packages/common/tests/eips.ts
@@ -3,15 +3,16 @@ import Common from '../src/'
 
 tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
   t.test('Correct initialization', function (st: tape.Test) {
-    const eips = ['EIP2537']
+    const eips = [2537]
     const c = new Common({ chain: 'mainnet', eips })
     st.equal(c.eips(), eips, 'should initialize with supported EIP')
     st.end()
   })
 
   t.test('Initialization errors', function (st: tape.Test) {
-    let eips = ['NOT_SUPPORTED_EIP']
-    let msg = 'should throw on not supported EIP'
+    const UNSUPPORTED_EIP = 1000000
+    let eips = [UNSUPPORTED_EIP]
+    let msg = 'should throw on an unsupported EIP'
     let f = () => {
       new Common({ chain: 'mainnet', eips })
     }
@@ -21,7 +22,7 @@ tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
     // Manual test since no test triggering EIP config available
     // TODO: recheck on addition of new EIP configs
     // To run manually change minimumHardfork in EIP2537 config to petersburg
-    eips = [ 'EIP2537', ]
+    eips = [ 2537, ]
     msg = 'should throw on not meeting minimum hardfork requirements'
     f = () => {
       new Common({ chain: 'mainnet', hardfork: 'byzantium', eips })

--- a/packages/common/tests/params.ts
+++ b/packages/common/tests/params.ts
@@ -3,7 +3,7 @@ import Common from '../src/'
 
 tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: tape.Test) {
   t.test('Basic usage', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet', eips: ['EIP2537'] })
+    const c = new Common({ chain: 'mainnet', eips: [2537] })
     let msg = 'Should return correct value when HF directly provided'
     st.equal(c.paramByHardfork('gasPrices', 'ecAdd', 'byzantium'), 500, msg)
 
@@ -93,22 +93,23 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
     const c = new Common({ chain: 'mainnet' })
 
     let msg = 'Should return null for non-existing value'
-    st.equal(c.paramByEIP('gasPrices', 'notexistingvalue', 'EIP2537'), null, msg)
+    st.equal(c.paramByEIP('gasPrices', 'notexistingvalue', 2537), null, msg)
 
+    const UNSUPPORTED_EIP = 1000000
     let f = function () {
-      c.paramByEIP('gasPrices', 'Bls12381G1AddGas', 'NOT_SUPPORTED_EIP')
+      c.paramByEIP('gasPrices', 'Bls12381G1AddGas', UNSUPPORTED_EIP)
     }
-    msg = 'Should throw for using paramByEIP() with a not supported EIP'
+    msg = 'Should throw for using paramByEIP() with an unsupported EIP'
     st.throws(f, /not supported$/, msg)
 
     f = function () {
-      c.paramByEIP('notExistingTopic', 'Bls12381G1AddGas', 'EIP2537')
+      c.paramByEIP('notExistingTopic', 'Bls12381G1AddGas', 2537)
     }
     msg = 'Should throw for using paramByEIP() with a not existing topic'
     st.throws(f, /not defined$/, msg)
 
     msg = 'Should return Bls12381G1AddGas gas price for EIP2537'
-    st.equal(c.paramByEIP('gasPrices', 'Bls12381G1AddGas', 'EIP2537'), 600, msg)
+    st.equal(c.paramByEIP('gasPrices', 'Bls12381G1AddGas', 2537), 600, msg)
     st.end()
   })
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -80,7 +80,7 @@ This API can be used as follows:
 
 ```typescript
 import VM from 'ethereumjs-vm'
-const vm = new VM({ eips: ['EIP2537'] })
+const vm = new VM({ eips: [2537] })
 ```
 
 ### API Change: New Major Library Versions

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -58,7 +58,7 @@ Supported `Istanbul` EIPs:
 
 #### EIP Support
 
-It is possible to individually activate EIP support in the VM. In order to do so, pass an array to the `eips` field of the VMs options, such as `new VM({eips: ['EIP2537']})`.
+It is possible to individually activate EIP support in the VM. In order to do so, pass an array to the `eips` field of the VMs options, such as `new VM({ eips: [ 2537 ]})`.
 
 Currently supported EIPs are:
 

--- a/packages/vm/lib/evm/precompiles/0a-bls12-g1add.ts
+++ b/packages/vm/lib/evm/precompiles/0a-bls12-g1add.ts
@@ -13,7 +13,7 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
   let inputData = opts.data
 
   // note: the gas used is constant; even if the input is incorrect.
-  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G1AddGas', 'EIP2537'))
+  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G1AddGas', 2537))
 
   if (opts.gasLimit.lt(gasUsed)) {
     return OOGResult(opts.gasLimit)

--- a/packages/vm/lib/evm/precompiles/0b-bls12-g1mul.ts
+++ b/packages/vm/lib/evm/precompiles/0b-bls12-g1mul.ts
@@ -17,7 +17,7 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
   let inputData = opts.data
 
   // note: the gas used is constant; even if the input is incorrect.
-  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G1MulGas', 'EIP2537'))
+  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G1MulGas', 2537))
 
   if (opts.gasLimit.lt(gasUsed)) {
     return OOGResult(opts.gasLimit)

--- a/packages/vm/lib/evm/precompiles/0c-bls12-g1multiexp.ts
+++ b/packages/vm/lib/evm/precompiles/0c-bls12-g1multiexp.ts
@@ -22,12 +22,8 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
 
   const numPairs = Math.floor(inputData.length / 160)
 
-  let gasUsedPerPair = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G1MulGas', 'EIP2537'))
-  let gasDiscountArray = opts._common.paramByEIP(
-    'gasPrices',
-    'Bls12381MultiExpGasDiscount',
-    'EIP2537',
-  )
+  let gasUsedPerPair = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G1MulGas', 2537))
+  let gasDiscountArray = opts._common.paramByEIP('gasPrices', 'Bls12381MultiExpGasDiscount', 2537)
   let gasDiscountMax = gasDiscountArray[gasDiscountArray.length - 1][1]
   let gasDiscountMultiplier
 

--- a/packages/vm/lib/evm/precompiles/0d-bls12-g2add.ts
+++ b/packages/vm/lib/evm/precompiles/0d-bls12-g2add.ts
@@ -13,7 +13,7 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
   let inputData = opts.data
 
   // note: the gas used is constant; even if the input is incorrect.
-  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G2AddGas', 'EIP2537'))
+  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G2AddGas', 2537))
 
   if (opts.gasLimit.lt(gasUsed)) {
     return OOGResult(opts.gasLimit)

--- a/packages/vm/lib/evm/precompiles/0e-bls12-g2mul.ts
+++ b/packages/vm/lib/evm/precompiles/0e-bls12-g2mul.ts
@@ -17,7 +17,7 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
   let inputData = opts.data
 
   // note: the gas used is constant; even if the input is incorrect.
-  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G2MulGas', 'EIP2537'))
+  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G2MulGas', 2537))
 
   if (opts.gasLimit.lt(gasUsed)) {
     return OOGResult(opts.gasLimit)

--- a/packages/vm/lib/evm/precompiles/0f-bls12-g2multiexp.ts
+++ b/packages/vm/lib/evm/precompiles/0f-bls12-g2multiexp.ts
@@ -22,12 +22,8 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
 
   const numPairs = Math.floor(inputData.length / 288)
 
-  let gasUsedPerPair = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G2MulGas', 'EIP2537'))
-  let gasDiscountArray = opts._common.paramByEIP(
-    'gasPrices',
-    'Bls12381MultiExpGasDiscount',
-    'EIP2537',
-  )
+  let gasUsedPerPair = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381G2MulGas', 2537))
+  let gasDiscountArray = opts._common.paramByEIP('gasPrices', 'Bls12381MultiExpGasDiscount', 2537)
   let gasDiscountMax = gasDiscountArray[gasDiscountArray.length - 1][1]
   let gasDiscountMultiplier
 

--- a/packages/vm/lib/evm/precompiles/10-bls12-pairing.ts
+++ b/packages/vm/lib/evm/precompiles/10-bls12-pairing.ts
@@ -15,14 +15,14 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
 
   let inputData = opts.data
 
-  let baseGas = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381PairingBaseGas', 'EIP2537'))
+  let baseGas = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381PairingBaseGas', 2537))
 
   if (inputData.length == 0) {
     return VmErrorResult(new VmError(ERROR.BLS_12_381_INPUT_EMPTY), opts.gasLimit)
   }
 
   let gasUsedPerPair = new BN(
-    opts._common.paramByEIP('gasPrices', 'Bls12381PairingPerPairGas', 'EIP2537'),
+    opts._common.paramByEIP('gasPrices', 'Bls12381PairingPerPairGas', 2537),
   )
   let gasUsed = baseGas.iadd(gasUsedPerPair.imul(new BN(Math.floor(inputData.length / 384))))
 

--- a/packages/vm/lib/evm/precompiles/11-bls12-map-fp-to-g1.ts
+++ b/packages/vm/lib/evm/precompiles/11-bls12-map-fp-to-g1.ts
@@ -13,7 +13,7 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
   let inputData = opts.data
 
   // note: the gas used is constant; even if the input is incorrect.
-  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381MapG1Gas', 'EIP2537'))
+  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381MapG1Gas', 2537))
 
   if (opts.gasLimit.lt(gasUsed)) {
     return OOGResult(opts.gasLimit)

--- a/packages/vm/lib/evm/precompiles/12-bls12-map-fp2-to-g2.ts
+++ b/packages/vm/lib/evm/precompiles/12-bls12-map-fp2-to-g2.ts
@@ -13,7 +13,7 @@ export default async function (opts: PrecompileInput): Promise<ExecResult> {
   let inputData = opts.data
 
   // note: the gas used is constant; even if the input is incorrect.
-  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381MapG2Gas', 'EIP2537'))
+  let gasUsed = new BN(opts._common.paramByEIP('gasPrices', 'Bls12381MapG2Gas', 2537))
 
   if (opts.gasLimit.lt(gasUsed)) {
     return OOGResult(opts.gasLimit)

--- a/packages/vm/lib/evm/precompiles/index.ts
+++ b/packages/vm/lib/evm/precompiles/index.ts
@@ -18,7 +18,6 @@ import { default as p10 } from './10-bls12-pairing'
 import { default as p11 } from './11-bls12-map-fp-to-g1'
 import { default as p12 } from './12-bls12-map-fp2-to-g2'
 import Common from '@ethereumjs/common'
-import VM from '../..'
 
 interface Precompiles {
   [key: string]: PrecompileFunc
@@ -28,14 +27,23 @@ interface PrecompileAvailability {
   [key: string]: PrecompileAvailabilityCheckType
 }
 
+type PrecompileAvailabilityCheckType =
+  | PrecompileAvailabilityCheckTypeHardfork
+  | PrecompileAvailabilityCheckTypeEIP
+
 enum PrecompileAvailabilityCheck {
   EIP,
   Hardfork,
 }
 
-interface PrecompileAvailabilityCheckType {
-  type: PrecompileAvailabilityCheck
+interface PrecompileAvailabilityCheckTypeHardfork {
+  type: PrecompileAvailabilityCheck.Hardfork
   param: string
+}
+
+interface PrecompileAvailabilityCheckTypeEIP {
+  type: PrecompileAvailabilityCheck.EIP
+  param: number
 }
 
 const ripemdPrecompileAddress = '0000000000000000000000000000000000000003'
@@ -96,39 +104,39 @@ const precompileAvailability: PrecompileAvailability = {
   },
   '000000000000000000000000000000000000000a': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '000000000000000000000000000000000000000b': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '000000000000000000000000000000000000000c': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '000000000000000000000000000000000000000d': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '000000000000000000000000000000000000000f': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '000000000000000000000000000000000000000e': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '0000000000000000000000000000000000000010': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '0000000000000000000000000000000000000011': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
   '0000000000000000000000000000000000000012': {
     type: PrecompileAvailabilityCheck.EIP,
-    param: 'EIP2537',
+    param: 2537,
   },
 }
 

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -36,11 +36,11 @@ export interface VMOpts {
    *
    * - `chain`: all chains supported by `Common` or a custom chain
    * - `hardfork`: `mainnet` hardforks up to the `MuirGlacier` hardfork
-   * - `eips`: `EIP2537` (usage e.g. `eips: ['EIP2537',]`)
+   * - `eips`: `2537` (usage e.g. `eips: [ 2537, ]`)
    *
    * ### Supported EIPs
    *
-   * - [EIP2537](https://eips.ethereum.org/EIPS/eip-2537) (`experimental`) - BLS12-381 precompiles
+   * - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) (`experimental`) - BLS12-381 precompiles
    *
    * *Annotations:*
    *
@@ -135,7 +135,7 @@ export default class VM extends AsyncEventEmitter {
 
     if (opts.common) {
       //EIPs
-      const supportedEIPs = ['EIP2537']
+      const supportedEIPs = [2537]
       for (const eip of opts.common.eips()) {
         if (!supportedEIPs.includes(eip)) {
           throw new Error(`${eip} is not supported by the VM`)
@@ -181,9 +181,9 @@ export default class VM extends AsyncEventEmitter {
     this.allowUnlimitedContractSize =
       opts.allowUnlimitedContractSize === undefined ? false : opts.allowUnlimitedContractSize
 
-    if (this._common.eips().includes('EIP2537')) {
+    if (this._common.eips().includes(2537)) {
       if (IS_BROWSER) {
-        throw new Error('EIP 2537 is currently not supported in browsers')
+        throw new Error('EIP-2537 is currently not supported in browsers')
       } else {
         this._mcl = mcl
       }
@@ -219,9 +219,9 @@ export default class VM extends AsyncEventEmitter {
       await this.stateManager.commit()
     }
 
-    if (this._common.eips().includes('EIP2537')) {
+    if (this._common.eips().includes(2537)) {
       if (IS_BROWSER) {
-        throw new Error('EIP 2537 is currently not supported in browsers')
+        throw new Error('EIP-2537 is currently not supported in browsers')
       } else {
         let mcl = this._mcl
         await mclInitPromise // ensure that mcl is initialized.

--- a/packages/vm/tests/BlockchainTestsRunner.js
+++ b/packages/vm/tests/BlockchainTestsRunner.js
@@ -30,7 +30,7 @@ module.exports = async function runBlockchainTest(options, testData, t) {
   if (options.forkConfigVM == 'berlin') {
     // currently, the BLS tests run on the Berlin network, but our VM does not activate EIP2537 
     // if you run the Berlin HF
-    eips = ['EIP2537']
+    eips = [2537]
   }
 
   let common

--- a/packages/vm/tests/GeneralStateTestsRunner.js
+++ b/packages/vm/tests/GeneralStateTestsRunner.js
@@ -55,7 +55,7 @@ async function runTestCase(options, testData, t) {
   if (options.forkConfigVM == 'berlin') {
     // currently, the BLS tests run on the Berlin network, but our VM does not activate EIP2537 
     // if you run the Berlin HF
-    eips = ['EIP2537'] 
+    eips = [2537] 
   }
 
   const common = new Common({ chain: 'mainnet', hardfork: options.forkConfigVM, eips })

--- a/packages/vm/tests/api/EIPs/EIP2537-BLS-tests.js
+++ b/packages/vm/tests/api/EIPs/EIP2537-BLS-tests.js
@@ -10,72 +10,70 @@ const precompileAddressEnd = 0x12
 const precompiles = []
 
 for (let address = precompileAddressStart; address <= precompileAddressEnd; address++) {
-    precompiles.push(address.toString(16).padStart(40, '0'))
+  precompiles.push(address.toString(16).padStart(40, '0'))
 }
 
-const dir = "./tests/api/berlin/"
+const dir = './tests/api/berlin/'
 
-tape('EIP2537 BLS tests', (t) => {
-    t.test('BLS precompiles should not be available if EIP not activated', async (st) => {
-        if (isRunningInKarma()) {
-            st.skip('BLS does not work in karma')
-            return st.end()
-        }
-        const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
-        const vm = new VM({ common: common })
+tape('EIP-2537 BLS tests', (t) => {
+  t.test('BLS precompiles should not be available if EIP not activated', async (st) => {
+    if (isRunningInKarma()) {
+      st.skip('BLS does not work in karma')
+      return st.end()
+    }
+    const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+    const vm = new VM({ common: common })
 
-        for (let address of precompiles) {
-            const result = await vm.runCall({
-                caller: Buffer.from('0000000000000000000000000000000000000000', 'hex'),
-                gasLimit: new BN(0xffffffffff),
-                to: Buffer.from(address, 'hex'),
-                value: new BN(0),
-                data: Buffer.alloc(0)
-            })
-          
-            if (!result.execResult.gasUsed.eq(new BN(0))) {
-                st.fail("BLS precompiles should not use any gas if EIP not activated")
-            }
+    for (let address of precompiles) {
+      const result = await vm.runCall({
+        caller: Buffer.from('0000000000000000000000000000000000000000', 'hex'),
+        gasLimit: new BN(0xffffffffff),
+        to: Buffer.from(address, 'hex'),
+        value: new BN(0),
+        data: Buffer.alloc(0),
+      })
 
-            if (result.execResult.exceptionError) {
-                st.fail('BLS precompiles should not throw if EIP not activated')
-            }
-        }
+      if (!result.execResult.gasUsed.eq(new BN(0))) {
+        st.fail('BLS precompiles should not use any gas if EIP not activated')
+      }
 
-        st.pass("BLS precompiles unreachable if EIP not activated")
-        st.end()
-    })
+      if (result.execResult.exceptionError) {
+        st.fail('BLS precompiles should not throw if EIP not activated')
+      }
+    }
 
-    t.test('BLS precompiles should throw on empty inputs', async (st) => {
-        if (isRunningInKarma()) {
-            st.skip('BLS does not work in karma')
-            return st.end()
-        }
-        const common = new Common({ chain: 'mainnet', hardfork: 'byzantium', eips: ['EIP2537'] })
-        const vm = new VM({ common: common })
-        const gasLimit = new BN(0xffffffffff)
-
-        for (let address of precompiles) {
-            const result = await vm.runCall({
-                caller: Buffer.from('0000000000000000000000000000000000000000', 'hex'),
-                gasLimit: gasLimit,
-                to: Buffer.from(address, 'hex'),
-                value: new BN(0),
-                data: Buffer.alloc(0)
-            })
-          
-            if (!result.execResult.gasUsed.eq(gasLimit)) {
-              st.fail("BLS precompiles should use all gas on empty inputs")
-            }
-
-            if (!result.execResult.exceptionError) {
-                st.fail('BLS precompiles should throw on empty inputs')
-            }
-        }
-
-        st.pass("BLS precompiles throw correctly on empty inputs")
-        st.end()
-    })
-
+    st.pass('BLS precompiles unreachable if EIP not activated')
+    st.end()
   })
 
+  t.test('BLS precompiles should throw on empty inputs', async (st) => {
+    if (isRunningInKarma()) {
+      st.skip('BLS does not work in karma')
+      return st.end()
+    }
+    const common = new Common({ chain: 'mainnet', hardfork: 'byzantium', eips: [2537] })
+    const vm = new VM({ common: common })
+    const gasLimit = new BN(0xffffffffff)
+
+    for (let address of precompiles) {
+      const result = await vm.runCall({
+        caller: Buffer.from('0000000000000000000000000000000000000000', 'hex'),
+        gasLimit: gasLimit,
+        to: Buffer.from(address, 'hex'),
+        value: new BN(0),
+        data: Buffer.alloc(0),
+      })
+
+      if (!result.execResult.gasUsed.eq(gasLimit)) {
+        st.fail('BLS precompiles should use all gas on empty inputs')
+      }
+
+      if (!result.execResult.exceptionError) {
+        st.fail('BLS precompiles should throw on empty inputs')
+      }
+    }
+
+    st.pass('BLS precompiles throw correctly on empty inputs')
+    st.end()
+  })
+})

--- a/packages/vm/tests/api/index.js
+++ b/packages/vm/tests/api/index.js
@@ -71,7 +71,7 @@ tape('VM with default blockchain', (t) => {
       st.skip('BLS does not work in karma')
       return st.end()
     }
-    const common = new Common({ chain: 'mainnet', eips: [ 'EIP2537', ] })
+    const common = new Common({ chain: 'mainnet', eips: [ 2537, ] })
     st.doesNotThrow(() => { new VM({ common }) })
     st.end()
   })


### PR DESCRIPTION
This PR updates the new `eips` option in Common and VM to use type `number` instead of `string`.

The primary reasons discussed were for dev ex brevity (less bulky), and better long term performance (iterating and comparing numbers should be faster than strings).