### PR TITLE
Blockchain concurrency and safety improvements

### DIFF
--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.0.0-beta.2 - UNRELEASED
+
+This is the second beta release towards a final `v5.0.0` `Blockchain` library release, see [v5.0.0-beta.1 release notes](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fblockchain%405.0.0-beta.1) for an overview on the full changes since the last publicly released version.
+
+This release introduces **new breaking changes**, so please carefully read the additional release note sections!
+
+**Safe Static Constructor**
+
+The library now has an additional safe static constructor `Blockchain.create()` which awaits the init method and throws if the init method throws:
+
+```typescript
+const common = new Common({ chain: 'ropsten' })
+const blockchain = await Blockchain.create({ common })
+```
+
+This is the new recommended way to instantiate a `Blockchain` object, see PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930).
+
+**Refactored Genesis Block Handling Mechanism**
+
+Genesis handling has been reworked to now be safer and reduce the risk of wiping a blockchain by setting a new genesis, see PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930).
+
+**Breaking**: The dedicated `setGenesisBlock()` methods and the optional `isGenesis` option on `Blockchain.putBlock()` have been removed. Instead the genesis block is created on initialization either from the `Common` library instance passed or a custom genesis block passed along with the `genesisBlock` option. If a custom genesis block is used, this custom block now always has to be passed along on `Blockchain` initialization, also when operating on an already existing DB. 
+
+**Changes and Refactoring**
+
+- Refactored `DBManager` with the introduction of an abstract DB operation handling mechanism, if you have modified `DBManager` in your code this will be a **potentially breaking** change for you, PR [#927](https://github.com/ethereumjs/ethereumjs-vm/pull/927)
+- Renaming of internal variables like `Blockchain._headBlock`, if you are using these variables in your code this will be a **potentially breaking** change for you, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Made internal `_` methods like `_saveHeads()` private, if you are using these functions in your code this will be a **potentially breaking** change for you, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Improved code documentation, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Fixed potential blockchain DB concurrency issues along PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+
+**Testing and CI**
+
+- Dedicated `blockchain` reorg test setup and executable test, PR [#926](https://github.com/ethereumjs/ethereumjs-vm/pull/926)
+
 ## 5.0.0-beta.1 - 2020-10-22
 
 ### New Package Name

--- a/packages/blockchain/src/db/constants.ts
+++ b/packages/blockchain/src/db/constants.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 
 // Geth compatible DB keys
 

--- a/packages/blockchain/src/db/helpers.ts
+++ b/packages/blockchain/src/db/helpers.ts
@@ -1,6 +1,5 @@
 import { DBOp, DBTarget } from './operation'
-import BN from 'bn.js'
-import { rlp } from 'ethereumjs-util'
+import { BN, rlp } from 'ethereumjs-util'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { bufBE8 } from './constants'
 

--- a/packages/blockchain/src/db/helpers.ts
+++ b/packages/blockchain/src/db/helpers.ts
@@ -4,9 +4,9 @@ import { Block, BlockHeader } from '@ethereumjs/block'
 import { bufBE8 } from './constants'
 
 /*
-    This extra helper file is an interface between blockchain / operation.ts 
-    It also handles the right encoding of the keys, so this does not have to happen in index.ts anymore.
-*/
+ * This extra helper file serves as an interface between the blockchain API functionality
+ * and the DB operations from `db/operation.ts` and also handles the right encoding of the keys
+ */
 
 function DBSetTD(TD: BN, blockNumber: BN, blockHash: Buffer): DBOp {
   return DBOp.set(DBTarget.TotalDifficulty, rlp.encode(TD), {
@@ -16,11 +16,12 @@ function DBSetTD(TD: BN, blockNumber: BN, blockHash: Buffer): DBOp {
 }
 
 /*
-    This method accepts either a BlockHeader or a Block and returns a list of DatabaseOperation
-    This always consists of a Set Header operation
-    It could also consist of a set body operation: this only happens if the body is not empty (it has transactions/uncles), or it is the genesis block
-    If the block is empty, we do not have to save it; the DB will assume that if the Header exists, but no block body, then the block was empty.
-*/
+ * This method accepts either a BlockHeader or a Block and returns a list of DatabaseOperation instances
+ *
+ * - A "Set Header Operation" is always added
+ * - A "Set Body Operation" is only added if the body is not empty (it has transactions/uncles) or if the block is the genesis block
+ * (if there is a header but no block saved the DB will implicitly assume the block to be empty)
+ */
 function DBSetBlockOrHeader(blockBody: Block | BlockHeader): DBOp[] {
   const header: BlockHeader = blockBody instanceof Block ? blockBody.header : blockBody
   const dbOps = []

--- a/packages/blockchain/src/db/helpers.ts
+++ b/packages/blockchain/src/db/helpers.ts
@@ -5,7 +5,7 @@ import { Block, BlockHeader } from '@ethereumjs/block'
 import { bufBE8 } from './constants'
 
 /*
-    This extra helper file is an interface between blockchain / databaseOperation.ts 
+    This extra helper file is an interface between blockchain / operation.ts 
     It also handles the right encoding of the keys, so this does not have to happen in index.ts anymore.
 */
 

--- a/packages/blockchain/src/db/helpers.ts
+++ b/packages/blockchain/src/db/helpers.ts
@@ -1,0 +1,78 @@
+import { DBOp, DBTarget } from './operation'
+import BN from 'bn.js'
+import { rlp } from 'ethereumjs-util'
+import { Block, BlockHeader } from '@ethereumjs/block'
+import { bufBE8 } from './constants'
+
+/*
+    This extra helper file is an interface between blockchain / databaseOperation.ts 
+    It also handles the right encoding of the keys, so this does not have to happen in index.ts anymore.
+*/
+
+function DBSetTD(TD: BN, blockNumber: BN, blockHash: Buffer): DBOp {
+  return DBOp.set(DBTarget.TotalDifficulty, rlp.encode(TD), {
+    blockNumber,
+    blockHash,
+  })
+}
+
+/*
+    This method accepts either a BlockHeader or a Block and returns a list of DatabaseOperation
+    This always consists of a Set Header operation
+    It could also consist of a set body operation: this only happens if the body is not empty (it has transactions/uncles), or it is the genesis block
+    If the block is empty, we do not have to save it; the DB will assume that if the Header exists, but no block body, then the block was empty.
+*/
+function DBSetBlockOrHeader(blockBody: Block | BlockHeader): DBOp[] {
+  const header: BlockHeader = blockBody instanceof Block ? blockBody.header : blockBody
+  const dbOps = []
+
+  const blockNumber = header.number
+  const blockHash = header.hash()
+
+  const headerValue = header.serialize()
+  dbOps.push(
+    DBOp.set(DBTarget.Header, headerValue, {
+      blockNumber,
+      blockHash,
+    })
+  )
+
+  const isGenesis = header.number.eqn(0)
+
+  if (
+    isGenesis ||
+    (blockBody instanceof Block && (blockBody.transactions.length || blockBody.uncleHeaders.length))
+  ) {
+    const bodyValue = rlp.encode(blockBody.raw().slice(1))
+    dbOps.push(
+      DBOp.set(DBTarget.Body, bodyValue, {
+        blockNumber,
+        blockHash,
+      })
+    )
+  }
+
+  return dbOps
+}
+
+function DBSetHashToNumber(blockHash: Buffer, blockNumber: BN): DBOp {
+  const blockNumber8Byte = bufBE8(blockNumber)
+  return DBOp.set(DBTarget.HashToNumber, blockNumber8Byte, {
+    blockHash,
+  })
+}
+
+function DBSaveLookups(blockHash: Buffer, blockNumber: BN): DBOp[] {
+  const ops = []
+  ops.push(DBOp.set(DBTarget.NumberToHash, blockHash, { blockNumber }))
+
+  const blockNumber8Bytes = bufBE8(blockNumber)
+  ops.push(
+    DBOp.set(DBTarget.HashToNumber, blockNumber8Bytes, {
+      blockHash,
+    })
+  )
+  return ops
+}
+
+export { DBOp, DBSetTD, DBSetBlockOrHeader, DBSetHashToNumber, DBSaveLookups }

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -32,9 +32,9 @@ export type CacheMap = { [key: string]: Cache<Buffer> }
  * @hidden
  */
 export class DBManager {
-  _cache: CacheMap
-  _common: Common
-  _db: LevelUp
+  private _cache: CacheMap
+  private _common: Common
+  private _db: LevelUp
 
   constructor(db: LevelUp, common: Common) {
     this._db = db

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -161,11 +161,11 @@ export default class Blockchain implements BlockchainInterface {
     try {
       genesisHash = await this.dbManager.numberToHash(new BN(0))
     } catch (error) {
-      await this._setCanonicalGenesisBlock()
-      genesisHash = this._genesis
       if (error.type !== 'NotFoundError') {
         throw error
       }
+      await this._setCanonicalGenesisBlock()
+      genesisHash = this._genesis
     }
 
     // load verified iterator heads
@@ -173,10 +173,10 @@ export default class Blockchain implements BlockchainInterface {
       const heads = await this.dbManager.getHeads()
       this._heads = heads
     } catch (error) {
-      this._heads = {}
       if (error.type !== 'NotFoundError') {
         throw error
       }
+      this._heads = {}
     }
 
     // load headerchain head
@@ -184,10 +184,10 @@ export default class Blockchain implements BlockchainInterface {
       const hash = await this.dbManager.getHeadHeader()
       this._headHeader = hash
     } catch (error) {
-      this._headHeader = genesisHash
       if (error.type !== 'NotFoundError') {
         throw error
       }
+      this._headHeader = genesisHash
     }
 
     // load blockchain head
@@ -195,10 +195,10 @@ export default class Blockchain implements BlockchainInterface {
       const hash = await this.dbManager.getHeadBlock()
       this._headBlock = hash
     } catch (error) {
-      this._headBlock = genesisHash
       if (error.type !== 'NotFoundError') {
         throw error
       }
+      this._headBlock = genesisHash
     }
 
     this._initDone = true

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -17,9 +17,8 @@ export interface BlockchainInterface {
    * Adds a block to the blockchain.
    *
    * @param block - The block to be added to the blockchain.
-   * @param isGenesis - True if block is the genesis block.
    */
-  putBlock(block: Block, isGenesis?: boolean): Promise<void>
+  putBlock(block: Block): Promise<void>
 
   /**
    * Deletes a block from the blockchain. All child blocks in the chain are

--- a/packages/blockchain/test/index.ts
+++ b/packages/blockchain/test/index.ts
@@ -46,7 +46,7 @@ tape('blockchain test', (t) => {
     })
     const badBlock = Block.fromBlockData({ header: { number: new BN(8) } })
     try {
-      await blockchain.putBlock(badBlock, false)
+      await blockchain.putBlock(badBlock)
     } catch (error) {
       st.ok(error, 'returned with error')
       st.end()
@@ -385,12 +385,12 @@ tape('blockchain test', (t) => {
       calcDifficultyFromHeader: blocks[14].header,
     })
 
-    blockchain._heads['staletest'] = blockchain._headHeader
+    blockchain._heads['staletest'] = blockchain._headHeaderHash
 
     await blockchain.putHeader(forkHeader)
 
     st.ok(blockchain._heads['staletest'].equals(blocks[14].hash()), 'should update stale head')
-    st.ok(blockchain._headBlock.equals(blocks[14].hash()), 'should update stale headBlock')
+    st.ok(blockchain._headBlockHash.equals(blocks[14].hash()), 'should update stale headBlock')
     st.end()
   })
 
@@ -410,17 +410,17 @@ tape('blockchain test', (t) => {
       calcDifficultyFromHeader: blocks[14].header,
     })
 
-    blockchain._heads['staletest'] = blockchain._headHeader
+    blockchain._heads['staletest'] = blockchain._headHeaderHash
 
     await blockchain.putHeader(forkHeader)
 
     st.ok(blockchain._heads['staletest'].equals(blocks[14].hash()), 'should update stale head')
-    st.ok(blockchain._headBlock.equals(blocks[14].hash()), 'should update stale headBlock')
+    st.ok(blockchain._headBlockHash.equals(blocks[14].hash()), 'should update stale headBlock')
 
     await blockchain.delBlock(forkHeader.hash())
 
-    st.ok(blockchain._headHeader.equals(blocks[14].hash()), 'should reset headHeader')
-    st.ok(blockchain._headBlock.equals(blocks[14].hash()), 'should not change headBlock')
+    st.ok(blockchain._headHeaderHash.equals(blocks[14].hash()), 'should reset headHeader')
+    st.ok(blockchain._headBlockHash.equals(blocks[14].hash()), 'should not change headBlock')
     st.end()
   })
 
@@ -437,7 +437,7 @@ tape('blockchain test', (t) => {
     }
 
     await delNextBlock(9)
-    st.ok(blockchain._headHeader.equals(blocks[5].hash()), 'should have block 5 as head')
+    st.ok(blockchain._headHeaderHash.equals(blocks[5].hash()), 'should have block 5 as head')
     st.end()
   })
 
@@ -445,7 +445,7 @@ tape('blockchain test', (t) => {
     const { blockchain, blocks, error } = await generateBlockchain(25)
     st.error(error, 'no error')
     await blockchain.delBlock(blocks[1].hash())
-    st.ok(blockchain._headHeader.equals(blocks[0].hash()), 'should have genesis as head')
+    st.ok(blockchain._headHeaderHash.equals(blocks[0].hash()), 'should have genesis as head')
     st.end()
   })
 

--- a/packages/blockchain/test/index.ts
+++ b/packages/blockchain/test/index.ts
@@ -577,6 +577,7 @@ tape('blockchain test', (t) => {
       db,
       validateBlocks: true,
       validatePow: false,
+      genesisBlock,
     })
 
     const latestHeader = await blockchain.getLatestHeader()

--- a/packages/blockchain/test/index.ts
+++ b/packages/blockchain/test/index.ts
@@ -122,13 +122,13 @@ tape('blockchain test', (t) => {
     const blockData = {
       header: {
         number: 1,
-        parentHash: genesis.hash(),
-        timestamp: genesis.header.timestamp.addn(1),
+        parentHash: genesisBlock.hash(),
+        timestamp: genesisBlock.header.timestamp.addn(1),
         gasLimit,
       },
     }
     const block = Block.fromBlockData(blockData, {
-      calcDifficultyFromHeader: genesis.header,
+      calcDifficultyFromHeader: genesisBlock.header,
     })
     blocks.push(block)
     await blockchain.putBlock(block)
@@ -545,7 +545,8 @@ tape('blockchain test', (t) => {
     const hash = await blockchain.dbManager.numberToHash(new BN(0))
     st.ok(genesis.hash().equals(hash), 'should perform _numberToHash correctly')
 
-    const td = await blockchain._getTd(genesis.hash(), new BN(0))
+    // cast the blockchain as <any> in order to get access to the private _getTd
+    const td = await (<any>blockchain)._getTd(genesis.hash(), new BN(0))
     st.ok(td.eq(genesis.header.difficulty), 'should perform _getTd correctly')
     st.end()
   })
@@ -564,12 +565,12 @@ tape('blockchain test', (t) => {
 
     const headerData = {
       number: 1,
-      parentHash: genesis.hash(),
+      parentHash: genesisBlock.hash(),
       gasLimit,
       timestamp: genesisBlock.header.timestamp.addn(1),
     }
     const header = BlockHeader.fromHeaderData(headerData, {
-      calcDifficultyFromHeader: genesis.header,
+      calcDifficultyFromHeader: genesisBlock.header,
     })
     await blockchain.putHeader(header)
 
@@ -603,21 +604,21 @@ tape('blockchain test', (t) => {
     const blockData = {
       header: {
         number: 1,
-        parentHash: genesis.hash(),
-        timestamp: genesis.header.timestamp.addn(3),
+        parentHash: genesisBlock.hash(),
+        timestamp: genesisBlock.header.timestamp.addn(3),
         gasLimit,
       },
     }
-    opts.calcDifficultyFromHeader = genesis.header
+    opts.calcDifficultyFromHeader = genesisBlock.header
     const block = Block.fromBlockData(blockData, opts)
 
     const headerData1 = {
       number: 1,
-      parentHash: genesis.hash(),
-      timestamp: genesis.header.timestamp.addn(1),
+      parentHash: genesisBlock.hash(),
+      timestamp: genesisBlock.header.timestamp.addn(1),
       gasLimit,
     }
-    opts.calcDifficultyFromHeader = genesis.header
+    opts.calcDifficultyFromHeader = genesisBlock.header
     const header1 = BlockHeader.fromHeaderData(headerData1, opts)
     const headers = [header1]
 
@@ -659,8 +660,8 @@ tape('blockchain test', (t) => {
     const blockData1 = {
       header: {
         number: 1,
-        parentHash: genesis.hash(),
-        timestamp: genesis.header.timestamp.addn(1),
+        parentHash: genesisBlock.hash(),
+        timestamp: genesisBlock.header.timestamp.addn(1),
         gasLimit,
       },
     }
@@ -671,11 +672,11 @@ tape('blockchain test', (t) => {
     }
 
     const blocks = [
-      genesis,
-      Block.fromBlockData(blockData1, { common, calcDifficultyFromHeader: genesis.header }),
+      genesisBlock,
+      Block.fromBlockData(blockData1, { common, calcDifficultyFromHeader: genesisBlock.header }),
       Block.fromBlockData(blockData2, {
         common: new Common({ chain: 'ropsten', hardfork: 'chainstart' }),
-        calcDifficultyFromHeader: genesis.header,
+        calcDifficultyFromHeader: genesisBlock.header,
       }),
     ]
 

--- a/packages/blockchain/test/reorg.ts
+++ b/packages/blockchain/test/reorg.ts
@@ -18,8 +18,12 @@ tape('reorg tests', (t) => {
     'should correctly reorg the chain if the total difficulty is higher on a lower block number than the current head block',
     async (st) => {
       const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
-      const blockchain = new Blockchain({ validateBlocks: true, validatePow: false, common })
-      await blockchain.putBlock(genesis, true)
+      const blockchain = new Blockchain({
+        validateBlocks: true,
+        validatePow: false,
+        common,
+        genesisBlock: genesis,
+      })
 
       const blocks_lowTD: Block[] = []
       const blocks_highTD: Block[] = []

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -37,15 +37,15 @@ export const generateBlocks = (numberOfBlocks: number, existingBlocks?: Block[])
 }
 
 export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block): Promise<any> => {
-  const blockchain = new Blockchain({
-    validateBlocks: true,
-    validatePow: false,
-  })
   const existingBlocks: Block[] = genesis ? [genesis] : []
   const blocks = generateBlocks(numberOfBlocks, existingBlocks)
 
+  const blockchain = new Blockchain({
+    validateBlocks: true,
+    validatePow: false,
+    genesisBlock: genesis || blocks[0],
+  })
   try {
-    await blockchain.putGenesis(blocks[0])
     await blockchain.putBlocks(blocks.slice(1))
   } catch (error) {
     return { error }

--- a/packages/vm/examples/run-blockchain/index.ts
+++ b/packages/vm/examples/run-blockchain/index.ts
@@ -12,10 +12,11 @@ async function main() {
   const validatePow = true
   const validateBlocks = true
 
-  const blockchain = new Blockchain({
+  const blockchain = await Blockchain.create({
     common,
     validatePow,
     validateBlocks,
+    genesisBlock: getGenesisBlock(common)
   })
 
   // When verifying PoW, setting this cache improves the
@@ -27,8 +28,6 @@ async function main() {
   const vm = new VM({ blockchain, common })
 
   await setupPreConditions(vm, testData)
-
-  await setGenesisBlock(blockchain, common)
 
   await putBlocks(blockchain, common, testData)
 
@@ -66,10 +65,10 @@ async function setupPreConditions(vm: VM, testData: any) {
   await vm.stateManager.commit()
 }
 
-async function setGenesisBlock(blockchain: any, common: Common) {
+function getGenesisBlock(common: Common) {
   const header = testData.genesisBlockHeader
   const genesis = Block.genesis({ header }, { common })
-  await blockchain.putGenesis(genesis)
+  return genesis
 }
 
 async function putBlocks(blockchain: any, common: Common, testData: any) {

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -1,7 +1,6 @@
 import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import { Account, Address } from 'ethereumjs-util'
 import Blockchain from '@ethereumjs/blockchain'
-import { Block } from '@ethereumjs/block'
 import Common from '@ethereumjs/common'
 import { StateManager, DefaultStateManager } from './state/index'
 import { default as runCode, RunCodeOpts } from './runCode'
@@ -90,11 +89,6 @@ export interface VMOpts {
    * Default: `false` [ONLY set to `true` during debugging]
    */
   allowUnlimitedContractSize?: boolean
-
-  /**
-   * Provide a non-canonical genesisBlock (non-canonical with respect to the `Common`) to initialize the blockchain with
-   */
-  genesisBlock?: Block
 }
 
 /**
@@ -205,8 +199,7 @@ export default class VM extends AsyncEventEmitter {
       })
     }
 
-    this.blockchain =
-      opts.blockchain || new Blockchain({ common: this._common, genesisBlock: opts.genesisBlock })
+    this.blockchain = opts.blockchain || new Blockchain({ common: this._common })
 
     this._allowUnlimitedContractSize = opts.allowUnlimitedContractSize || false
 

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -121,16 +121,15 @@ tape('VM with blockchain', (t) => {
 
   t.test('should run blockchain with mocked runBlock', async (st) => {
     const common = new Common({ chain: 'goerli' })
-    const vm = setupVM({ common })
-    await vm.init()
-
     const genesisRlp = Buffer.from(testData.genesisRLP.slice(2), 'hex')
-    const genesis = Block.fromRLPSerializedBlock(genesisRlp, { common })
+    const genesisBlock = Block.fromRLPSerializedBlock(genesisRlp, { common })
 
     const blockRlp = Buffer.from(testData.blocks[0].rlp.slice(2), 'hex')
     const block = Block.fromRLPSerializedBlock(blockRlp, { common })
 
-    await vm.blockchain.putGenesis(genesis)
+    const vm = setupVM({ common, genesisBlock })
+    await vm.init()
+
     st.equal(vm.blockchain.meta.genesis?.toString('hex'), testData.genesisBlockHeader.hash.slice(2))
 
     await vm.blockchain.putBlock(block)
@@ -152,16 +151,16 @@ tape('VM with blockchain', (t) => {
 
   t.test('should run blockchain with blocks', async (st) => {
     const common = new Common({ chain: 'goerli' })
-    const vm = setupVM({ common })
-    await vm.init()
 
     const genesisRlp = toBuffer(testData.genesisRLP)
-    const genesis = Block.fromRLPSerializedBlock(genesisRlp, { common })
+    const genesisBlock = Block.fromRLPSerializedBlock(genesisRlp, { common })
 
     const blockRlp = toBuffer(testData.blocks[0].rlp)
     const block = Block.fromRLPSerializedBlock(blockRlp, { common })
 
-    await vm.blockchain.putGenesis(genesis)
+    const vm = setupVM({ common, genesisBlock })
+    await vm.init()
+
     st.equal(vm.blockchain.meta.genesis?.toString('hex'), testData.genesisBlockHeader.hash.slice(2))
 
     await vm.blockchain.putBlock(block)

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -2,6 +2,7 @@ import { Account, BN } from 'ethereumjs-util'
 import Blockchain from '@ethereumjs/blockchain'
 import VM from '../../lib/index'
 import { VMOpts } from '../../lib'
+import { Block } from '@ethereumjs/block'
 
 const level = require('level-mem')
 
@@ -9,11 +10,17 @@ export function createAccount(nonce: BN = new BN(0), balance: BN = new BN(0xfff3
   return new Account(nonce, balance)
 }
 
-export function setupVM(opts: VMOpts = {}) {
+export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
   const db = level()
-  const common = opts.common
+  const { common, genesisBlock } = opts
   if (!opts.blockchain) {
-    opts.blockchain = new Blockchain({ db, validateBlocks: false, validatePow: false, common })
+    opts.blockchain = new Blockchain({
+      db,
+      validateBlocks: false,
+      validatePow: false,
+      common,
+      genesisBlock,
+    })
   }
   return new VM(opts)
 }


### PR DESCRIPTION
WIP. Cherry-picked from #895 and builds upon #927 

Closes #690 

This PR aims to:

- Fix concurrency issues when using the Blockchain (getters/setters now all wait)
- Document the library
- Make variable names more correct
- Make the library more readable (more docs, some (unnecessary?) recursion removed)

Also security:

- Genesis block should be put in the Blockchain constructor to prevent accidentally wiping the Genesis block from the DB / Tracking a completely other network (!)
- This also means that **putGenesis** is now not possible anymore. You set Genesis in constructor and it cannot change after that.
- Safe `static` constructor which throws if the `init` method throws