### PR TITLE
BlockHeader: Make BlockOptions param optional

### DIFF
--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -65,7 +65,7 @@ updated.
 
 There are three new factory methods to create a new `BlockHeader`:
 
-1. Pass in a Header-attribute named dictionary to `BlockHeader.fromHeaderData(headerData: HeaderData = {}, opts: BlockOptions = {})`:
+1. Pass in a Header-attribute named dictionary to `BlockHeader.fromHeaderData(headerData: HeaderData = {}, opts?: BlockOptions)`:
 
 ```typescript
 const headerData = {
@@ -75,7 +75,7 @@ const headerData = {
   gasLimit: 8000000,
   timestamp: 1562422144,
 }
-const header = BlockHeader.fromHeaderData(headerData, {})
+const header = BlockHeader.fromHeaderData(headerData)
 ```
 
 2. Create a `BlockHeader` from an RLP-serialized header `Buffer` with `BlockHeader.fromRLPSerializedHeader(serialized: Buffer, opts: BlockOptions)`.
@@ -83,16 +83,16 @@ const header = BlockHeader.fromHeaderData(headerData, {})
 ```typescript
 const serialized = Buffer.from(
   'f901f7a06bfee7294bf44572b7266358e627f3c35105e1c3851f3de09e6d646f955725a7a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000830200000f837a120080845d20ab8080a00000000000000000000000000000000000000000000000000000000000000000880000000000000000',
-  'hex',
+  'hex'
 )
-const header = BlockHeader.fromRLPSerializedHeader(serialized, {})
+const header = BlockHeader.fromRLPSerializedHeader(serialized)
 ```
 
 3. Create a `BlockHeader` from an array of `Buffer` values, you can do a first short roundtrip test with:
 
 ```typescript
 const valuesArray = header.raw()
-BlockHeader.fromValuesArray(valuesArray, {})
+BlockHeader.fromValuesArray(valuesArray)
 ```
 
 Generally internal types representing block header values are now closer to their domain representation
@@ -102,9 +102,9 @@ Generally internal types representing block header values are now closer to thei
 
 There are analogue new static factories for the `Block` class:
 
-- `Block.fromBlockData(blockData: BlockData = {}, opts: BlockOptions = {})`
-- `Block.fromRLPSerializedBlock(serialized: Buffer, opts: BlockOptions = {})`
-- `Block.fromValuesArray(values: BlockBuffer, opts: BlockOptions = {})`
+- `Block.fromBlockData(blockData: BlockData = {}, opts?: BlockOptions)`
+- `Block.fromRLPSerializedBlock(serialized: Buffer, opts?: BlockOptions)`
+- `Block.fromValuesArray(values: BlockBuffer, opts?: BlockOptions)`
 
 Learn more about the full API in the [docs](./docs/README.md).
 
