### PR TITLE
Add browser field to package.json's of modules with browser builds

### DIFF
--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist.browser"
   ],
   "browser": "dist.browser/index.js",
   "scripts": {

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "build": "ethereumjs-config-ts-build",
     "prepublishOnly": "npm run test && npm run build",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -5,8 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist",
+    "dist.browser"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "prepublishOnly": "npm run lint && npm run test && npm run build",
     "build": "ethereumjs-config-ts-build",

--- a/packages/blockchain/tsconfig.browser.json
+++ b/packages/blockchain/tsconfig.browser.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@ethereumjs/config-typescript/tsconfig.browser.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "./dist.browser",
+    "types": ["node"],
+    "typeRoots": ["node_modules/@types"]
+  }
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist.browser"
   ],
   "browser": "dist.browser/index.js",
   "scripts": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "build": "ethereumjs-config-ts-build",
     "prepublishOnly": "npm run test && npm run build",

--- a/packages/common/tsconfig.browser.json
+++ b/packages/common/tsconfig.browser.json
@@ -1,6 +1,6 @@
 {
   "extends": "@ethereumjs/config-typescript/tsconfig.browser.json",
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.json"],
   "compilerOptions": {
     "outDir": "./dist.browser"
   }

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "build": "ethereumjs-config-ts-build",
     "tsc": "ethereumjs-config-tsc",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist.browser"
   ],
   "browser": "dist.browser/index.js",
   "scripts": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist.browser"
   ],
   "browser": "dist.browser/index.js",
   "scripts": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "build": "ethereumjs-config-ts-build",
     "prepublishOnly": "npm run test && npm run build",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -5,8 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist",
+    "dist.browser"
   ],
+  "browser": "dist.browser/index.js",
   "scripts": {
     "build": "ethereumjs-config-ts-build",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",

--- a/packages/vm/tsconfig.browser.json
+++ b/packages/vm/tsconfig.browser.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@ethereumjs/config-typescript/tsconfig.browser.json",
+  "include": ["lib/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "./dist.browser",
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
Addresses [leftover review comment][3] from #913/886. 

Follows pattern established in [merkle-patricia-tree 117][1]. 

Per [clarifying comment][2] there:
> Web bundlers just use the browser version when resolving requires/imports. Then they pass those versions to the rest of the toolchain, like uglify

There are 4 packages with browser builds:
+ block
+ common
+ ethash
+ tx


[1]: https://github.com/ethereumjs/merkle-patricia-tree/pull/117#issue-412233007
[2]: https://github.com/ethereumjs/merkle-patricia-tree/pull/117#issuecomment-622572455
[3]: https://github.com/ethereumjs/ethereumjs-vm/pull/886#discussion_r501610246