### PR TITLE
Benchmark action improvements (disables comment-always)

### DIFF
--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -145,14 +145,16 @@ jobs:
           tool: 'benchmarkjs'
           # Where the output from the benchmark tool is stored
           output-file-path: ${{ env.cwd }}/output.txt
+          # Set alert threshold (default: 200%)
+          alert-threshold: '150%'
           # Enable alert commit comment
           comment-on-alert: true
-          # Always leave a commit comment comparing the current benchmark with previous
-          comment-always: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy to GitHub pages branch automatically (if on master)
           auto-push: 'true'
+          # Only keep and display the last 30 commits worth of benchmark data
+          max-items-in-chart: 30
 
       # Re-apply git stash to prepare for saving back to cache.
       # Avoids exit code 1 by checking if there are changes to be stashed first

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -145,9 +145,7 @@ jobs:
           tool: 'benchmarkjs'
           # Where the output from the benchmark tool is stored
           output-file-path: ${{ env.cwd }}/output.txt
-          # Set alert threshold (default: 200%)
-          alert-threshold: '150%'
-          # Enable alert commit comment
+          # Enable alert commit comment (default alert threshold: 200%)
           comment-on-alert: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -150,9 +150,7 @@ jobs:
           tool: 'benchmarkjs'
           # Where the output from the benchmark tool is stored
           output-file-path: ${{ env.cwd }}/output.txt
-          # Set alert threshold (default: 200%)
-          alert-threshold: '150%'
-          # Enable alert commit comment
+          # Enable alert commit comment (default alert threshold: 200%)
           comment-on-alert: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -150,10 +150,10 @@ jobs:
           tool: 'benchmarkjs'
           # Where the output from the benchmark tool is stored
           output-file-path: ${{ env.cwd }}/output.txt
+          # Set alert threshold (default: 200%)
+          alert-threshold: '150%'
           # Enable alert commit comment
           comment-on-alert: true
-          # Always leave a commit comment comparing the current benchmark with previous
-          comment-always: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy to GitHub pages branch automatically (if on master)

--- a/packages/vm/developer.md
+++ b/packages/vm/developer.md
@@ -147,6 +147,8 @@ NODE_OPTIONS="--max-old-space-size=4096" clinic flame -- node ./tests/tester.js 
 
 This helps us see how the VM performs when running mainnet blocks.
 
+View the historical benchmark data for the master branch on the [github page](http://ethereumjs.github.io/ethereumjs-vm/dev/bench/).
+
 We want to use the compiled JS so `ts-node` does not show up in the profile. So run:
 
 `npm run build:benchmarks`


### PR DESCRIPTION
This PR:
  * Disables `comment-always` to reduce verbosity of comments on commits with normal benchmark results.
    * The gh action will make an alert comment on the commit if any of the runs exceeds the default 200% threshold as compared to the last run on master.
  * Adds documentation link to benchmark [github page](http://ethereumjs.github.io/ethereumjs-vm/dev/bench/).
  * Stores max 30 commits of historical benchmark data for master branch.