### PR TITLE
Small Release/README Fixes

### DIFF
--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -1,4 +1,4 @@
-# ethereumjs-block
+# @ethereumjs/block
 
 [![NPM Package][block-npm-badge]][block-npm-link]
 [![GitHub Issues][block-issues-badge]][block-issues-link]
@@ -6,7 +6,8 @@
 [![Code Coverage][block-coverage-badge]][block-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-Implements schema and functions related to Ethereum's block.
+| Implements schema and functions related to Ethereum's block. |
+| --- |
 
 Note: this `README` reflects the state of the library from `v3.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethereumjs-block) for an introduction on the last preceeding release.
 

--- a/packages/blockchain/README.md
+++ b/packages/blockchain/README.md
@@ -1,4 +1,4 @@
-# ethereumjs-blockchain
+# @ethereumjs/blockchain
 
 [![NPM Package][blockchain-npm-badge]][blockchain-npm-link]
 [![GitHub Issues][blockchain-issues-badge]][blockchain-issues-link]
@@ -6,7 +6,8 @@
 [![Code Coverage][blockchain-coverage-badge]][blockchain-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-A module to store and interact with blocks.
+| A module to store and interact with blocks. |
+| --- |
 
 Note: this `README` reflects the state of the library from `v5.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethereumjs-blockchain) for an introduction on the last preceeding release.
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -116,7 +116,7 @@ There are two ways to set up a common instance with parameters for a private/cus
 The `hardfork` can be set in constructor like this:
 
 ```typescript
-const c = new Common({ chain: 'ropsten', 'byzantium' })
+const c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
 ```
 
 ### Active Hardforks

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,4 +1,4 @@
-# ethereumjs-common
+# @ethereumjs/common
 
 [![NPM Package][common-npm-badge]][common-npm-link]
 [![GitHub Issues][common-issues-badge]][common-issues-link]
@@ -6,7 +6,8 @@
 [![Code Coverage][common-coverage-badge]][common-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-Resources common to all Ethereum implementations.
+| Resources common to all Ethereum implementations. |
+| --- |
 
 Note: this `README` reflects the state of the library from `v2.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethereumjs-common) for an introduction on the last preceeding release.
 
@@ -68,50 +69,15 @@ to ease `blockNumber` based access to parameters.
 
 - [API Docs](./docs/README.md)
 
-# Hardfork Params
+# SETUP
 
-## Active Hardforks
+## Chains
 
-There are currently parameter changes by the following past and future hardfork by the
-library supported:
+The `chain` can be set in the constructor like this:
 
-- `chainstart`
-- `homestead`
-- `dao`
-- `tangerineWhistle`
-- `spuriousDragon`
-- `byzantium`
-- `constantinople`
-- `petersburg` (aka `constantinopleFix`, apply together with `constantinople`)
-- `istanbul` (`DEFAULT_HARDFORK` (`v2.0.0` release series))
-- `muirGlacier` (since `v1.5.0`)
-
-## Future Hardforks
-
-General support for the `berlin` hardfork has been added along `v2.0.0`, specification of the hardfork regarding EIPs included was not finalized upon release date.
-
-Currently supported `berlin` EIPs:
-
-- `EIP-2315`
-
-## Parameter Access
-
-For hardfork-specific parameter access with the `param()` and `paramByBlock()` functions
-you can use the following `topics`:
-
-- `gasConfig`
-- `gasPrices`
-- `vm`
-- `pow`
-
-See one of the hardfork files like `byzantium.json` in the `hardforks` directory
-for an overview. For consistency, the chain start (`chainstart`) is considered an own
-hardfork.
-
-The hardfork-specific json files only contain the deltas from `chainstart` and
-shouldn't be accessed directly until you have a specific reason for it.
-
-# Chain Params
+```typescript
+const c = new Common({ chain: 'ropsten' })
+```
 
 Supported chains:
 
@@ -136,7 +102,7 @@ The following chain-specific parameters are provided:
 To get an overview of the different parameters have a look at one of the chain-specifc
 files like `mainnet.json` in the `chains` directory, or to the `Chain` type in [./src/types.ts](./src/types.ts).
 
-## Working with private/custom chains
+### Working with private/custom chains
 
 There are two ways to set up a common instance with parameters for a private/custom chain:
 
@@ -145,12 +111,75 @@ There are two ways to set up a common instance with parameters for a private/cus
 
 2. You can base your custom chain's config in a standard one, using the `Common.forCustomChain` method.
 
-# Bootstrap Nodes
+## Hardforks
+
+The `hardfork` can be set in constructor like this:
+
+```typescript
+const c = new Common({ chain: 'ropsten', 'byzantium' })
+```
+
+### Active Hardforks
+
+There are currently parameter changes by the following past and future hardfork by the
+library supported:
+
+- `chainstart`
+- `homestead`
+- `dao`
+- `tangerineWhistle`
+- `spuriousDragon`
+- `byzantium`
+- `constantinople`
+- `petersburg` (aka `constantinopleFix`, apply together with `constantinople`)
+- `istanbul` (`DEFAULT_HARDFORK` (`v2.0.0` release series))
+- `muirGlacier` (since `v1.5.0`)
+
+### Future Hardforks
+
+General support for the `berlin` hardfork has been added along `v2.0.0`, specification of the hardfork regarding EIPs included was not finalized upon release date.
+
+Currently supported `berlin` EIPs:
+
+- `EIP-2315`
+
+### Parameter Access
+
+For hardfork-specific parameter access with the `param()` and `paramByBlock()` functions
+you can use the following `topics`:
+
+- `gasConfig`
+- `gasPrices`
+- `vm`
+- `pow`
+
+See one of the hardfork files like `byzantium.json` in the `hardforks` directory
+for an overview. For consistency, the chain start (`chainstart`) is considered an own
+hardfork.
+
+The hardfork-specific json files only contain the deltas from `chainstart` and
+shouldn't be accessed directly until you have a specific reason for it.
+
+## EIPs
+
+Starting with the `v2.0.0` release of the library, EIPs are now native citizens within the library
+and can be activated like this:
+
+```typescript
+const c = new Common({ chain: 'mainnet', eips: [2537] })
+```
+
+The following EIPs are currently supported:
+
+- [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537): BLS precompiles
+- [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929): gas cost increases for state access opcodes
+
+## Bootstrap Nodes
 
 There is no separate config file for bootstrap nodes like in the old `ethereum-common` library.
 Instead use the `common.bootstrapNodes()` function to get nodes for a specific chain/network.
 
-# Genesis States
+## Genesis States
 
 Network-specific genesis files are located in the `genesisStates` folder.
 

--- a/packages/ethash/README.md
+++ b/packages/ethash/README.md
@@ -6,7 +6,7 @@
 [![Code Coverage][ethash-coverage-badge]][ethash-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-| Implements [Ethash](https://github.com/ethereum/wiki/wiki/Ethash). |
+| [Ethash](https://github.com/ethereum/wiki/wiki/Ethash) implementation in TypeScript. |
 | --- |
 
 Note: this `README` reflects the state of the library from `v1.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethashjs) for an introduction on the last preceeding release.

