### PR TITLE
CHANGELOG Completion for VM v5 Release

### DIFF
--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -59,7 +59,7 @@ factory methods to create new objects.
 
 **Breaking**: While the main constructors can still be called, signatures changed significantly and
 your old `new Block(...)`, `new BlockHeader(...)` instantiations won't work any more and needs to be
-adopted.
+updated.
 
 **BlockHeader Class**
 
@@ -141,19 +141,42 @@ try {
 }
 ```
 
+### New Default Hardfork
+
+**Breaking:** The default HF on the library has been updated from `petersburg` to `instanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
+see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
 ### Other Changes
+
+**Features**
+
+- Added `Block.genesis()` and `BlockHeader.genesis()` aliases to create
+  a genesis block or header,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Added `DAO` hardfork support (check for `extraData` attribute if `DAO` HF is active),
+  PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
 
 **Changes and Refactoring**
 
 - Added Node `10`, `12` support, dropped Node `7` support,
   PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Passing in a blockchain is now optional on `Block.validate()`,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: `Block.validateTransactions(stringError: true)` now returns a `string[]`,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: Decoupling of the `Block.serialize()` and `Block.raw()` methods,
+  `Block.serialize()` now always returns the RLP-encoded block (signature change!),
+  `Block.raw()` always returns the pure `Buffer` array,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: `Block.toJSON()` now always returns the labeled `JSON` representation,
+  removal of the `labeled` function parameter,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Updated `merkle-patricia-tree` dependency to `v4`,
+  PR [#787](https://github.com/ethereumjs/ethereumjs-vm/pull/787)
+- Updated `ethereumjs-util` dependency to `v7`,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
 - Removal of the `async` dependency,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-- Update `ethereumjs-common` dependency from `v1.1.0` to `v1.5.0`,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-- Update `ethereumjs-tx` dependency from `v1.2.2` to `v2.1.1`,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-- Update `ethereumjs-util` dependency from `v5.0.0` to `v6.1.0`,
   PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
 
 **CI and Testing**

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -75,6 +75,10 @@ The deprecated `validate` option has been removed, please use `valdiateBlock` an
 - Fixed blockchain hanging forever in case code throws between a semaphore `lock`/`unlock`,
   Issue [#877](https://github.com/ethereumjs/ethereumjs-vm/issues/877)
 
+## [4.0.4] - 2020-07-27
+
+This release replaces the tiled (`~`) dependency from `ethereumjs-util` for a caret (`^`) one, meaning that any update to `ethereumjs-util` v6 will also be available for this library.
+
 ## [4.0.3] - 2019-12-19
 
 Supports `MuirGlacier` by updating `ethereumjs-block` to

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -61,6 +61,20 @@ The deprecated `validate` option has been removed, please use `valdiateBlock` an
 
 [5.0.0]: https://github.com/ethereumjs/ethereumjs-vm/compare/%40ethereumjs%2Fblockchain%404.0.2...%40ethereumjs%2Fblockchain%405.0.0
 
+### Other Changes
+
+**Changes and Refactoring**
+
+- Removed `async` dependency,
+  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+
+**Bug Fixes**
+
+- Fixed blockchain hanging forever in case code throws between a semaphore `lock`/`unlock`,
+  Issue [#877](https://github.com/ethereumjs/ethereumjs-vm/issues/877)
+
 ## [4.0.3] - 2019-12-19
 
 Supports `MuirGlacier` by updating `ethereumjs-block` to

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -77,7 +77,7 @@ The deprecated `validate` option has been removed, please use `valdiateBlock` an
 
 ## 4.0.4 - 2020-07-27
 
-This release replaces the tiled (`~`) dependency from `ethereumjs-util` for a caret (`^`) one, meaning that any update to `ethereumjs-util` v6 will also be available for this library.
+This release replaces the tilde (`~`) dependency from `ethereumjs-util` for a caret (`^`) one, meaning that any update to `ethereumjs-util` v6 will also be available for this library.
 
 ## [4.0.3] - 2019-12-19
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -75,7 +75,7 @@ The deprecated `validate` option has been removed, please use `valdiateBlock` an
 - Fixed blockchain hanging forever in case code throws between a semaphore `lock`/`unlock`,
   Issue [#877](https://github.com/ethereumjs/ethereumjs-vm/issues/877)
 
-## [4.0.4] - 2020-07-27
+## 4.0.4 - 2020-07-27
 
 This release replaces the tiled (`~`) dependency from `ethereumjs-util` for a caret (`^`) one, meaning that any update to `ethereumjs-util` v6 will also be available for this library.
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -65,6 +65,8 @@ The deprecated `validate` option has been removed, please use `valdiateBlock` an
 
 **Changes and Refactoring**
 
+- Use `@ethereumjs/block` `v3.0.0` block library version,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
 - Removed `async` dependency,
   PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
 - Updated `ethereumjs-util` to v7,

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -27,6 +27,12 @@ A new function `setHardforkByBlockNumber()` has been added, PR [#863](https://gi
 
 The default hardfork has been added as an accessible readonly property `DEFAULT_HARDFORK`, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863). Current default hardfork is set to `istanbul`, PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
 
+## [1.5.2] - 2020-07-26
+
+This is a maintenance release.
+
+- Updates Goerli chain ID, PR [#792](https://github.com/ethereumjs/ethereumjs-vm/pull/792).
+
 ## [1.5.1] - 2020-05-04
 
 This is a maintenance release.

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,9 +8,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [2.0.0] - [UNRELEASED]
 
+### New Package Name
+
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a new scoped package name format. In this case the library is renamed as follows:
+
+- `ethereumjs-common` -> `@ethereumjs/common`
+
+Please update your library references accordingly or install with:
+
+```shell
+npm i @ethereumjs/common
+```
+
 ### New constructor
 
-The constructor has been changed to accept a dict, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863)
+**Breaking**: The constructor has been changed to require an options dict to be passed, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863)
 
 Example:
 
@@ -19,15 +31,72 @@ import Common from '@ethereumjs/common'
 const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
 ```
 
-### Hardfork by block number
+### EIP Support
 
-A new function `setHardforkByBlockNumber()` has been added, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863)
+EIPs are now native citizens within the `Common` library, see PRs [#856](https://github.com/ethereumjs/ethereumjs-vm/pull/856), [#869](https://github.com/ethereumjs/ethereumjs-vm/pull/869) and [#872](https://github.com/ethereumjs/ethereumjs-vm/pull/872). Supported EIPs have their own configuration file like the [eips/2537.json](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/eips/2537.json) file for the BLS precompile EIP and EIP settings can be activated by passing supported EIP numbers to the constructor:
 
-### Default hardfork
+```typescript
+const c = new Common({ chain: 'mainnet', eips: [2537] })
+```
 
-The default hardfork has been added as an accessible readonly property `DEFAULT_HARDFORK`, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863). Current default hardfork is set to `istanbul`, PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+The following EIPs are initially supported within this release:
 
-## [1.5.2] - 2020-07-26
+- [EIP-2537](https://eips.ethereum.org/EIPS/eip-2315) BLS Precompiles
+- [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) EVM Subroutines (PR [#876](https://github.com/ethereumjs/ethereumjs-vm/pull/876))
+
+EIPs provided are then activated and parameters requested with `Common.param()` being present in these EIPs take precedence over the setting from the latest hardfork.
+
+There are two new utility functions which dedicatedly return the hardfork respectively EIP values:
+
+- `Common.paramByHardfork()`
+- `Common.paramByEIP()`
+
+**Breaking**: It is now not possible any more to pass a dedicated HF setting to `Common.param()`. Please update your code to explicitly use `Common.paramByHardfork()` for requesting a parameter for a HF deviating from the HF currently set within your `Common` instance.
+
+For setting and requesting active EIPs there is `Common.setEIPs()` and `Common.eips()` added to the mix.
+
+Along there is a new EIP-based hardfork file format which allows to just reference EIPs (pointing to the EIP files which then contain the parameters) instead of containing parameters directly, see PR [#876](https://github.com/ethereumjs/ethereumjs-vm/pull/876). This is in preparation for an upcoming `Yolo v2` testnet integration.
+
+Side note: with this new structural setup it gets now possible for all EIPs still implicitly contained within the hardfork files to be extracted as an EIP parameter set within its own dedicated EIP file (which can then be activated via the `eip` parameter on initialization) without loosing on functionality. If you have a need there feel free to open a PR!
+
+### Gas Parameter Completeness for all Hardforks
+
+Remaining gas base fees which still resided in the VM have been moved over to `Common` along PR [#806](https://github.com/ethereumjs/ethereumjs-vm/pull/806).
+Gas fees for all hardforks up to `MuirGlacier` are now completely present within the `Common` library.
+
+### Eth/64 Forkhash Support
+
+There is a new `Common.forkHash()` method returning pre-calculated Forkhash values or alternatively use the internal `Common._calcForkHash()` implementation to calculate a forkhash on the fly.
+
+Forkhashes are used to uniquely identify a set of hardforks passed to be able to better differentiate between different dedicated chains. This is used for the `Eth/64` devp2p protocol update and specificed in [EIP-2124](https://eips.ethereum.org/EIPS/eip-2124) to help improve the devp2p networking stack.
+
+### New Block/Hardfork related Utility Functions
+
+The following block respectively hardfork related utility functions have been added along PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863) and PR [#805](https://github.com/ethereumjs/ethereumjs-vm/pull/805):
+
+- `setHardforkByBlockNumber()` - Sets the hardfork determined by the block number passed
+- `nextHardforkBlock()` - Returns the next HF block for a HF provided or set
+- `isNextHardforkBlock()` - Some convenience additional utility method, matching the existing `hardforkBlock()` / `isHardforkBlock()` method setup
+- `hardforkForForkHash()` - Returns the data available for a HF given a specific forkHash
+
+### Default Hardfork
+
+The default hardfork has been added as an accessible readonly property `DEFAULT_HARDFORK`, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863). This setting is used starting with the latest major releases of the monorepo libraries like the VM to keep the HF setting in sync across the different libraries.
+
+Current default hardfork is set to `istanbul`, PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+
+### Other Changes
+
+**Changes and Refactoring**
+
+- Removed old `consensus` and `finality` fields,
+  PR [#758](https://github.com/ethereumjs/ethereumjs-vm/pull/758)
+- Removed old `casper` and `sharding` fields,
+  PR [#762](https://github.com/ethereumjs/ethereumjs-vm/pull/762)
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+
+## 1.5.2 - 2020-07-26
 
 This is a maintenance release.
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -46,7 +46,7 @@ The following EIPs are initially supported within this release:
 
 EIPs provided are then activated and parameters requested with `Common.param()` being present in these EIPs take precedence over the setting from the latest hardfork.
 
-There are two new utility functions which dedicatedly return the hardfork respectively EIP values:
+There are two new utility functions which return hardfork and EIP values respectively:
 
 - `Common.paramByHardfork()`
 - `Common.paramByEIP()`
@@ -55,7 +55,7 @@ There are two new utility functions which dedicatedly return the hardfork respec
 
 For setting and requesting active EIPs there is `Common.setEIPs()` and `Common.eips()` added to the mix.
 
-Along there is a new EIP-based hardfork file format which allows to just reference EIPs (pointing to the EIP files which then contain the parameters) instead of containing parameters directly, see PR [#876](https://github.com/ethereumjs/ethereumjs-vm/pull/876). This is in preparation for an upcoming `Yolo v2` testnet integration.
+There is also a new EIP-based hardfork file format which delegates parameter definition to dedicated EIP files (see PR [#876](https://github.com/ethereumjs/ethereumjs-vm/pull/876)). This is in preparation for an upcoming `Yolo v2` testnet integration.
 
 Side note: with this new structural setup it gets now possible for all EIPs still implicitly contained within the hardfork files to be extracted as an EIP parameter set within its own dedicated EIP file (which can then be activated via the `eip` parameter on initialization) without loosing on functionality. If you have a need there feel free to open a PR!
 
@@ -72,7 +72,7 @@ Forkhashes are used to uniquely identify a set of hardforks passed to be able to
 
 ### New Block/Hardfork related Utility Functions
 
-The following block respectively hardfork related utility functions have been added along PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863) and PR [#805](https://github.com/ethereumjs/ethereumjs-vm/pull/805):
+The following block and hardfork related utility functions have been added with PRs [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863) and [#805](https://github.com/ethereumjs/ethereumjs-vm/pull/805) respectively:
 
 - `setHardforkByBlockNumber()` - Sets the hardfork determined by the block number passed
 - `nextHardforkBlock()` - Returns the next HF block for a HF provided or set

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -47,6 +47,11 @@ for a complete example.
 
 [1.0.0]: https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fethash%401.0.0
 
+### Other Changes
+
+- Removed `async` dependency,
+  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+
 ## [0.0.8] - 2020-05-27
 
 This is a maintenance release with dependency updates, CI improvements, and some code modernization.

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -49,6 +49,8 @@ for a complete example.
 
 ### Other Changes
 
+- Updated Block dependency to `@ethereumjs/block` `v3.0.0`,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
 - Removed `async` dependency,
   PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -22,7 +22,7 @@ npm i @ethereumjs/tx
 
 ### Major Refactoring - Breaking Changes
 
-This release is a major refactoring of the transaction library to simplify and strengthen its code base.
+This release is a major refactoring of the transaction library to simplify and strengthen its code base. Refactoring work has been done along PR [#812](https://github.com/ethereumjs/ethereumjs-vm/pull/812) and PR [#887](https://github.com/ethereumjs/ethereumjs-vm/pull/887).
 
 #### New Constructor Params
 
@@ -68,12 +68,6 @@ const tx = Transaction.fromValuesArray(arr)
 
 Learn more about the full API in the [docs](./docs/README.md).
 
-#### New Default Hardfork
-
-The default HF on the library has been updated from `petersburg` to `instanbul`.
-The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
-see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
-
 #### Immutability
 
 The returned transaction is now frozen and immutable. To work with a maliable transaction, copy it with `const fakeTx = Object.create(tx)`.
@@ -89,6 +83,21 @@ Getting a message to sign has been changed from calling `tx.hash(false)` to `tx.
 #### Fake Transaction
 
 The `FakeTransaction` class was removed since its functionality can now be implemented with less code. To create a fake tansaction for use in e.g. `VM.runTx()` overwrite `getSenderAddress` with your own `Address`. See a full example in the section in the [README](./README.md#fake-transaction).
+
+### New Default Hardfork
+
+**Breaking:** The default HF on the library has been updated from `petersburg` to `instanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
+see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
+### Other Changes
+
+**Changes and Refactoring**
+
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Replaced `new Buffer()` (deprecated) statements with `Buffer.from()`,
+  PR [#721](https://github.com/ethereumjs/ethereumjs-vm/pull/721)
 
 ## [2.1.2] - 2019-12-19
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -50,7 +50,7 @@ const common = new Common({ chain: 'mainnet', hardfork: 'spuriousDragon' })
 const vm = new VM({ common })
 ```
 
-The default HF from the VM has been updated from `petersburg` to `instanbul`.
+**Breaking**: The default HF from the VM has been updated from `petersburg` to `instanbul`.
 The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
 see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
 
@@ -69,8 +69,6 @@ PR [#754](https://github.com/ethereumjs/ethereumjs-vm/pull/754).
 **Attention!** Berlin HF support is still considered experimental
 and implementations can change on non-major VM releases!
 
-[TODO: FINALIZE THIS SECTION ONCE #785 OR FOLLOW-UP PR IS MERGED ]
-
 Support for BLS12-381 precompiles (`EIP-2537`) is added as an independent EIP
 implementation - see PR [#785](https://github.com/ethereumjs/ethereumjs-vm/pull/785) -
 since there is still an ongoing discussion on taking this EIP in for Berlin or
@@ -78,7 +76,9 @@ using a more generalized approach on curve computation with the Ethereum EVM
 (`evm384` by the eWASM team).
 
 The integration comes along with an API addition to the VM to support the activation
-of specific EIPs, PR [#856](https://github.com/ethereumjs/ethereumjs-vm/pull/856).
+of specific EIPs, see PR [#856](https://github.com/ethereumjs/ethereumjs-vm/pull/856),
+PR [#869](https://github.com/ethereumjs/ethereumjs-vm/pull/869) and
+PR [#872](https://github.com/ethereumjs/ethereumjs-vm/pull/872).
 
 This API can be used as follows:
 
@@ -98,30 +98,69 @@ and can be passed in on instantiation have been updated to new major versions.
   PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833)
 - `ethereumjs-common` `v1` -> `@ethereumjs/common` `v2`
 
-If you pass in instances of these libraries to the VM please make sure to
+**Breaking**: If you pass in instances of these libraries to the VM please make sure to
 update these library versions as stated. Please also take a note on the
 package name changes!
 
 All these libraries are now written in `TypeScript` and use promises instead of
 callbacks for accessing their APIs.
 
-### Other Additions/Changes
+### New StateManager Interface
 
-- Add `StateManager` interface,
-  PR [#763](https://github.com/ethereumjs/ethereumjs-vm/pull/763)
-- New benchmarking tool for the VM, CI integration on GitHub actions,
-  PR [#830](https://github.com/ethereumjs/ethereumjs-vm/pull/830)
+There is now a new `TypeScript` interface for the `StateManager`, see
+PR [#763](https://github.com/ethereumjs/ethereumjs-vm/pull/763). If you are
+using a custom `StateManager` you can use this interface to get better
+assurance that you are using a `StateManager` going conform with the current
+`StateManager` API and therefore running in the VM without problems.
+
+### Other Changes
+
+**Changes and Refactoring**
+
 - Group opcodes based upon hardfork,
   PR [#798](https://github.com/ethereumjs/ethereumjs-vm/pull/798)
+- Split opcodes logic into codes, fns, and utils files,
+  PR [#896](https://github.com/ethereumjs/ethereumjs-vm/pull/896)
 - Group precompiles based upon hardfork,
   PR [#783](https://github.com/ethereumjs/ethereumjs-vm/pull/783)
 - Make `memory.ts` use Buffers instead of Arrays,
   PR [#850](https://github.com/ethereumjs/ethereumjs-vm/pull/850)
+- Use `Map` for `OpcodeList` and `opcode` handlers,
+  PR [#852](https://github.com/ethereumjs/ethereumjs-vm/pull/852)
+- Compare buffers directly,
+  PR [#851](https://github.com/ethereumjs/ethereumjs-vm/pull/851)
+- Moved gas base fees from VM to Common,
+  PR [#806](https://github.com/ethereumjs/ethereumjs-vm/pull/806)
+- Return precompiles on `getPrecompile()` based on hardfork,
+  PR [#783](https://github.com/ethereumjs/ethereumjs-vm/pull/783)
+- Removed `async` dependency,
+  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+
+**CI and Test Improvements**
+
+- New benchmarking tool for the VM, CI integration on GitHub actions,
+  PR [#794](https://github.com/ethereumjs/ethereumjs-vm/pull/794) and
+  PR [#830](https://github.com/ethereumjs/ethereumjs-vm/pull/830)
+- Various updates, fixes and refactoring work on the test runner,
+  PR [#752](https://github.com/ethereumjs/ethereumjs-vm/pull/752) and
+  PR [#849](https://github.com/ethereumjs/ethereumjs-vm/pull/849)
+- Integrated `ethereumjs-testing` code logic into VM for more
+  flexible future test load optimizations,
+  PR [#808](https://github.com/ethereumjs/ethereumjs-vm/pull/808)
+- Transition VM tests to TypeScript,
+  PR [#881](https://github.com/ethereumjs/ethereumjs-vm/pull/881) and
+  PR [#882](https://github.com/ethereumjs/ethereumjs-vm/pull/882)
 
 **Bug Fixes**
 
 - Fix `activatePrecompiles`,
   PR [#797](https://github.com/ethereumjs/ethereumjs-vm/pull/797)
+- Strip zeros when putting contract storage in StateManager,
+  PR [#880](https://github.com/ethereumjs/ethereumjs-vm/pull/880)
+- Two bug fixes along `istanbul` `SSTORE` gas calculation,
+  PR [#870](https://github.com/ethereumjs/ethereumjs-vm/pull/870)
 
 ## [4.2.0] - 2020-05-06
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -110,8 +110,8 @@ callbacks for accessing their APIs.
 There is now a new `TypeScript` interface for the `StateManager`, see
 PR [#763](https://github.com/ethereumjs/ethereumjs-vm/pull/763). If you are
 using a custom `StateManager` you can use this interface to get better
-assurance that you are using a `StateManager` going conform with the current
-`StateManager` API and therefore running in the VM without problems.
+assurance that you are using a `StateManager` which conforms with the current
+`StateManager` API and will run in the VM without problems.
 
 ### Other Changes
 


### PR DESCRIPTION
Completion of the CHANGELOG files for the various libaries in preparation for the VM v5 release.

Dates on latest included merges are added to the commit messages, so some last PRs can be added upon the final release PRs (or - better - along eventually following feature PRs).

Updates here will be kept in sync with the TODO list from #907 upon pushes.