### PR TITLE
Audit dependencies and clean up dependency tree

### DIFF
--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -44,7 +44,6 @@
     "@types/tape": "^4.13.0",
     "@typescript-eslint/eslint-plugin": "^4.1.1",
     "browserify": "^16.5.1",
-    "contributor": "^0.1.25",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-implicit-dependencies": "^1.0.4",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -54,7 +54,7 @@
     "merkle-patricia-tree": "^4.0.0",
     "rustbn.js": "~0.2.0",
     "util.promisify": "^1.0.1",
-    "mcl-wasm": "^0.4.5"
+    "mcl-wasm": "^0.7.1"
   },
   "devDependencies": {
     "@ethereumjs/config-coverage": "^2.0.0",


### PR DESCRIPTION
This PR fixes #952 issue to remove vulnerable dependencies from EthereumJS libraries.

### TODOLIST

#### `@ethereumjs/block`

|  | Found | Fixed |
|--|--|--|
| deps | 0 | 0 |
| dev-deps | 0 | 0 |

#### `@ethereumjs/blockchain`

|  | Found | Fixed |
|--|--|--|
| deps | 0 | 0 |
| dev-deps | 0 | 0 |

#### `@ethereumjs/common`

|  | Found | Fixed |
|--|--|--|
| deps | 0 | 0 |
| dev-deps | 0 | 0 |

#### `@ethereumjs/ethash`

|  | Found | Fixed |
|--|--|--|
| deps | 0 | 0 |
| dev-deps | 0 | 0 |

#### `@ethereumjs/tx`

|  | Found | Fixed |
|--|--|--|
| deps | 0 | 0 |
| dev-deps | 9 | 9 |

- Removed redundant [contributor](https://www.npmjs.com/package/contributor) package. Reason: dependency is not in use.

#### `@ethereumjs/vm`

|  | Found | Fixed |
|--|--|--|
| deps | 0 | 0 |
| dev-deps | 144 | 0 |
