### PR TITLE
ci: disabling most of the hardfork-specific tests

### DIFF
--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -53,15 +53,15 @@ jobs:
       matrix:
         fork: [
           'Berlin',
-          'MuirGlacier',
+          # 'MuirGlacier',
           'Istanbul',
-          'Petersburg',
-          'Constantinople',
-          'Byzantium',
-          'SpuriousDragon',
-          'TangerineWhistle',
-          'Homestead',
-          'Chainstart'
+          # 'Petersburg',
+          # 'Constantinople',
+          # 'Byzantium',
+          # 'SpuriousDragon',
+          # 'TangerineWhistle',
+          # 'Homestead',
+          # 'Chainstart'
         ]
       fail-fast: false
     steps:
@@ -93,17 +93,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Args to pass to the tester. Note that some have splitted the slow tests and only running those: these are only on forks where that is applicable (see PR #489 for numbers on these)
+        # Args to pass to the tester. Note that some have splitted the slow tests and only 
+        #   running those: these are only on forks where that is applicable (see PR #489 for numbers on these)
+        
+        # Tests were splitted with --dir and --excludeDir to balance execution times below the 9min mark.
         args: [
-          '--fork=Chainstart --expected-test-amount=4385',
-          '--fork=Homestead --expected-test-amount=6997',
-          '--fork=Petersburg --excludeDir=stTimeConsuming --expected-test-amount=17174',
-          '--fork=Petersburg --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
-          '--fork=Constantinople --excludeDir=stTimeConsuming --expected-test-amount=17193',
-          '--fork=Constantinople --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
-          '--fork=Istanbul --excludeDir=stTimeConsuming --expected-test-amount=19817',
+          '--fork=Berlin --expected-test-amount=33',
           '--fork=Istanbul --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
-          '--fork=Berlin --expected-test-amount=33'
+          '--fork=Istanbul --excludeDir=stTimeConsuming --expected-test-amount=19817',
+          # '--fork=Constantinople --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
+          # '--fork=Constantinople --excludeDir=stTimeConsuming --expected-test-amount=17193',
+          # '--fork=Petersburg --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
+          # '--fork=Petersburg --excludeDir=stTimeConsuming --expected-test-amount=17174',
+          # '--fork=Homestead --expected-test-amount=6997',
+          # '--fork=Chainstart --expected-test-amount=4385'
         ]
       fail-fast: false
     steps:

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -52,8 +52,8 @@ jobs:
     strategy:
       matrix:
         fork: [
-          'Berlin',
-          # 'MuirGlacier',
+          # 'Berlin',
+          'MuirGlacier',
           'Istanbul',
           # 'Petersburg',
           # 'Constantinople',
@@ -98,7 +98,7 @@ jobs:
         
         # Tests were splitted with --dir and --excludeDir to balance execution times below the 9min mark.
         args: [
-          '--fork=Berlin --expected-test-amount=33',
+          # '--fork=Berlin --expected-test-amount=33',
           '--fork=Istanbul --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
           '--fork=Istanbul --excludeDir=stTimeConsuming --expected-test-amount=19817',
           # '--fork=Constantinople --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:ethash": "npm run build:tree -- --scope @ethereumjs/ethash",
     "build:tx": "npm run build:tree -- --scope @ethereumjs/tx",
     "build:vm": "npm run build:tree -- --scope @ethereumjs/vm",
-    "lint": "lerna run lint --stream --parallel",
+    "lint": "lerna run lint --stream --parallel -- --mode compact",
     "lint:fix": "lerna run lint:fix --stream --parallel",
     "test": "lerna exec npm run test --parallel",
     "coverage": "lerna run coverage --stream",


### PR DESCRIPTION
As promised, this PR disables most of the hardfork specific tests, to favor job concurrency. 

It can be easily reverted, by un-commenting those lines.