### PR TITLE
Update ethereumjs-util to v7.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -285,16 +285,19 @@
 			}
 		},
 		"@ethereumjs/config-coverage": {
-			"version": "https://gitpkg.now.sh/ethereumjs/ethereumjs-config/packages/coverage?use-positional-path-selection-in-lint-scripts",
-			"integrity": "sha512-q+VqFf+9iqB6I+vJvUiX2+DQKIt7kVw0ldVoUQrx3jyaXeCZTTtHqbBD7/QrC6CtqoCtkLpHkaM3QcZLK+7Apw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ethereumjs/config-coverage/-/config-coverage-2.0.0.tgz",
+			"integrity": "sha512-ruYpZHn4AC/z9fXyGpHFIZsMDu7/QPnhkep+m8SiZKZMOQqKkcYV72QDxbmfOhDHiyvifusuYFxZ3NFrFMMTqQ=="
 		},
 		"@ethereumjs/config-typescript": {
-			"version": "https://gitpkg.now.sh/ethereumjs/ethereumjs-config/packages/typescript?use-positional-path-selection-in-lint-scripts",
-			"integrity": "sha512-bV2E2Kj0Q/g/WbaamthvIHk5leo8netnLNpzTlIR/mtMV6+M4/6JFglGs9B1nfpHqwnfcws9UKiEBGzBitllaw=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ethereumjs/config-typescript/-/config-typescript-2.0.0.tgz",
+			"integrity": "sha512-a2jZI+xdQ540e5sVGrixjDm3yoraMtosT77Nrb26REnjoFMGUUwJUwdsIm41n0C/00JHGGP6Q44cJXSWLv16+w=="
 		},
 		"@ethereumjs/eslint-config-defaults": {
-			"version": "https://gitpkg.now.sh/ethereumjs/ethereumjs-config/packages/lint?use-positional-path-selection-in-lint-scripts",
-			"integrity": "sha512-MsWlrHgqz9dKnuxv13rC5grExMAd7etwb/31zHd+g1/EI/il0L+wNFlY02mBUPpI/3WE3XLxb1BCBD50a+UYLg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ethereumjs/eslint-config-defaults/-/eslint-config-defaults-2.0.0.tgz",
+			"integrity": "sha512-34pGbbQnOBprlJdUxZeclzSGPbLV/XSWFh/fvVsCPTiu5Mdg3kIoIECU6iHh6hBxqTF5aMWRuvtxqsXmcahUJg==",
 			"requires": {
 				"@typescript-eslint/eslint-plugin": "^2.34.0",
 				"@typescript-eslint/parser": "^2.34.0",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -40,7 +40,7 @@
     "@ethereumjs/common": "^1.5.1",
     "@ethereumjs/tx": "^2.1.2",
     "@types/bn.js": "^4.11.6",
-    "ethereumjs-util": "^7.0.6",
+    "ethereumjs-util": "^7.0.7",
     "merkle-patricia-tree": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -2,6 +2,7 @@ import Common from '@ethereumjs/common'
 import {
   Address,
   BN,
+  bnToHex,
   KECCAK256_RLP_ARRAY,
   KECCAK256_RLP,
   rlp,
@@ -10,14 +11,7 @@ import {
   unpadBuffer,
   zeros,
 } from 'ethereumjs-util'
-import {
-  HeaderData,
-  JsonHeader,
-  BlockHeaderBuffer,
-  Blockchain,
-  BlockOptions,
-  bnToHex,
-} from './types'
+import { HeaderData, JsonHeader, BlockHeaderBuffer, Blockchain, BlockOptions } from './types'
 import { Block } from './block'
 
 const DEFAULT_GAS_LIMIT = new BN(Buffer.from('ffffffffffffff', 'hex'))

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -1,4 +1,4 @@
-import { Address, BN, BNLike, BufferLike } from 'ethereumjs-util'
+import { AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { TxData, JsonTx } from '@ethereumjs/tx'
 import { Block } from './block'
@@ -111,19 +111,4 @@ export interface JsonHeader {
 
 export interface Blockchain {
   getBlock(hash: Buffer): Promise<Block>
-}
-
-/**
- * A type that represents an Address-like value.
- * To convert to address, use `new Address(toBuffer(value))
- * TODO: Move to ethereumjs-util
- */
-export type AddressLike = Address | Buffer | string
-
-/**
- * Convert BN to 0x-prefixed hex string.
- * TODO: Move to ethereumjs-util
- */
-export function bnToHex(value: BN): string {
-  return `0x${value.toString(16)}`
 }

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -37,7 +37,7 @@
     "@ethereumjs/block": "^3.0.0",
     "@ethereumjs/common": "^1.5.1",
     "@ethereumjs/ethash": "^1.0.0",
-    "ethereumjs-util": "^7.0.6",
+    "ethereumjs-util": "^7.0.7",
     "level-mem": "^5.0.1",
     "lru-cache": "^5.1.1",
     "rlp": "^2.2.3",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@types/levelup": "^4.3.0",
     "buffer-xor": "^2.0.1",
-    "ethereumjs-util": "^7.0.6",
+    "ethereumjs-util": "^7.0.7",
     "miller-rabin": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -30,7 +30,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@ethereumjs/common": "^1.5.1",
-    "ethereumjs-util": "^7.0.6"
+    "ethereumjs-util": "^7.0.7"
   },
   "devDependencies": {
     "@ethereumjs/config-coverage": "^2.0.0",

--- a/packages/tx/src/transaction.ts
+++ b/packages/tx/src/transaction.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'buffer'
 import {
   Address,
   BN,
+  bnToHex,
   bnToRlp,
   ecrecover,
   ecsign,
@@ -15,7 +16,7 @@ import {
   MAX_INTEGER,
 } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
-import { TxOptions, TxData, JsonTx, bnToHex } from './types'
+import { TxOptions, TxData, JsonTx } from './types'
 
 // secp256k1n/2
 const N_DIV_2 = new BN('7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0', 16)

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -1,4 +1,4 @@
-import { Address, BN, BNLike, BufferLike } from 'ethereumjs-util'
+import { AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 
 /**
@@ -79,18 +79,3 @@ export interface JsonTx {
   s?: string
   value?: string
 }
-
-/**
- * Convert BN to 0x-prefixed hex string.
- * TODO: Move to ethereumjs-util
- */
-export function bnToHex(value: BN): string {
-  return `0x${value.toString(16)}`
-}
-
-/**
- * A type that represents an Address-like value.
- * To convert to address, use `new Address(toBuffer(value))
- * TODO: Move to ethereumjs-util
- */
-export type AddressLike = Address | Buffer | string

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -491,11 +491,7 @@ export default class DefaultStateManager implements StateManager {
    */
   async accountIsEmpty(address: Buffer): Promise<boolean> {
     const account = await this.getAccount(address)
-    // Note: ethereumjs-util account.isEmpty() additionally checks for empty stateRoot which differs here.
-    // EIP-161: "An account is considered empty when it has no code and zero nonce and zero balance."
-    return (
-      account.nonce.isZero() && account.balance.isZero() && account.codeHash.equals(KECCAK256_NULL)
-    )
+    return account.isEmpty()
   }
 
   /**

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -47,7 +47,7 @@
     "@ethereumjs/blockchain": "^4.0.3",
     "@ethereumjs/common": "^1.5.1",
     "@ethereumjs/tx": "^2.1.2",
-    "ethereumjs-util": "^7.0.6",
+    "ethereumjs-util": "^7.0.7",
     "functional-red-black-tree": "^1.0.1",
     "merkle-patricia-tree": "^4.0.0",
     "rustbn.js": "~0.2.0",


### PR DESCRIPTION
 This small PR bumps `ethereumjs-util` to [v7.0.7](https://github.com/ethereumjs/ethereumjs-util/releases/tag/v7.0.7):
  * Updates vm `accountIsEmpty` check
  * Imports `AddressLike` and `bnToHex`