--- a/packages/ethash/README.md
+++ b/packages/ethash/README.md
@@ -6,7 +6,8 @@
 [![Code Coverage][ethash-coverage-badge]][ethash-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-Implements [Ethash](https://github.com/ethereum/wiki/wiki/Ethash).
+| Implements [Ethash](https://github.com/ethereum/wiki/wiki/Ethash). |
+| --- |
 
 Note: this `README` reflects the state of the library from `v1.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethashjs) for an introduction on the last preceeding release.
 
@@ -90,7 +91,7 @@ An `Object` containing:
 
 # TESTS
 
-`npm test`
+`npm run test`
 
 # LICENSE
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 3.0.0-beta.2 - 2020-11-12
 
+This is the second beta release towards a final library release, see [beta.1 release notes](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Ftx%403.0.0-beta.1) for an overview on the full changes since the last publicly released version.
+
 - Added `freeze` option to allow for transaction freeze deactivation (e.g. to allow for subclassing tx and adding additional parameters), see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
 - **Breaking:** Reworked constructor to take in data as a `TxData` typed dictionary instead of single values, the `Tx.fromTxData()` factory method becomes an alias for the constructor with this change, see PR [#944](https://github.com/ethereumjs/ethereumjs-vm/pull/944)
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -6,6 +6,9 @@
 [![Code Coverage][tx-coverage-badge]][tx-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
+| Implements schema and functions related to Ethereum's transaction. |
+| --- |
+
 Note: this `README` reflects the state of the library from `v3.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethereumjs-tx) for an introduction on the last preceeding release.
 
 # INSTALL
@@ -65,21 +68,23 @@ _getFakeTransaction(txParams: TxParams): Transaction {
 }
 ```
 
-# Chain and Hardfork Support
+# SETUP
+
+## Chain and Hardfork Support
 
 The `Transaction` constructor receives a parameter of an [`@ethereumjs/common`](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common) object that lets you specify the chain and hardfork to be used. By default, `mainnet` and `istanbul` will be used.
 
-## MuirGlacier Support
+### MuirGlacier Support
 
 The `MuirGlacier` hardfork is supported by the library since the `v2.1.2` release.
 
-## Istanbul Support
+### Istanbul Support
 
 Support for reduced non-zero call data gas prices from the `Istanbul` hardfork
 ([EIP-2028](https://eips.ethereum.org/EIPS/eip-2028)) has been added to the library
 along with the `v2.1.1` release.
 
-# EIP-155 support
+## EIP-155 support
 
 `EIP-155` replay protection is activated since the `spuriousDragon` hardfork. To disable it, set the hardfork to one earlier than `spuriousDragon`.
 

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -6,7 +6,7 @@
 [![Code Coverage][vm-coverage-badge]][vm-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-| Implements Ethereum's VM in TypeScript. |
+| TypeScript implementation of the Ethereum VM. |
 | --- |
 
 Note: this `README` reflects the state of the library from `v5.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethereumjs-vm) for an introduction on the last preceeding release.

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -1,4 +1,4 @@
-# ethereumjs-vm
+# @ethereumjs/vm
 
 [![NPM Package][vm-npm-badge]][vm-npm-link]
 [![GitHub Issues][vm-issues-badge]][vm-issues-link]
@@ -6,7 +6,8 @@
 [![Code Coverage][vm-coverage-badge]][vm-coverage-link]
 [![Discord][discord-badge]][discord-link]
 
-Implements Ethereum's VM in `TypeScript`.
+| Implements Ethereum's VM in TypeScript. |
+| --- |
 
 Note: this `README` reflects the state of the library from `v5.0.0` onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/ethereumjs-vm) for an introduction on the last preceeding release.
 


### PR DESCRIPTION
This PR fixes some inconsistencies within the README files discovered while browsing through the repository after having done the `beta.2` releases.

Changes are mostly header updates and headline hierarchy corrections, also some small rewrites.

The eventually somewhat unusual (or: not so commonly spotted) subtitle formatting is a table header without a body and renders like the following:

![Bildschirmfoto 2020-11-12 um 10 55 51](https://user-images.githubusercontent.com/931137/98927501-e779ff00-24d8-11eb-8d1a-26cd860422da.png)
