### PR TITLE
Blockchain: Add reorg test + do not skip any reorg test in VM

### DIFF
--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -19,7 +19,7 @@
     "tsc": "ethereumjs-config-tsc",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
-    "test": "tape -r ts-node/register ./test/index.ts"
+    "test": "tape -r ts-node/register ./test/*.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/blockchain/test/reorg.ts
+++ b/packages/blockchain/test/reorg.ts
@@ -5,7 +5,7 @@ import tape from 'tape'
 import Blockchain from '../src'
 import { generateConsecutiveBlock } from './util'
 
-const genesisBlock = Block.fromBlockData({
+const genesis = Block.fromBlockData({
   header: {
     number: new BN(0),
     difficulty: new BN(0x020000),
@@ -19,17 +19,17 @@ tape('reorg tests', (t) => {
     async (st) => {
       const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
       const blockchain = new Blockchain({ validateBlocks: true, validatePow: false, common })
-      await blockchain.putBlock(genesisBlock, true)
+      await blockchain.putBlock(genesis, true)
 
       const blocks_lowTD: Block[] = []
       const blocks_highTD: Block[] = []
 
-      blocks_lowTD.push(generateConsecutiveBlock(genesisBlock, 0))
+      blocks_lowTD.push(generateConsecutiveBlock(genesis, 0))
 
-      const TD_Low = new BN(genesisBlock.header.difficulty).add(
+      const TD_Low = new BN(genesis.header.difficulty).add(
         new BN(blocks_lowTD[0].header.difficulty)
       )
-      const TD_High = new BN(genesisBlock.header.difficulty)
+      const TD_High = new BN(genesis.header.difficulty)
 
       // Keep generating blocks until the Total Difficulty (TD) of the High TD chain is higher than the TD of the Low TD chain
       // This means that the block number of the high TD chain is 1 lower than the low TD chain
@@ -37,7 +37,7 @@ tape('reorg tests', (t) => {
       while (TD_High.cmp(TD_Low) == -1) {
         blocks_lowTD.push(generateConsecutiveBlock(blocks_lowTD[blocks_lowTD.length - 1], 0))
         blocks_highTD.push(
-          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesisBlock, 1)
+          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesis, 1)
         )
 
         TD_Low.iadd(new BN(blocks_lowTD[blocks_lowTD.length - 1].header.difficulty))
@@ -51,8 +51,17 @@ tape('reorg tests', (t) => {
       const number_lowTD = new BN(lowTDBlock.header.number)
       const number_highTD = new BN(highTDBlock.header.number)
 
-      // ensure that the block number is indeed higher on the low TD chain
-      t.ok(number_lowTD.cmp(number_highTD) == 1)
+      // ensure that the block difficulty is higher on the highTD chain when compared to the low TD chain
+      t.ok(
+        number_lowTD.cmp(number_highTD) == 1,
+        'low TD should have a lower TD than the reported high TD'
+      )
+      t.ok(
+        blocks_lowTD[blocks_lowTD.length - 1].header.number.gt(
+          blocks_highTD[blocks_highTD.length - 1].header.number
+        ),
+        'low TD block should have a higher number than high TD block'
+      )
 
       await blockchain.putBlocks(blocks_lowTD)
 
@@ -62,8 +71,15 @@ tape('reorg tests', (t) => {
 
       const head_highTD = await blockchain.getHead()
 
-      t.ok(head_lowTD.hash().equals(lowTDBlock.hash()))
-      t.ok(head_highTD.hash().equals(highTDBlock.hash()))
+      t.ok(
+        head_lowTD.hash().equals(lowTDBlock.hash()),
+        'head on the low TD chain should equal the low TD block'
+      )
+      t.ok(
+        head_highTD.hash().equals(highTDBlock.hash()),
+        'head on the high TD chain should equal the high TD block'
+      )
+
       st.end()
     }
   )

--- a/packages/blockchain/test/reorg.ts
+++ b/packages/blockchain/test/reorg.ts
@@ -1,31 +1,35 @@
 import Common from '@ethereumjs/common'
-import { Block, BlockHeader } from '@ethereumjs/block'
-import { BN, toBuffer, bufferToInt } from 'ethereumjs-util'
-import * as test from 'tape'
+import { Block } from '@ethereumjs/block'
+import { BN } from 'ethereumjs-util'
+import tape from 'tape'
 import Blockchain from '../src'
-import { generateBlocks, generateConsecutiveBlock } from './util'
-import * as testData from './testdata.json'
+import { generateConsecutiveBlock } from './util'
 
-const level = require('level-mem')
+const genesisBlock = Block.fromBlockData({
+  header: {
+    number: new BN(0),
+    difficulty: new BN(0x020000),
+    gasLimit: new BN(8000000),
+  },
+})
 
-const genesis = generateBlocks(1)[0]
-genesis.header.difficulty = Buffer.from('02000', 'hex') // minimum difficulty
-
-test('reorg tests', (t) => {
+tape('reorg tests', (t) => {
   t.test(
     'should correctly reorg the chain if the total difficulty is higher on a lower block number than the current head block',
     async (st) => {
       const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
       const blockchain = new Blockchain({ validateBlocks: true, validatePow: false, common })
-      await blockchain.putBlock(genesis, true)
+      await blockchain.putBlock(genesisBlock, true)
 
-      let blocks_lowTD: Block[] = []
-      let blocks_highTD: Block[] = []
+      const blocks_lowTD: Block[] = []
+      const blocks_highTD: Block[] = []
 
-      blocks_lowTD.push(generateConsecutiveBlock(genesis, 0))
+      blocks_lowTD.push(generateConsecutiveBlock(genesisBlock, 0))
 
-      let TD_Low = new BN(genesis.header.difficulty).add(new BN(blocks_lowTD[0].header.difficulty))
-      let TD_High = new BN(genesis.header.difficulty)
+      const TD_Low = new BN(genesisBlock.header.difficulty).add(
+        new BN(blocks_lowTD[0].header.difficulty)
+      )
+      const TD_High = new BN(genesisBlock.header.difficulty)
 
       // Keep generating blocks until the Total Difficulty (TD) of the High TD chain is higher than the TD of the Low TD chain
       // This means that the block number of the high TD chain is 1 lower than the low TD chain
@@ -33,7 +37,7 @@ test('reorg tests', (t) => {
       while (TD_High.cmp(TD_Low) == -1) {
         blocks_lowTD.push(generateConsecutiveBlock(blocks_lowTD[blocks_lowTD.length - 1], 0))
         blocks_highTD.push(
-          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesis, 1),
+          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesisBlock, 1)
         )
 
         TD_Low.iadd(new BN(blocks_lowTD[blocks_lowTD.length - 1].header.difficulty))
@@ -44,23 +48,23 @@ test('reorg tests', (t) => {
       const lowTDBlock = blocks_lowTD[blocks_lowTD.length - 1]
       const highTDBlock = blocks_highTD[blocks_highTD.length - 1]
 
-      let number_lowTD = new BN(lowTDBlock.header.number)
-      let number_highTD = new BN(highTDBlock.header.number)
+      const number_lowTD = new BN(lowTDBlock.header.number)
+      const number_highTD = new BN(highTDBlock.header.number)
 
       // ensure that the block number is indeed higher on the low TD chain
       t.ok(number_lowTD.cmp(number_highTD) == 1)
 
       await blockchain.putBlocks(blocks_lowTD)
 
-      let head_lowTD = await blockchain.getHead()
+      const head_lowTD = await blockchain.getHead()
 
       await blockchain.putBlocks(blocks_highTD)
 
-      let head_highTD = await blockchain.getHead()
+      const head_highTD = await blockchain.getHead()
 
       t.ok(head_lowTD.hash().equals(lowTDBlock.hash()))
       t.ok(head_highTD.hash().equals(highTDBlock.hash()))
       st.end()
-    },
+    }
   )
 })

--- a/packages/blockchain/test/reorg.ts
+++ b/packages/blockchain/test/reorg.ts
@@ -26,10 +26,8 @@ tape('reorg tests', (t) => {
 
       blocks_lowTD.push(generateConsecutiveBlock(genesis, 0))
 
-      const TD_Low = new BN(genesis.header.difficulty).add(
-        new BN(blocks_lowTD[0].header.difficulty)
-      )
-      const TD_High = new BN(genesis.header.difficulty)
+      const TD_Low = genesis.header.difficulty.add(blocks_lowTD[0].header.difficulty)
+      const TD_High = genesis.header.difficulty.clone()
 
       // Keep generating blocks until the Total Difficulty (TD) of the High TD chain is higher than the TD of the Low TD chain
       // This means that the block number of the high TD chain is 1 lower than the low TD chain
@@ -40,16 +38,16 @@ tape('reorg tests', (t) => {
           generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesis, 1)
         )
 
-        TD_Low.iadd(new BN(blocks_lowTD[blocks_lowTD.length - 1].header.difficulty))
-        TD_High.iadd(new BN(blocks_highTD[blocks_highTD.length - 1].header.difficulty))
+        TD_Low.iadd(blocks_lowTD[blocks_lowTD.length - 1].header.difficulty)
+        TD_High.iadd(blocks_highTD[blocks_highTD.length - 1].header.difficulty)
       }
 
       // sanity check
       const lowTDBlock = blocks_lowTD[blocks_lowTD.length - 1]
       const highTDBlock = blocks_highTD[blocks_highTD.length - 1]
 
-      const number_lowTD = new BN(lowTDBlock.header.number)
-      const number_highTD = new BN(highTDBlock.header.number)
+      const number_lowTD = lowTDBlock.header.number
+      const number_highTD = highTDBlock.header.number
 
       // ensure that the block difficulty is higher on the highTD chain when compared to the low TD chain
       t.ok(

--- a/packages/blockchain/test/reorg.ts
+++ b/packages/blockchain/test/reorg.ts
@@ -1,0 +1,66 @@
+import Common from '@ethereumjs/common'
+import { Block, BlockHeader } from '@ethereumjs/block'
+import { BN, toBuffer, bufferToInt } from 'ethereumjs-util'
+import * as test from 'tape'
+import Blockchain from '../src'
+import { generateBlocks, generateConsecutiveBlock } from './util'
+import * as testData from './testdata.json'
+
+const level = require('level-mem')
+
+const genesis = generateBlocks(1)[0]
+genesis.header.difficulty = Buffer.from('02000', 'hex') // minimum difficulty
+
+test('reorg tests', (t) => {
+  t.test(
+    'should correctly reorg the chain if the total difficulty is higher on a lower block number than the current head block',
+    async (st) => {
+      const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+      const blockchain = new Blockchain({ validateBlocks: true, validatePow: false, common })
+      await blockchain.putBlock(genesis, true)
+
+      let blocks_lowTD: Block[] = []
+      let blocks_highTD: Block[] = []
+
+      blocks_lowTD.push(generateConsecutiveBlock(genesis, 0))
+
+      let TD_Low = new BN(genesis.header.difficulty).add(new BN(blocks_lowTD[0].header.difficulty))
+      let TD_High = new BN(genesis.header.difficulty)
+
+      // Keep generating blocks until the Total Difficulty (TD) of the High TD chain is higher than the TD of the Low TD chain
+      // This means that the block number of the high TD chain is 1 lower than the low TD chain
+
+      while (TD_High.cmp(TD_Low) == -1) {
+        blocks_lowTD.push(generateConsecutiveBlock(blocks_lowTD[blocks_lowTD.length - 1], 0))
+        blocks_highTD.push(
+          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesis, 1),
+        )
+
+        TD_Low.iadd(new BN(blocks_lowTD[blocks_lowTD.length - 1].header.difficulty))
+        TD_High.iadd(new BN(blocks_highTD[blocks_highTD.length - 1].header.difficulty))
+      }
+
+      // sanity check
+      const lowTDBlock = blocks_lowTD[blocks_lowTD.length - 1]
+      const highTDBlock = blocks_highTD[blocks_highTD.length - 1]
+
+      let number_lowTD = new BN(lowTDBlock.header.number)
+      let number_highTD = new BN(highTDBlock.header.number)
+
+      // ensure that the block number is indeed higher on the low TD chain
+      t.ok(number_lowTD.cmp(number_highTD) == 1)
+
+      await blockchain.putBlocks(blocks_lowTD)
+
+      let head_lowTD = await blockchain.getHead()
+
+      await blockchain.putBlocks(blocks_highTD)
+
+      let head_highTD = await blockchain.getHead()
+
+      t.ok(head_lowTD.hash().equals(lowTDBlock.hash()))
+      t.ok(head_highTD.hash().equals(highTDBlock.hash()))
+      st.end()
+    },
+  )
+})

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -54,6 +54,34 @@ export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block
     blocks,
     error: null,
   }
+/**
+ *
+ * @param parentBlock parent block to generate the consecutive block on top of
+ * @param difficultyChangeFactor this integer can be any value, but will only return unique blocks between [-99, 1] (this is due to difficulty calculation). 1 will increase the difficulty, 0 will keep the difficulty constant any any negative number will decrease the difficulty
+ */
+
+export const generateConsecutiveBlock = (
+  parentBlock: Block,
+  difficultyChangeFactor: number,
+): Block => {
+  const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+  const block = new Block(undefined, { common })
+  block.header.number = toBuffer(new BN(parentBlock.header.number).add(new BN(1)))
+  block.header.parentHash = parentBlock.hash()
+  block.header.gasLimit = toBuffer(8000000)
+  if (difficultyChangeFactor > 1) {
+    difficultyChangeFactor = 1
+  }
+  block.header.timestamp = toBuffer(
+    bufferToInt(parentBlock.header.timestamp) + (10 + -difficultyChangeFactor * 9),
+  )
+  block.header.difficulty = toBuffer(block.header.canonicalDifficulty(parentBlock))
+  return new Block(
+    {
+      header: block.header,
+    },
+    { common },
+  )
 }
 
 export const isConsecutive = (blocks: Block[]) => {

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -1,4 +1,4 @@
-import { BN, rlp, toBuffer } from 'ethereumjs-util'
+import { BN, rlp } from 'ethereumjs-util'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import Common from '@ethereumjs/common'
 import Blockchain from '../src'
@@ -54,6 +54,7 @@ export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block
     blocks,
     error: null,
   }
+}
 /**
  *
  * @param parentBlock parent block to generate the consecutive block on top of
@@ -62,7 +63,7 @@ export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block
 
 export const generateConsecutiveBlock = (
   parentBlock: Block,
-  difficultyChangeFactor: number,
+  difficultyChangeFactor: number
 ): Block => {
   if (difficultyChangeFactor > 1) {
     difficultyChangeFactor = 1
@@ -78,11 +79,11 @@ export const generateConsecutiveBlock = (
       parentHash: parentBlock.hash(),
       gasLimit: new BN(8000000),
       timestamp: parentBlock.header.timestamp.addn(10 + -difficultyChangeFactor * 9),
-      difficulty: new BN(tmpHeader.canonicalDifficulty(parentBlock)),
+      difficulty: new BN(tmpHeader.canonicalDifficulty(parentBlock.header)),
     },
     {
       common,
-    },
+    }
   )
 
   const block = new Block(header, undefined, undefined, { common })

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -70,16 +70,16 @@ export const generateConsecutiveBlock = (
   }
   const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
   const tmpHeader = BlockHeader.fromHeaderData({
-    number: new BN(parentBlock.header.number).add(new BN(1)),
+    number: parentBlock.header.number.addn(1),
     timestamp: parentBlock.header.timestamp.addn(10 + -difficultyChangeFactor * 9),
   })
   const header = BlockHeader.fromHeaderData(
     {
-      number: new BN(parentBlock.header.number).add(new BN(1)),
+      number: parentBlock.header.number.addn(1),
       parentHash: parentBlock.hash(),
       gasLimit: new BN(8000000),
       timestamp: parentBlock.header.timestamp.addn(10 + -difficultyChangeFactor * 9),
-      difficulty: new BN(tmpHeader.canonicalDifficulty(parentBlock.header)),
+      difficulty: tmpHeader.canonicalDifficulty(parentBlock.header),
     },
     {
       common,

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -86,9 +86,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
 
   let currentFork = common.hardfork()
   let currentBlock = new BN(0)
-  let lastBlock = new BN(0)
   for (const raw of testData.blocks) {
-    lastBlock = currentBlock
     const paramFork = `expectException${options.forkConfigTestSuite}`
     // Two naming conventions in ethereum/tests to indicate "exception occurs on all HFs" semantics
     // Last checked: ethereumjs-testing v1.3.1 (2020-05-11)

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -109,12 +109,6 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
       continue
     }
 
-    if (currentBlock.lt(lastBlock)) {
-      // "re-org": rollback the blockchain to currentBlock (i.e. delete that block number in the blockchain plus the children)
-      t.fail('re-orgs are not supported by the test suite')
-      return
-    }
-
     try {
       // check if we should update common.
       const newFork = common.setHardforkByBlockNumber(currentBlock)

--- a/packages/vm/tests/config.ts
+++ b/packages/vm/tests/config.ts
@@ -11,26 +11,11 @@ export const DEFAULT_FORK_CONFIG = 'Istanbul'
 export const SKIP_BROKEN = [
   'ForkStressTest', // Only BlockchainTest, temporary till fixed (2020-05-23)
   'ChainAtoChainB', // Only BlockchainTest, temporary, along expectException fixes (2020-05-23)
-  'sha3_bigOffset', // SHA3: Only BlockchainTest, unclear SHA3 test situation (2020-05-28) (https://github.com/ethereumjs/ethereumjs-vm/pull/743#issuecomment-635116418)
-  'sha3_memSizeNoQuadraticCost', // SHA3: See also:
-  'sha3_memSizeQuadraticCost', // SHA3: https://github.com/ethereumjs/ethereumjs-vm/pull/743#issuecomment-635116418
-  'sha3_bigSize', // SHA3
 
-  // these tests need "re-org" support in blockchain
+  // In these tests, we have access to two forked chains. Their total difficulty is equal. There are errors in the second chain, but we have no reason to execute this chain if the TD remains equal.
   'blockChainFrontierWithLargerTDvsHomesteadBlockchain2_FrontierToHomesteadAt5',
   'blockChainFrontierWithLargerTDvsHomesteadBlockchain_FrontierToHomesteadAt5',
   'HomesteadOverrideFrontier_FrontierToHomesteadAt5',
-  'DaoTransactions_HomesteadToDaoAt5',
-  'RPC_API_Test',
-  'lotsOfBranchesOverrideAtTheEnd',
-  'lotsOfBranchesOverrideAtTheMiddle',
-  'newChainFrom4Block',
-  'newChainFrom5Block',
-  'newChainFrom6Block',
-  'sideChainWithMoreTransactions',
-  'sideChainWithMoreTransactions2',
-  'sideChainWithNewMaxDifficultyStartingFromBlock3AfterBlock4',
-  'uncleBlockAtBlock3afterBlock4',
 ]
 
 /**
@@ -405,10 +390,10 @@ export function getSkipTests(choices: string, defaultChoice: string): string[] {
       skipTests = skipTests.concat(SKIP_BROKEN)
     }
     if (all || choicesList.includes('permanent')) {
-      skipTests = skipTests.concat(SKIP_PERMANENT)
+      //skipTests = skipTests.concat(SKIP_PERMANENT)
     }
     if (all || choicesList.includes('slow')) {
-      skipTests = skipTests.concat(SKIP_SLOW)
+      //skipTests = skipTests.concat(SKIP_SLOW)
     }
   }
   return skipTests

--- a/packages/vm/tests/config.ts
+++ b/packages/vm/tests/config.ts
@@ -390,10 +390,10 @@ export function getSkipTests(choices: string, defaultChoice: string): string[] {
       skipTests = skipTests.concat(SKIP_BROKEN)
     }
     if (all || choicesList.includes('permanent')) {
-      //skipTests = skipTests.concat(SKIP_PERMANENT)
+      skipTests = skipTests.concat(SKIP_PERMANENT)
     }
     if (all || choicesList.includes('slow')) {
-      //skipTests = skipTests.concat(SKIP_SLOW)
+      skipTests = skipTests.concat(SKIP_SLOW)
     }
   }
   return skipTests


### PR DESCRIPTION
Closes #879 

This PR cherry-picks from #895 and does:

- Adds a specific (big) reorg test in the Blockchain

In this test, we create two chains: one chain which has a low difficulty and another one which has a higher difficulty, but this chain is actually **1 block behind** the other chain. This is possible due to the difficulty formula: if time since last block > 18 seconds, decrease the difficulty, if it is < 9 seconds, increase the difficulty. Block number is thus not a good identifier to find the "best chain" (which has the highest sum of difficulties, i.e. the Total Difficulty). In practice, this test first writes 65 blocks to the chain. Then it puts all the blocks in (64 blocks) which have a higher total difficulty: this thus **re-orgs 65 blocks**. Without any necessary change this test passes. Thus, we can also:

- Re-enables blockchain reorg tests on VM
- Checks each skipped test in VM, if these pass, remove them from skipped tests.