### PR TITLE
Block: make blockchain mandatory in validation methods

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -186,11 +186,22 @@ export class Block {
   /**
    * Validates the block, throwing if invalid.
    *
-   * @param blockchain - additionally validate against a @ethereumjs/blockchain
+   * @param blockchain - validate against a @ethereumjs/blockchain
    */
-  async validate(blockchain?: Blockchain): Promise<void> {
+  async validate(blockchain: Blockchain): Promise<void> {
     await this.header.validate(blockchain)
-
+    await this.validateUncles(blockchain)
+    await this.validateData()
+  }
+  /**
+   * Validates the block data, throwing if invalid.
+   * This can be checked on the Block itself without needing access to any parent block
+   * It checks:
+   * - All transactions are valid
+   * - The transactions trie is valid
+   * - The uncle hash is valid
+   */
+  async validateData(): Promise<void> {
     const txErrors = this.validateTransactions(true)
     if (txErrors.length > 0) {
       throw new Error(`invalid transactions: ${txErrors.join(' ')}`)
@@ -200,8 +211,6 @@ export class Block {
     if (!validateTxTrie) {
       throw new Error('invalid transaction trie')
     }
-
-    await this.validateUncles(blockchain)
 
     if (!this.validateUnclesHash()) {
       throw new Error('invalid uncle hash')
@@ -221,7 +230,7 @@ export class Block {
    *
    * @param blockchain - additionally validate against a @ethereumjs/blockchain
    */
-  async validateUncles(blockchain?: Blockchain): Promise<void> {
+  async validateUncles(blockchain: Blockchain): Promise<void> {
     if (this.isGenesis()) {
       return
     }
@@ -278,7 +287,7 @@ export class Block {
     }
   }
 
-  private _validateUncleHeader(uncleHeader: BlockHeader, blockchain?: Blockchain) {
+  private _validateUncleHeader(uncleHeader: BlockHeader, blockchain: Blockchain) {
     // TODO: Validate that the uncle header hasn't been included in the blockchain yet.
     // This is not possible in ethereumjs-blockchain since this PR was merged:
     // https://github.com/ethereumjs/ethereumjs-blockchain/pull/47

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -221,7 +221,7 @@ export class BlockHeader {
     this.nonce = nonce
 
     this._validateBufferLengths()
-    this._verifyExtraData()
+    this._checkDAOExtraData()
 
     // Now we have set all the values of this Header, we possibly have set a dummy
     // `difficulty` value (defaults to 0). If we have a `calcDifficultyFromHeader`
@@ -261,21 +261,6 @@ export class BlockHeader {
     if (nonce.length !== 8) {
       throw new Error(`nonce must be 8 bytes, received ${nonce.length} bytes`)
     }
-  }
-
-  /**
-   * Validates the extra data, throws if invalid
-   */
-  _verifyExtraData() {
-    if (!this.isGenesis()) {
-      const hardfork = this._getHardfork()
-      if (
-        this.extraData.length > this._common.paramByHardfork('vm', 'maxExtraDataSize', hardfork)
-      ) {
-        throw new Error('invalid amount of extra data')
-      }
-    }
-    this._checkDAOExtraData()
   }
 
   /**
@@ -407,6 +392,11 @@ export class BlockHeader {
     if (this.isGenesis()) {
       return
     }
+    const hardfork = this._getHardfork()
+    if (this.extraData.length > this._common.paramByHardfork('vm', 'maxExtraDataSize', hardfork)) {
+      throw new Error('invalid amount of extra data')
+    }
+
     const header = await this._getHeaderByHash(blockchain, this.parentHash)
 
     if (!header) {

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -2,6 +2,7 @@ import tape from 'tape'
 import { rlp, zeros } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block, BlockBuffer } from '../src'
+import { Mockchain } from './mockchain'
 
 tape('[Block]: block functions', function (t) {
   t.test('should test block initialization', function (st) {
@@ -71,8 +72,10 @@ tape('[Block]: block functions', function (t) {
   t.test('should test block validation', async function (st) {
     const blockRlp = testData.blocks[0].rlp
     const block = Block.fromRLPSerializedBlock(blockRlp)
+    const blockchain = new Mockchain()
+    await blockchain.putBlock(Block.fromRLPSerializedBlock(testData.genesisRLP))
     st.doesNotThrow(async () => {
-      await block.validate()
+      await block.validate(blockchain)
       st.end()
     })
   })

--- a/packages/block/test/mockchain.ts
+++ b/packages/block/test/mockchain.ts
@@ -1,0 +1,13 @@
+import { Block, Blockchain } from '../src'
+
+// Helper class to setup a mock Blockchain
+
+export class Mockchain implements Blockchain {
+  private HashMap: { [key: string]: Block } = {}
+  async getBlock(hash: Buffer) {
+    return this.HashMap[hash.toString('hex')]
+  }
+  async putBlock(block: Block) {
+    this.HashMap[block.hash().toString('hex')] = block
+  }
+}


### PR DESCRIPTION
This PR: 

- Makes `blockchain` parameter mandatory in `validate` methods of `Block` and `BlockHeader`
- Adds `validateData` method to `Block`
- ~~Hoists the `extraData` check to the constructor of `BlockHeader`~~

Rationale:
If you called `validate` in `BlockHeader` without a `blockchain`, the **only check** which is being done is checking that `extraData.length` is within the current bounds of the maximum `extraData`. This can give consumers the false idea that the header is correct, but the method does practically nothing.

Validate is now explicitly used to `validate` against the parent `BlockHeader` (or `Block`). There is an additional function in `Block` which has the logic which does not need `blockchain` in case a consumer does have a block but no access to a blockchain. (We cannot do all this in the constructor of the Block, as we need access to Trie here which is async).

Note: hoisting the `extraData` check to the constructor makes the Ethash test fail, will open an issue for this, looks like this data is invalid (?). See #943 

This mandatory `blockchain` parameter is necessary in #933, this PR simply ensures that we make this parameter mandatory so we can work on this uncle validation logic in the future.