### PR TITLE
VM: Strip zeros when putting contract storage in StateManager

### DIFF
--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -276,7 +276,7 @@ export default class DefaultStateManager implements StateManager {
    * corresponding to `address` at the provided `key`.
    * @param address -  Address to set a storage value for
    * @param key - Key to set the value at. Must be 32 bytes long.
-   * @param value - Value to set at `key` for account corresponding to `address`. Cannot be more than 32 bytes. Will be left-padded with zeros if less than 32 bytes. If it is a empty or filled with zeros, delete the value.
+   * @param value - Value to set at `key` for account corresponding to `address`. Cannot be more than 32 bytes. Leading zeros are stripped. If it is a empty or filled with zeros, deletes the value.
    */
   async putContractStorage(address: Buffer, key: Buffer, value: Buffer): Promise<void> {
     if (key.length !== 32) {
@@ -421,7 +421,7 @@ export default class DefaultStateManager implements StateManager {
   }
 
   /**
-   * Dumps the the RLP-encoded storage values for an `account` specified by `address`.
+   * Dumps the RLP-encoded storage values for an `account` specified by `address`.
    * @param address - The address of the `account` to return storage for
    * @returns {Promise<StorageDump>} - The state of the account as an `Object` map.
    * Keys are are the storage keys, values are the storage values as strings.

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -284,7 +284,7 @@ export default class DefaultStateManager implements StateManager {
     }
 
     if (value.length > 32) {
-      throw new Error('Storage key cannot be longer than 32 bytes')
+      throw new Error('Storage value cannot be longer than 32 bytes')
     }
 
     value = unpadBuffer(value)

--- a/packages/vm/tests/api/state/stateManager.spec.ts
+++ b/packages/vm/tests/api/state/stateManager.spec.ts
@@ -428,22 +428,23 @@ tape('StateManager - Contract storage', (tester) => {
     t.end()
   })
 
-  it('should strip storage values lower than 32 bytes', async (t) => {
+  it('should strip zeros of storage values', async (t) => {
     const stateManager = new DefaultStateManager()
     const address = zeros(20)
-    const key0 = zeros(32)
-    const value0 = Buffer.from('aa'.repeat(31), 'hex') // put a value of 31-bytes length
-    const expect0 = unpadBuffer(value0)
-    const key1 = Buffer.concat([zeros(31), Buffer.from('01', 'hex')])
-    const value1 = Buffer.from('aa'.repeat(1), 'hex') // put a vlaue of 1-byte length
-    const expect1 = unpadBuffer(value1)
 
+    const key0 = zeros(32)
+    const value0 = Buffer.from('00' + 'aa'.repeat(30), 'hex') // put a value of 31-bytes length with a leading zero byte
+    const expect0 = unpadBuffer(value0)
     await stateManager.putContractStorage(address, key0, value0)
     const slot0 = await stateManager.getContractStorage(address, key0)
     t.ok(slot0.equals(expect0), 'value of 31 bytes padded correctly')
 
+    const key1 = Buffer.concat([zeros(31), Buffer.from('01', 'hex')])
+    const value1 = Buffer.from('0000' + 'aa'.repeat(1), 'hex') // put a value of 1-byte length with two leading zero bytes
+    const expect1 = unpadBuffer(value1)
     await stateManager.putContractStorage(address, key1, value1)
     const slot1 = await stateManager.getContractStorage(address, key1)
+
     t.ok(slot1.equals(expect1), 'value of 1 byte padded correctly')
     t.end()
   })

--- a/packages/vm/tests/api/state/stateManager.spec.ts
+++ b/packages/vm/tests/api/state/stateManager.spec.ts
@@ -413,29 +413,29 @@ tape('StateManager - Contract code', (tester) => {
 tape('StateManager - Contract storage', (tester) => {
   const it = tester.test
 
-  it('should throw on storage values larger than 32 bytes', async(t) => {
+  it('should throw on storage values larger than 32 bytes', async (t) => {
     t.plan(1)
     const stateManager = new DefaultStateManager()
     const address = zeros(20)
     const key = zeros(32)
-    const value = Buffer.from(("aa").repeat(33), 'hex')
+    const value = Buffer.from('aa'.repeat(33), 'hex')
     try {
       await stateManager.putContractStorage(address, key, value)
-      t.fail("did not throw")
+      t.fail('did not throw')
     } catch (e) {
-      t.pass("threw on trying to set storage values larger than 32 bytes")
+      t.pass('threw on trying to set storage values larger than 32 bytes')
     }
     t.end()
   })
 
-  it('should strip storage values lower than 32 bytes', async(t) => {
+  it('should strip storage values lower than 32 bytes', async (t) => {
     const stateManager = new DefaultStateManager()
     const address = zeros(20)
     const key0 = zeros(32)
-    const value0 = Buffer.from(("aa").repeat(31), 'hex') // put a value of 31-bytes length
+    const value0 = Buffer.from('aa'.repeat(31), 'hex') // put a value of 31-bytes length
     const expect0 = unpadBuffer(value0)
     const key1 = Buffer.concat([zeros(31), Buffer.from('01', 'hex')])
-    const value1 = Buffer.from(("aa").repeat(1), 'hex') // put a vlaue of 1-byte length
+    const value1 = Buffer.from('aa'.repeat(1), 'hex') // put a vlaue of 1-byte length
     const expect1 = unpadBuffer(value1)
 
     await stateManager.putContractStorage(address, key0, value0)
@@ -448,12 +448,12 @@ tape('StateManager - Contract storage', (tester) => {
     t.end()
   })
 
-  it ('should delete storage values which only consist of zero bytes', async(t) => {
+  it('should delete storage values which only consist of zero bytes', async (t) => {
     const address = zeros(20)
     const key = zeros(32)
     const startValue = Buffer.from('01', 'hex')
 
-    const zeroLengths = [0, 1, 31, 32]  // checks for arbitrary-length zeros
+    const zeroLengths = [0, 1, 31, 32] // checks for arbitrary-length zeros
     t.plan(zeroLengths.length)
 
     for (let length of zeroLengths) {
@@ -463,18 +463,18 @@ tape('StateManager - Contract storage', (tester) => {
       const currentValue = await stateManager.getContractStorage(address, key)
       if (!currentValue.equals(startValue)) {
         // sanity check
-        t.fail("contract value not set correctly")
+        t.fail('contract value not set correctly')
       } else {
-        // delete the value 
+        // delete the value
         await stateManager.putContractStorage(address, key, value)
         const deleted = await stateManager.getContractStorage(address, key)
-        t.ok(deleted.equals(zeros(0)), "the storage key should be deleted")
+        t.ok(deleted.equals(zeros(0)), 'the storage key should be deleted')
       }
     }
     t.end()
   })
 
-  it('should not strip trailing zeros', async(t) => {
+  it('should not strip trailing zeros', async (t) => {
     const address = zeros(20)
     const key = zeros(32)
     const value = Buffer.from('0000aabb00', 'hex')


### PR DESCRIPTION
Closes #875 

Had a bit of a wrong understanding here, storage slot values should be stripped of leading zeros, which is now enforced in `putContractStorage`. Since putting >32 bytes storage values is not possible in EVM, this is now also disallowed. If we strip leading zeros this means that any zero-byte will immediately be detected as "delete value", both in StateManager but also in MPT, which is nice.