### PR TITLE
vm tests: fix state tests count

### DIFF
--- a/packages/vm/tests/config.ts
+++ b/packages/vm/tests/config.ts
@@ -361,7 +361,7 @@ const expectedTestsFull: any = {
     TangerineWhistle: 1097,
     SpuriousDragon: 1222,
     Byzantium: 4754,
-    Constantinople: 10759,
+    Constantinople: 10530,
     Petersburg: 10525,
     Istanbul: 10759,
     MuirGlacier: 10759,
@@ -370,7 +370,7 @@ const expectedTestsFull: any = {
     EIP158ToByzantiumAt5: 0,
     FrontierToHomesteadAt5: 0,
     HomesteadToDaoAt5: 0,
-    HomesteadToEIP150At5: 3,
+    HomesteadToEIP150At5: 0,
   },
 }
 /**

--- a/packages/vm/tests/tester.ts
+++ b/packages/vm/tests/tester.ts
@@ -192,7 +192,7 @@ async function runTests() {
         }
       }
 
-      if (expectedTests) {
+      if (expectedTests != undefined) {
         t.ok(
           (t as any).assertCount >= expectedTests,
           'expected ' + expectedTests + ' checks, got ' + (t as any).assertCount,


### PR DESCRIPTION
This PR (should) fix the nightly CI runs.

This PR fixes the amount of state tests which is based upon [this nightly run](https://github.com/ethereumjs/ethereumjs-vm/actions/runs/269725216). It also explicitly does a test in case we pass "0" tests to expected tests (I think this is more clean than not explicitly testing here).