### PR TITLE
ci: Updated slow test files

### DIFF
--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -19,19 +19,15 @@ jobs:
           node-version: 12.x
       - uses: actions/checkout@v1
 
-      # This is important, so the CI runs with a fresh combination of packages
+      # This is specific to Nightly test 1/2.
+      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
+      # So in this step, we remove the lockfiles
       - run: rm package-lock.json packages/*/package-lock.json
         working-directory: ${{github.workspace}}
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: VM-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
-
+      # This is specific to Nightly test 2/2.
+      # Here, we generate new lockfiles
       - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ${{github.workspace}}
 
       - run: npm run build
@@ -48,19 +44,15 @@ jobs:
           node-version: 12.x
       - uses: actions/checkout@v1
 
-      # This is important, so the CI runs with a fresh combination of packages
+      # This is specific to Nightly test 1/2.
+      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
+      # So in this step, we remove the lockfiles
       - run: rm package-lock.json packages/*/package-lock.json
         working-directory: ${{github.workspace}}
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: VM-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
-
+      # This is specific to Nightly test 2/2.
+      # Here, we generate new lockfiles
       - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ${{github.workspace}}
 
       - run: npm run build
@@ -76,20 +68,26 @@ jobs:
           node-version: 12.x
       - uses: actions/checkout@v1
 
-      # This is important, so the CI runs with a fresh combination of packages
+      # This is specific to Nightly test 1/2.
+      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
+      # So in this step, we remove the lockfiles
       - run: rm package-lock.json packages/*/package-lock.json
         working-directory: ${{github.workspace}}
 
-      - name: Dependency cache
+      # This is specific to Nightly test 2/2.
+      # Here, we generate new lockfiles
+      - run: npm install
+        working-directory: ${{github.workspace}}
+
+      # This is specific to Nightly test 3/2.
+      # In the case lockfiles a.re not so fresh, use information from cache
+      - name: Dependency cache.
+      # We need this to save cache afterwards, so other jobs can benefit from it.
         uses: actions/cache@v2
         id: cache
         with:
           key: VM-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           path: '**/node_modules'
-
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
 
       - run: npm run build
         working-directory: ${{github.workspace}}
@@ -105,19 +103,15 @@ jobs:
           node-version: 12.x
       - uses: actions/checkout@v1
       
-      # This is important, so the CI runs with a fresh combination of packages
+      # This is specific to Nightly test 1/2.
+      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
+      # So in this step, we remove the lockfiles
       - run: rm package-lock.json packages/*/package-lock.json
         working-directory: ${{github.workspace}}
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: VM-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
-
+      # This is specific to Nightly test 2/2.
+      # Here, we generate new lockfiles
       - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
         working-directory: ${{github.workspace}}
 
       - run: npm run build


### PR DESCRIPTION
Ideally, the cache should go after `npm install`, so it would generate/use cache based on hashes of the updated `package-lock.json` files.

- Decided to remove cache read/write altogether, so we guarantee no cache for empty keys are being created, or that it is using wrong cache keys

I'm making an `package-lock.json` audit, which I'll document and make use recommendations.