@@ -143,7 +143,7 @@ try {
 
 ### Header Validation Methods > Signature Changes
 
-**Breaking**: The signatures of the following header validation methods have been updated to take a `parentBlockHeader` instead of a 
+**Breaking**: The signatures of the following header validation methods have been updated to take a `parentBlockHeader` instead of a
 `parentBlock` input parameter for consistency and removing a circling dependency with `Block`:
 
 - `BlockHeader.canonicalDifficulty(parentBlockHeader: BlockHeader): BN`
@@ -161,8 +161,8 @@ see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on 
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
+We significantly updated our internal tool and CI setup along the work on
+PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint`
 for code linting and formatting and the introduction of a new build setup.
 
 Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -17,7 +17,7 @@ export class Block {
   public readonly txTrie = new Trie()
   public readonly _common: Common
 
-  public static fromBlockData(blockData: BlockData = {}, opts: BlockOptions = {}) {
+  public static fromBlockData(blockData: BlockData = {}, opts?: BlockOptions) {
     const { header: headerData, transactions: txsData, uncleHeaders: uhsData } = blockData
 
     const header = BlockHeader.fromHeaderData(headerData, opts)
@@ -39,7 +39,7 @@ export class Block {
     return new Block(header, transactions, uncleHeaders)
   }
 
-  public static fromRLPSerializedBlock(serialized: Buffer, opts: BlockOptions = {}) {
+  public static fromRLPSerializedBlock(serialized: Buffer, opts?: BlockOptions) {
     const values = (rlp.decode(serialized) as any) as BlockBuffer
 
     if (!Array.isArray(values)) {
@@ -49,7 +49,7 @@ export class Block {
     return Block.fromValuesArray(values, opts)
   }
 
-  public static fromValuesArray(values: BlockBuffer, opts: BlockOptions = {}) {
+  public static fromValuesArray(values: BlockBuffer, opts?: BlockOptions) {
     if (values.length > 3) {
       throw new Error('invalid block. More values than expected were received')
     }
@@ -76,7 +76,7 @@ export class Block {
   /**
    * Alias for Block.fromBlockData() with initWithGenesisHeader set to true.
    */
-  public static genesis(blockData: BlockData = {}, opts: BlockOptions = {}) {
+  public static genesis(blockData: BlockData = {}, opts?: BlockOptions) {
     opts = { ...opts, initWithGenesisHeader: true }
     return Block.fromBlockData(blockData, opts)
   }

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -37,7 +37,7 @@ export class BlockHeader {
 
   public readonly _common: Common
 
-  public static fromHeaderData(headerData: HeaderData = {}, opts: BlockOptions = {}) {
+  public static fromHeaderData(headerData: HeaderData = {}, opts?: BlockOptions) {
     const {
       parentHash,
       uncleHash,
@@ -76,7 +76,7 @@ export class BlockHeader {
     )
   }
 
-  public static fromRLPSerializedHeader(serialized: Buffer, opts: BlockOptions) {
+  public static fromRLPSerializedHeader(serialized: Buffer, opts?: BlockOptions) {
     const values = rlp.decode(serialized)
 
     if (!Array.isArray(values)) {
@@ -86,7 +86,7 @@ export class BlockHeader {
     return BlockHeader.fromValuesArray(values, opts)
   }
 
-  public static fromValuesArray(values: BlockHeaderBuffer, opts: BlockOptions) {
+  public static fromValuesArray(values: BlockHeaderBuffer, opts?: BlockOptions) {
     if (values.length > 15) {
       throw new Error('invalid header. More values than expected were received')
     }
@@ -132,7 +132,7 @@ export class BlockHeader {
   /**
    * Alias for Header.fromHeaderData() with initWithGenesisHeader set to true.
    */
-  public static genesis(headerData: HeaderData = {}, opts: BlockOptions = {}) {
+  public static genesis(headerData: HeaderData = {}, opts?: BlockOptions) {
     opts = { ...opts, initWithGenesisHeader: true }
     return BlockHeader.fromHeaderData(headerData, opts)
   }

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -98,7 +98,7 @@ const format = (exports.format = function (
  * @param {TxOptions} opts Tx opts that can include an @ethereumjs/common object
  * @returns {Transaction} Transaction to be passed to VM.runTx function
  */
-export function makeTx(txData: any, opts: TxOptions = {}) {
+export function makeTx(txData: any, opts?: TxOptions) {
   const tx = Transaction.fromTxData(txData, opts)
 
   if (txData.secretKey) {
@@ -258,7 +258,7 @@ export function verifyLogs(logs: any, testData: any, t: tape.Test) {
   }
 }
 
-export function makeBlockHeader(data: any, opts: BlockOptions = {}) {
+export function makeBlockHeader(data: any, opts?: BlockOptions) {
   const {
     currentTimestamp,
     currentGasLimit,
@@ -285,7 +285,7 @@ export function makeBlockHeader(data: any, opts: BlockOptions = {}) {
  * @param uncleHeaders uncle headers for the block (optional)
  * @returns the block
  */
-export function makeBlockFromEnv(env: any, opts: BlockOptions = {}): Block {
+export function makeBlockFromEnv(env: any, opts?: BlockOptions): Block {
   const header = makeBlockHeader(env, opts)
   return new Block(header)
 }


### PR DESCRIPTION
This PR updates the `BlockHeader` factory methods to make the `BlockOptions` param optional.