### PR TITLE
Structural Preparations for PoA Support

### DIFF
--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -9,11 +9,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## 3.0.0-beta.2 - UNRELEASED
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 - Added `freeze` option to allow for block freeze deactivation (e.g. to allow for subclassing block and adding additional parameters), see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
 - Fixed bug where block options have not been passed on to the main constructor from the static factory methods, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
 =======
 - Block, header and uncle validation methods which include difficulty validation (`canonicalDifficulty()`, `validateDifficulty()`, `validate()`, `validateUncles()`) now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
 >>>>>>> block -> poa preparations: throw on block, header and uncle validation methods which include difficulty validation
+=======
+- **Breaking:** Block, header and uncle validation methods which include difficulty validation (`canonicalDifficulty()`, `validateDifficulty()`, `validate()`, `validateUncles()`) now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
+>>>>>>> blockchain -> poa preparations: validatePow to validateConsensus option renaming, throw on unsupported chain consensus types (PoA)
 
 ## 3.0.0-beta.1 - 2020-10-22
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -8,16 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 3.0.0-beta.2 - UNRELEASED
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 - Added `freeze` option to allow for block freeze deactivation (e.g. to allow for subclassing block and adding additional parameters), see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
+- **Breaking:** Difficulty-depending methods `canonicalDifficulty()` and `validateDifficulty()` in block and header now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
+- **Breaking:** Non-blockchain dependent validation checks have been extracted from `validate()` to its own `Block.validateData()` function. For the `validate()` method in block and header `blockchain` is now a mandatory parameter, see PR [#942](https://github.com/ethereumjs/ethereumjs-vm/pull/942)
 - Fixed bug where block options have not been passed on to the main constructor from the static factory methods, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
-=======
-- Block, header and uncle validation methods which include difficulty validation (`canonicalDifficulty()`, `validateDifficulty()`, `validate()`, `validateUncles()`) now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
->>>>>>> block -> poa preparations: throw on block, header and uncle validation methods which include difficulty validation
-=======
-- **Breaking:** Block, header and uncle validation methods which include difficulty validation (`canonicalDifficulty()`, `validateDifficulty()`, `validate()`, `validateUncles()`) now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
->>>>>>> blockchain -> poa preparations: validatePow to validateConsensus option renaming, throw on unsupported chain consensus types (PoA)
 
 ## 3.0.0-beta.1 - 2020-10-22
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -8,8 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 3.0.0-beta.2 - UNRELEASED
 
+<<<<<<< HEAD
 - Added `freeze` option to allow for block freeze deactivation (e.g. to allow for subclassing block and adding additional parameters), see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
 - Fixed bug where block options have not been passed on to the main constructor from the static factory methods, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
+=======
+- Block, header and uncle validation methods which include difficulty validation (`canonicalDifficulty()`, `validateDifficulty()`, `validate()`, `validateUncles()`) now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
+>>>>>>> block -> poa preparations: throw on block, header and uncle validation methods which include difficulty validation
 
 ## 3.0.0-beta.1 - 2020-10-22
 

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -148,7 +148,8 @@ export class Block {
   }
 
   /**
-   * Validates the transaction trie.
+   * Validates the transaction trie by generating a trie
+   * and do a check on the root hash.
    */
   async validateTransactionsTrie(): Promise<boolean> {
     if (this.transactions.length === 0) {
@@ -163,7 +164,7 @@ export class Block {
   }
 
   /**
-   * Validates the transactions.
+   * Validates transaction signatures and minimum gas requirements.
    *
    * @param stringError - If `true`, a string with the indices of the invalid txs is returned.
    */
@@ -184,7 +185,14 @@ export class Block {
   }
 
   /**
-   * Validates the block, throwing if invalid.
+   * Performs the following consistency checks on the block:
+   *
+   * - Value checks on the header fields
+   * - Signature and gasLimit validation for included txs
+   * - Validation of the tx trie
+   * - Consistency checks and header validation of included uncles
+   *
+   * Throws if invalid.
    *
    * @param blockchain - validate against a @ethereumjs/blockchain
    */
@@ -226,9 +234,12 @@ export class Block {
   }
 
   /**
-   * Validates the uncles that are in the block, if any. This method throws if they are invalid.
+   * Consistency checks and header validation for uncles included
+   * in the block, if any.
    *
-   * @param blockchain - additionally validate against a @ethereumjs/blockchain
+   * Throws if invalid.
+   *
+   * @param blockchain - additionally validate against an @ethereumjs/blockchain instance
    */
   async validateUncles(blockchain: Blockchain): Promise<void> {
     if (this.isGenesis()) {
@@ -268,7 +279,8 @@ export class Block {
   }
 
   /**
-   * Validates the gasLimit.
+   * Validates if the block gasLimit remains in the
+   * boundaries set by the protocol.
    *
    * @param parentBlock - the parent of this `Block`
    */

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -364,7 +364,8 @@ export class BlockHeader {
   }
 
   /**
-   * Validates the gasLimit.
+   * Validates if the block gasLimit remains in the
+   * boundaries set by the protocol.
    *
    * @param parentBlockHeader - the header from the parent `Block` of this header
    */
@@ -398,9 +399,6 @@ export class BlockHeader {
    * @param height - If this is an uncle header, this is the height of the block that is including it
    */
   async validate(blockchain: Blockchain, height?: BN): Promise<void> {
-    if (this._common.consensusType() !== 'pow') {
-      throw new Error('block validation is currently only supported on PoW chains')
-    }
     if (this.isGenesis()) {
       return
     }
@@ -424,8 +422,10 @@ export class BlockHeader {
       throw new Error('invalid timestamp')
     }
 
-    if (!this.validateDifficulty(header)) {
-      throw new Error('invalid difficulty')
+    if (this._common.consensusType() === 'pow') {
+      if (!this.validateDifficulty(header)) {
+        throw new Error('invalid difficulty')
+      }
     }
 
     if (!this.validateGasLimit(header)) {

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -269,6 +269,12 @@ export class BlockHeader {
    * @param parentBlockHeader - the header from the parent `Block` of this header
    */
   canonicalDifficulty(parentBlockHeader: BlockHeader): BN {
+    if (this._common.consensusType() !== 'pow') {
+      throw new Error('difficulty calculation is only supported on PoW chains')
+    }
+    if (this._common.consensusAlgorithm() !== 'ethash') {
+      throw new Error('difficulty calculation currently only supports the ethash algorithm')
+    }
     const hardfork = this._getHardfork()
     const blockTs = this.timestamp
     const { timestamp: parentTs, difficulty: parentDif } = parentBlockHeader
@@ -351,6 +357,9 @@ export class BlockHeader {
    * @param parentBlockHeader - the header from the parent `Block` of this header
    */
   validateDifficulty(parentBlockHeader: BlockHeader): boolean {
+    if (this._common.consensusType() !== 'pow') {
+      throw new Error('difficulty validation is currently only supported on PoW chains')
+    }
     return this.canonicalDifficulty(parentBlockHeader).eq(this.difficulty)
   }
 
@@ -389,6 +398,9 @@ export class BlockHeader {
    * @param height - If this is an uncle header, this is the height of the block that is including it
    */
   async validate(blockchain: Blockchain, height?: BN): Promise<void> {
+    if (this._common.consensusType() !== 'pow') {
+      throw new Error('block validation is currently only supported on PoW chains')
+    }
     if (this.isGenesis()) {
       return
     }

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -84,8 +84,10 @@ tape('[Block]: block functions', function (t) {
     const blockRlp = testData.blocks[0].rlp
     const common = new Common({ chain: 'goerli' })
     const block = Block.fromRLPSerializedBlock(blockRlp, { common })
+    const blockchain = new Mockchain()
+    await blockchain.putBlock(Block.fromRLPSerializedBlock(testData.genesisRLP))
     try {
-      await block.validate()
+      await block.validate(blockchain)
     } catch (error) {
       st.ok(error.toString().match(/block validation is currently only supported on PoW chains/))
     }

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -69,7 +69,7 @@ tape('[Block]: block functions', function (t) {
 
   const testData = require('./testdata/testdata.json')
 
-  t.test('should test block validation', async function (st) {
+  t.test('should test block validation on pow chain', async function (st) {
     const blockRlp = testData.blocks[0].rlp
     const block = Block.fromRLPSerializedBlock(blockRlp)
     const blockchain = new Mockchain()
@@ -78,6 +78,18 @@ tape('[Block]: block functions', function (t) {
       await block.validate(blockchain)
       st.end()
     })
+  })
+
+  t.test('should test block validation on poa chain', async function (st) {
+    const blockRlp = testData.blocks[0].rlp
+    const common = new Common({ chain: 'goerli' })
+    const block = Block.fromRLPSerializedBlock(blockRlp, { common })
+    try {
+      await block.validate()
+    } catch (error) {
+      st.ok(error.toString().match(/block validation is currently only supported on PoW chains/))
+    }
+    st.end()
   })
 
   async function testTransactionValidation(st: tape.Test, block: Block) {

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -40,6 +40,7 @@ Genesis handling has been reworked to now be safer and reduce the risk of wiping
 **Testing and CI**
 
 - Dedicated `blockchain` reorg test setup and executable test, PR [#926](https://github.com/ethereumjs/ethereumjs-vm/pull/926)
+- **Breaking:** `validatePow` option has been renamed to `validateConsensus` to prepare for a future integration of non-PoW (PoA) consensus mechanisms, `validateConsensus` as well as `validateBlocks` options now throw when set to `true` for validation on a non-PoW chain (determined by `Common`, e.g. 'goerli'), see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
 
 ## 5.0.0-beta.1 - 2020-10-22
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -144,8 +144,8 @@ export default class Blockchain implements BlockchainInterface {
       })
     }
 
-    this._validateConsensus = opts.validateConsensus !== undefined ? opts.validateConsensus : true
-    this._validateBlocks = opts.validateBlocks !== undefined ? opts.validateBlocks : true
+    this._validateConsensus = opts.validateConsensus ?? true
+    this._validateBlocks = opts.validateBlocks ?? true
 
     this.db = opts.db ? opts.db : level()
     this.dbManager = new DBManager(this.db, this._common)
@@ -467,10 +467,12 @@ export default class Blockchain implements BlockchainInterface {
         await block.validate(this)
       }
 
-      if (this._validateConsensus && this._ethash) {
-        const valid = await this._ethash.verifyPOW(block)
-        if (!valid) {
-          throw new Error('invalid POW')
+      if (this._validateConsensus) {
+        if (this._ethash) {
+          const valid = await this._ethash.verifyPOW(block)
+          if (!valid) {
+            throw new Error('invalid POW')
+          }
         }
       }
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -63,8 +63,8 @@ export interface BlockchainOptions {
   db?: LevelUp
 
   /**
-   * This flags indicates if a block should be validated by the consensus algorithm
-   * or protocol used by the chain.
+   * This flags indicates if a block should be validated along the consensus algorithm
+   * or protocol used by the chain, e.g. by verifying the PoW on the block.
    *
    * Supported: 'pow' with 'ethash' algorithm (taken from the `Common` instance)
    * Default: `true`.
@@ -72,12 +72,10 @@ export interface BlockchainOptions {
   validateConsensus?: boolean
 
   /**
-   * This flags indicates if blocks should be validated. See Block#validate for details. If
-   * `validate` is provided, this option takes its value. If neither `validate` nor this option are
-   * provided.
+   * This flag indicates if protocol-given consistency checks on
+   * block headers and included uncles and transactions should be performed,
+   * see Block#validate for details.
    *
-   * Supported: 'pow' with 'ethash' algorithm (taken from the `Common` instance)
-   * Default: `true`.
    */
   validateBlocks?: boolean
 
@@ -159,15 +157,6 @@ export default class Blockchain implements BlockchainInterface {
       }
 
       this._ethash = new Ethash(this.db)
-    }
-
-    if (this._validateBlocks) {
-      if (this._common.consensusType() !== 'pow') {
-        throw new Error('block validation only supported for pow chains')
-      }
-      if (this._common.consensusAlgorithm() !== 'ethash') {
-        throw new Error('block validation only supported for pow ethash algorithm')
-      }
     }
 
     this._heads = {}

--- a/packages/blockchain/test/index.ts
+++ b/packages/blockchain/test/index.ts
@@ -12,7 +12,7 @@ tape('blockchain test', (t) => {
   t.test('should not crash on getting head of a blockchain without a genesis', async (st) => {
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
     })
     await blockchain.getHead()
     st.end()
@@ -28,11 +28,30 @@ tape('blockchain test', (t) => {
     st.end()
   })
 
+  t.test('should only initialize with supported consensus validation options', (st) => {
+    let common = new Common({ chain: 'mainnet' })
+    st.doesNotThrow(() => {
+      new Blockchain({ common, validateConsensus: true })
+    })
+    st.doesNotThrow(() => {
+      new Blockchain({ common, validateBlocks: true })
+    })
+
+    common = new Common({ chain: 'goerli' })
+    st.throws(() => {
+      new Blockchain({ common, validateConsensus: true })
+    })
+    st.throws(() => {
+      new Blockchain({ common, validateBlocks: true })
+    })
+    st.end()
+  })
+
   t.test('should add a genesis block without errors', async (st) => {
     const genesisBlock = Block.genesis()
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
     await blockchain.initPromise
@@ -48,7 +67,7 @@ tape('blockchain test', (t) => {
     try {
       await Blockchain.create({
         validateBlocks: true,
-        validatePow: false,
+        validateConsensus: false,
         genesisBlock,
       })
     } catch (error) {
@@ -60,7 +79,7 @@ tape('blockchain test', (t) => {
   t.test('should initialize with a genesis block', async (st) => {
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
     })
     const blocks = await blockchain.getBlocks(0, 5, 0, false)
     st.equal(blocks!.length, 1)
@@ -76,7 +95,7 @@ tape('blockchain test', (t) => {
 
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -115,7 +134,7 @@ tape('blockchain test', (t) => {
 
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -148,7 +167,7 @@ tape('blockchain test', (t) => {
 
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
     const block = await blockchain.getBlock(genesisBlock.hash())
@@ -346,7 +365,7 @@ tape('blockchain test', (t) => {
   t.test('should not call iterator function in an empty blockchain', async (st) => {
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
     })
 
     await blockchain.iterator('test', () => {
@@ -458,7 +477,7 @@ tape('blockchain test', (t) => {
     const blocks = generateBlocks(15)
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock: blocks[0],
     })
     await blockchain.putBlock(blocks[1])
@@ -473,7 +492,7 @@ tape('blockchain test', (t) => {
     blocks.push(...generateBlocks(15, [genesisBlock]))
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
     await blockchain.putBlocks(blocks.slice(1))
@@ -501,7 +520,7 @@ tape('blockchain test', (t) => {
     const genesisBlock = Block.genesis({ header: { gasLimit: 8000000 } })
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -522,7 +541,7 @@ tape('blockchain test', (t) => {
     })
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -559,7 +578,7 @@ tape('blockchain test', (t) => {
     let blockchain = new Blockchain({
       db,
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -577,7 +596,7 @@ tape('blockchain test', (t) => {
     blockchain = new Blockchain({
       db,
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -597,7 +616,7 @@ tape('blockchain test', (t) => {
     const genesisBlock = Block.genesis({ header: { gasLimit } }, opts)
     const blockchain = new Blockchain({
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 
@@ -652,7 +671,6 @@ tape('blockchain test', (t) => {
 
   t.test('mismatched chains', async (st) => {
     const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
-
     const gasLimit = 8000000
 
     const genesisBlock = Block.genesis({ header: { gasLimit } }, { common })
@@ -683,7 +701,7 @@ tape('blockchain test', (t) => {
     const blockchain = new Blockchain({
       common,
       validateBlocks: true,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 

--- a/packages/blockchain/test/reorg.ts
+++ b/packages/blockchain/test/reorg.ts
@@ -20,7 +20,7 @@ tape('reorg tests', (t) => {
       const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
       const blockchain = new Blockchain({
         validateBlocks: true,
-        validatePow: false,
+        validateConsensus: false,
         common,
         genesisBlock: genesis,
       })

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -42,7 +42,7 @@ export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block
 
   const blockchain = new Blockchain({
     validateBlocks: true,
-    validatePow: false,
+    validateConsensus: false,
     genesisBlock: genesis || blocks[0],
   })
   try {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0-beta.2 - UNRELEASED
+
+- Added consensus information to chains, new functions `Common.consensusType()` for consensus type access ("pow" or "poa") and `Common.consensusAlgorithm()` to get the associated algorithm or protocol (e.g. "ethash" PoW algorithm or "clique" PoA protocol), see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
+
 ## 2.0.0-beta.1 - 2020-10-22
 
 ### New Package Name

--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -2,6 +2,10 @@
   "name": "goerli",
   "chainId": 5,
   "networkId": 5,
+  "consensus": {
+    "type": "poa",
+    "algorithm": "clique"
+  },
   "comment": "Cross-client PoA test network",
   "url": "https://github.com/goerli/testnet",
   "genesis": {

--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -2,6 +2,10 @@
   "name": "kovan",
   "chainId": 42,
   "networkId": 42,
+  "consensus": {
+    "type": "poa",
+    "algorithm": "aura"
+  },
   "comment": "Parity PoA test network",
   "url": "https://kovan-testnet.github.io/website/",
   "genesis": {

--- a/packages/common/src/chains/mainnet.json
+++ b/packages/common/src/chains/mainnet.json
@@ -2,6 +2,10 @@
   "name": "mainnet",
   "chainId": 1,
   "networkId": 1,
+  "consensus": {
+    "type": "pow",
+    "algorithm": "ethash"
+  },
   "comment": "The Ethereum main chain",
   "url": "https://ethstats.net/",
   "genesis": {

--- a/packages/common/src/chains/rinkeby.json
+++ b/packages/common/src/chains/rinkeby.json
@@ -2,6 +2,10 @@
   "name": "rinkeby",
   "chainId": 4,
   "networkId": 4,
+  "consensus": {
+    "type": "poa",
+    "algorithm": "clique"
+  },
   "comment": "PoA test network",
   "url": "https://www.rinkeby.io",
   "genesis": {

--- a/packages/common/src/chains/ropsten.json
+++ b/packages/common/src/chains/ropsten.json
@@ -2,6 +2,10 @@
   "name": "ropsten",
   "chainId": 3,
   "networkId": 3,
+  "consensus": {
+    "type": "pow",
+    "algorithm": "ethash"
+  },
   "comment": "PoW test network",
   "url": "https://github.com/ethereum/ropsten",
   "genesis": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -631,4 +631,22 @@ export default class Common {
   eips(): number[] {
     return this._eips
   }
+
+  /**
+   * Returns the consensus type of the network
+   * Possible values: "pow"|"poa"
+   */
+  consensusType(): string {
+    return (<any>this._chainParams)['consensus']['type']
+  }
+
+  /**
+   * Returns the concrete consensus implementation
+   * algorithm or protocol for the network
+   * e.g. "ethash" for "pow" consensus type or
+   * "clique" for "poa" consensus type
+   */
+  consensusAlgorithm(): string {
+    return (<any>this._chainParams)['consensus']['algorithm']
+  }
 }

--- a/packages/common/tests/chains.ts
+++ b/packages/common/tests/chains.ts
@@ -73,6 +73,8 @@ tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
     st.equal(c.genesis().hash, hash, 'should return correct genesis hash')
     st.equal(c.hardforks()[3]['block'], 2463000, 'should return correct hardfork data')
     st.equal(typeof c.bootstrapNodes()[0].port, 'number', 'should return a port as number')
+    st.equal(c.consensusType(), 'pow', 'should return correct consensus type')
+    st.equal(c.consensusAlgorithm(), 'ethash', 'should return correct consensus algorithm')
     st.end()
   })
 

--- a/packages/tx/src/transaction.ts
+++ b/packages/tx/src/transaction.ts
@@ -226,7 +226,9 @@ export default class Transaction {
    */
   verifySignature(): boolean {
     try {
-      return unpadBuffer(this.getSenderPublicKey()).length !== 0
+      // Main signature verification is done in `getSenderPublicKey()`
+      const publicKey = this.getSenderPublicKey()
+      return unpadBuffer(publicKey).length !== 0
     } catch (e) {
       return false
     }
@@ -308,7 +310,9 @@ export default class Transaction {
   }
 
   /**
-   * Validates the signature and checks to see if it has enough gas.
+   * Validates the signature and checks if
+   * the transaction has the minimum amount of gas required
+   * (DataFee + TxFee + Creation Fee).
    */
   validate(): boolean
   validate(stringError: false): boolean

--- a/packages/vm/examples/run-blockchain/index.ts
+++ b/packages/vm/examples/run-blockchain/index.ts
@@ -9,12 +9,12 @@ const level = require('level')
 
 async function main() {
   const common = new Common({ chain: testData.network.toLowerCase() })
-  const validatePow = true
+  const validatePow = common.consensusType() === 'pow'
   const validateBlocks = true
 
   const blockchain = await Blockchain.create({
     common,
-    validatePow,
+    validateConsensus: validatePow,
     validateBlocks,
     genesisBlock: getGenesisBlock(common)
   })
@@ -22,7 +22,7 @@ async function main() {
   // When verifying PoW, setting this cache improves the
   // performance of subsequent runs of this script.
   if (validatePow) {
-    blockchain.ethash!.cacheDB = level('./.cachedb')
+    blockchain._ethash!.cacheDB = level('./.cachedb')
   }
 
   const vm = new VM({ blockchain, common })

--- a/packages/vm/examples/run-blockchain/index.ts
+++ b/packages/vm/examples/run-blockchain/index.ts
@@ -21,6 +21,8 @@ async function main() {
 
   // When verifying PoW, setting this cache improves the
   // performance of subsequent runs of this script.
+  // Note that this optimization is a bit hacky and might
+  // not be working in the future though. :-)
   if (validatePow) {
     blockchain._ethash!.cacheDB = level('./.cachedb')
   }

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -150,7 +150,7 @@ tape('VM with blockchain', (t) => {
   })
 
   t.test('should run blockchain with blocks', async (st) => {
-    const common = new Common({ chain: 'goerli' })
+    const common = new Common({ chain: 'ropsten' })
 
     const genesisRlp = toBuffer(testData.genesisRLP)
     const genesisBlock = Block.fromRLPSerializedBlock(genesisRlp, { common })
@@ -175,14 +175,14 @@ tape('VM with blockchain', (t) => {
   })
 
   t.test('should pass the correct Common object when copying the VM', async (st) => {
-    const vm = setupVM({ common: new Common({ chain: 'goerli', hardfork: 'byzantium' }) })
+    const vm = setupVM({ common: new Common({ chain: 'ropsten', hardfork: 'byzantium' }) })
     await vm.init()
 
-    st.equal(vm._common.chainName(), 'goerli')
+    st.equal(vm._common.chainName(), 'ropsten')
     st.equal(vm._common.hardfork(), 'byzantium')
 
     const copiedVM = vm.copy()
-    st.equal(copiedVM._common.chainName(), 'goerli')
+    st.equal(copiedVM._common.chainName(), 'ropsten')
     st.equal(copiedVM._common.hardfork(), 'byzantium')
 
     st.end()

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -18,7 +18,7 @@ tape('runBlockchain', (t) => {
     db: blockchainDB,
     common,
     validateBlocks: false,
-    validatePow: false,
+    validateConsensus: false,
   })
 
   const stateManager = new DefaultStateManager({ common })

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -53,7 +53,7 @@ tape('runBlockchain', (t) => {
         db: blockchainDB,
         common,
         validateBlocks: false,
-        validatePow: false,
+        validateConsensus: false,
         genesisBlock,
       })
 
@@ -85,7 +85,7 @@ tape('runBlockchain', (t) => {
       db: blockchainDB,
       common,
       validateBlocks: false,
-      validatePow: false,
+      validateConsensus: false,
       genesisBlock,
     })
 

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -17,9 +17,9 @@ export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
     opts.blockchain = new Blockchain({
       db,
       validateBlocks: false,
-      validatePow: false,
+      validateConsensus: false,
       common,
-      genesisBlock,
+      genesisBlock
     })
   }
   return new VM(opts)

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -19,7 +19,7 @@ export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
       validateBlocks: false,
       validateConsensus: false,
       common,
-      genesisBlock
+      genesisBlock,
     })
   }
   return new VM(opts)


### PR DESCRIPTION
This PR provides some ground for a future PoA support, see #689. I am doing this now since I hope that this will allow us for a future PoA feature addition without the need for another major release respectively introducing breaking changes. I have done some reading along on the Clique PoA [EIP-225](https://eips.ethereum.org/EIPS/eip-225) and I think this should get a solid enough structural setup with this PR which should allow for non-breaking integration (by adding signer validation on PoA chains along an activated `Blockchain.validateConsensus` setting), this might benefit from some validation though.

The PR introduces code parts to now throw on `Block` or `Blockchain` validation triggers on setups which we just don't support yet (validate blocks on 'goerli') or which doesn't make sense (run 'validateDifficulty()' on goerli) and therefore reduces undefined behavior within the libraries.

@jochem-brouwer if this PR is supported and reviewed, we can merge on top of your blockchain refactoring changes with me rebasing or the the other way around, as you prefer.