### PR TITLE
Block: add methods to calculate difficulty of a consecutive header/block

### DIFF
--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -155,7 +155,7 @@ as an input parameter.
 
 ### New Default Hardfork
 
-**Breaking:** The default HF on the library has been updated from `petersburg` to `instanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+**Breaking:** The default HF on the library has been updated from `petersburg` to `istanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
 The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
 see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
 
@@ -179,6 +179,7 @@ in performance benefits for Node.js consumers, see [here](https://github.com/eth
   PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
 - Added `DAO` hardfork support (check for `extraData` attribute if `DAO` HF is active),
   PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
+- Added the `calcDifficultyFromHeader` constructor option. If this `BlockHeader` is supplied, then the `difficulty` of the constructed `BlockHeader` will be set to the canonical difficulty (also if `difficulty` is set as parameter in the constructor). See [#929](https://github.com/ethereumjs/ethereumjs-vm/pull/929)
 
 **Changes and Refactoring**
 

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -223,6 +223,13 @@ export class BlockHeader {
     this._validateBufferLengths()
     this._checkDAOExtraData()
 
+    // Now we have set all the values of this Header, we possibly have set a dummy `difficulty` value (defaults to 0)
+    // If we have a `calcDifficultyFromHeader` block option parameter, we instead set difficulty to this value.
+
+    if (options.calcDifficultyFromHeader) {
+      this.difficulty = this.canonicalDifficulty(options.calcDifficultyFromHeader)
+    }
+
     Object.freeze(this)
   }
 

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -223,9 +223,9 @@ export class BlockHeader {
     this._validateBufferLengths()
     this._checkDAOExtraData()
 
-    // Now we have set all the values of this Header, we possibly have set a dummy `difficulty` value (defaults to 0)
-    // If we have a `calcDifficultyFromHeader` block option parameter, we instead set difficulty to this value.
-
+    // Now we have set all the values of this Header, we possibly have set a dummy
+    // `difficulty` value (defaults to 0). If we have a `calcDifficultyFromHeader`
+    // block option parameter, we instead set difficulty to this value.
     if (options.calcDifficultyFromHeader) {
       this.difficulty = this.canonicalDifficulty(options.calcDifficultyFromHeader)
     }

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -279,7 +279,7 @@ export class BlockHeader {
       let a = blockTs.sub(parentTs).idivn(9).ineg().iaddn(uncleAddend)
       const cutoff = new BN(-99)
       // MAX(cutoff, a)
-      if (cutoff.cmp(a) === 1) {
+      if (cutoff.gt(a)) {
         a = cutoff
       }
       dif = parentDif.add(offset.mul(a))
@@ -308,16 +308,14 @@ export class BlockHeader {
       let a = blockTs.sub(parentTs).idivn(10).ineg().iaddn(1)
       const cutoff = new BN(-99)
       // MAX(cutoff, a)
-      if (cutoff.cmp(a) === 1) {
+      if (cutoff.gt(a)) {
         a = cutoff
       }
       dif = parentDif.add(offset.mul(a))
     } else {
       // pre-homestead
       if (
-        parentTs
-          .addn(this._common.paramByHardfork('pow', 'durationLimit', hardfork))
-          .cmp(blockTs) === 1
+        parentTs.addn(this._common.paramByHardfork('pow', 'durationLimit', hardfork)).gt(blockTs)
       ) {
         dif = offset.add(parentDif)
       } else {
@@ -330,7 +328,7 @@ export class BlockHeader {
       dif.iadd(new BN(2).pow(exp))
     }
 
-    if (dif.cmp(minimumDifficulty) === -1) {
+    if (dif.lt(minimumDifficulty)) {
       dif = minimumDifficulty
     }
 
@@ -411,7 +409,7 @@ export class BlockHeader {
 
       if (height) {
         const dif = height.sub(header.number)
-        if (!(dif.cmpn(8) === -1 && dif.cmpn(1) === 1)) {
+        if (!(dif.ltn(8) && dif.gtn(1))) {
           throw new Error('uncle block has a parent that is too old or too young')
         }
       }

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -38,7 +38,9 @@ export interface BlockOptions {
   initWithGenesisHeader?: boolean
 
   /**
-   * If a `BlockHeader` is given, then this header is used to calculate the difficulty upon creating the Block Header.
+   * If a preceding `BlockHeader` (usually the parent header) is given the preceding
+   * header will be used to calculate the difficulty for this block and the calculated
+   * difficulty takes precedence over a provided static `difficulty` value.
    */
   calcDifficultyFromHeader?: BlockHeader
 }

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -2,6 +2,7 @@ import { AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { TxData, JsonTx } from '@ethereumjs/tx'
 import { Block } from './block'
+import { BlockHeader } from './header'
 
 /**
  * An object to set to which blockchain the blocks and their headers belong. This could be specified
@@ -35,6 +36,11 @@ export interface BlockOptions {
    * Default: `false`
    */
   initWithGenesisHeader?: boolean
+
+  /**
+   * If a `BlockHeader` is given, then this header is used to calculate the difficulty upon creating the Block Header.
+   */
+  calcDifficultyFromHeader?: BlockHeader
 }
 
 /**

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -22,12 +22,14 @@ export const generateBlocks = (numberOfBlocks: number, existingBlocks?: Block[])
       header: {
         number: i,
         parentHash: lastBlock.hash(),
-        difficulty: lastBlock.canonicalDifficulty(lastBlock),
         gasLimit,
         timestamp: lastBlock.header.timestamp.addn(1),
       },
     }
-    const block = Block.fromBlockData(blockData, opts)
+    const block = Block.fromBlockData(blockData, {
+      common,
+      calcDifficultyFromHeader: lastBlock.header,
+    })
     blocks.push(block)
   }
 
@@ -83,6 +85,7 @@ export const generateConsecutiveBlock = (
     },
     {
       common,
+      calcDifficultyFromHeader: parentBlock.header,
     }
   )
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -86,7 +86,7 @@ The `FakeTransaction` class was removed since its functionality can now be imple
 
 ### New Default Hardfork
 
-**Breaking:** The default HF on the library has been updated from `petersburg` to `instanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+**Breaking:** The default HF on the library has been updated from `petersburg` to `istanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
 The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
 see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -54,7 +54,7 @@ const common = new Common({ chain: 'mainnet', hardfork: 'spuriousDragon' })
 const vm = new VM({ common })
 ```
 
-**Breaking**: The default HF from the VM has been updated from `petersburg` to `instanbul`.
+**Breaking**: The default HF from the VM has been updated from `petersburg` to `istanbul`.
 The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
 see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
 


### PR DESCRIPTION
Cherry-picked from #895 

It is (recently) not allowed anymore to edit params like `difficulty` in Header. In order to currently set the (right) difficulty in header (i.e. the canonical difficulty) then one has to create a mock Header and then call `canonicalDifficulty` on this mock Header. Then, one can create a new `Header` with the difficulty as returned by this `canonicalDifficulty` call.

It doesn't make a lot of sense to create a mock header.  We want to "just set it to the correct value".

This PR:

- Adds `calcDifficultyFromHeader` as a `BlockOption`. If this is defined, then this `Header` will be used to calculate the difficulty; any existing difficulty will be overwritten to this new, correct, value. Suggestion by @holgerd77 👍 
- Change tests in `blockchain` to use this new method.
- Make `canonicalDifficulty` method a bit more readable by instead using the corresponding `gt`/`lt` methods of `BN` instead of using `cmp`. Suggestion by @ryanio 👍 