### PR TITLE
Public Blockchain.getTotalDifficulty() method

### DIFF
--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.0.0-rc.1 UNRELEASED
+
+- Exposed private `Blockchain._getTd()` total difficulty function as `Blockchain.getTotalDifficulty()`, PR [#956](https://github.com/ethereumjs/ethereumjs-vm/issues/956)
+
 ## 5.0.0-beta.2 - 2020-11-12
 
 This is the second beta release towards a final library release, see [beta.1 release notes](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fblockchain%405.0.0-beta.1) for an overview on the full changes since the last publicly released version.

--- a/packages/blockchain/docs/README.md
+++ b/packages/blockchain/docs/README.md
@@ -6,4 +6,9 @@
 
 ### Modules
 
+* ["db/cache"](modules/_db_cache_.md)
+* ["db/constants"](modules/_db_constants_.md)
+* ["db/helpers"](modules/_db_helpers_.md)
+* ["db/manager"](modules/_db_manager_.md)
+* ["db/operation"](modules/_db_operation_.md)
 * ["index"](modules/_index_.md)

--- a/packages/blockchain/docs/classes/_db_helpers_.dbop.md
+++ b/packages/blockchain/docs/classes/_db_helpers_.dbop.md
@@ -1,0 +1,116 @@
+[@ethereumjs/blockchain](../README.md) › ["db/helpers"](../modules/_db_helpers_.md) › [DBOp](_db_helpers_.dbop.md)
+
+# Class: DBOp
+
+The DBOp class aids creating database operations which is used by `level` using a more high-level interface
+
+## Hierarchy
+
+* **DBOp**
+
+## Index
+
+### Properties
+
+* [baseDBOp](_db_helpers_.dbop.md#basedbop)
+* [cacheString](_db_helpers_.dbop.md#cachestring)
+* [operationTarget](_db_helpers_.dbop.md#operationtarget)
+
+### Methods
+
+* [updateCache](_db_helpers_.dbop.md#updatecache)
+* [del](_db_helpers_.dbop.md#static-del)
+* [get](_db_helpers_.dbop.md#static-get)
+* [set](_db_helpers_.dbop.md#static-set)
+
+## Properties
+
+###  baseDBOp
+
+• **baseDBOp**: *DBOpData*
+
+*Defined in [db/operation.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L49)*
+
+___
+
+###  cacheString
+
+• **cacheString**: *string | undefined*
+
+*Defined in [db/operation.ts:50](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L50)*
+
+___
+
+###  operationTarget
+
+• **operationTarget**: *[DBTarget](../enums/_db_operation_.dbtarget.md)*
+
+*Defined in [db/operation.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L48)*
+
+## Methods
+
+###  updateCache
+
+▸ **updateCache**(`cacheMap`: [CacheMap](../modules/_db_manager_.md#cachemap)): *void*
+
+*Defined in [db/operation.ts:128](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L128)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cacheMap` | [CacheMap](../modules/_db_manager_.md#cachemap) |
+
+**Returns:** *void*
+
+___
+
+### `Static` del
+
+▸ **del**(`operationTarget`: [DBTarget](../enums/_db_operation_.dbtarget.md), `key?`: [DatabaseKey](../modules/_db_operation_.md#databasekey)): *[DBOp](_db_helpers_.dbop.md)*
+
+*Defined in [db/operation.ts:122](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L122)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`operationTarget` | [DBTarget](../enums/_db_operation_.dbtarget.md) |
+`key?` | [DatabaseKey](../modules/_db_operation_.md#databasekey) |
+
+**Returns:** *[DBOp](_db_helpers_.dbop.md)*
+
+___
+
+### `Static` get
+
+▸ **get**(`operationTarget`: [DBTarget](../enums/_db_operation_.dbtarget.md), `key?`: [DatabaseKey](../modules/_db_operation_.md#databasekey)): *[DBOp](_db_helpers_.dbop.md)*
+
+*Defined in [db/operation.ts:103](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L103)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`operationTarget` | [DBTarget](../enums/_db_operation_.dbtarget.md) |
+`key?` | [DatabaseKey](../modules/_db_operation_.md#databasekey) |
+
+**Returns:** *[DBOp](_db_helpers_.dbop.md)*
+
+___
+
+### `Static` set
+
+▸ **set**(`operationTarget`: [DBTarget](../enums/_db_operation_.dbtarget.md), `value`: Buffer | object, `key?`: [DatabaseKey](../modules/_db_operation_.md#databasekey)): *[DBOp](_db_helpers_.dbop.md)*
+
+*Defined in [db/operation.ts:108](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L108)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`operationTarget` | [DBTarget](../enums/_db_operation_.dbtarget.md) |
+`value` | Buffer &#124; object |
+`key?` | [DatabaseKey](../modules/_db_operation_.md#databasekey) |
+
+**Returns:** *[DBOp](_db_helpers_.dbop.md)*

--- a/packages/blockchain/docs/classes/_db_operation_.dbop.md
+++ b/packages/blockchain/docs/classes/_db_operation_.dbop.md
@@ -1,0 +1,116 @@
+[@ethereumjs/blockchain](../README.md) › ["db/operation"](../modules/_db_operation_.md) › [DBOp](_db_operation_.dbop.md)
+
+# Class: DBOp
+
+The DBOp class aids creating database operations which is used by `level` using a more high-level interface
+
+## Hierarchy
+
+* **DBOp**
+
+## Index
+
+### Properties
+
+* [baseDBOp](_db_operation_.dbop.md#basedbop)
+* [cacheString](_db_operation_.dbop.md#cachestring)
+* [operationTarget](_db_operation_.dbop.md#operationtarget)
+
+### Methods
+
+* [updateCache](_db_operation_.dbop.md#updatecache)
+* [del](_db_operation_.dbop.md#static-del)
+* [get](_db_operation_.dbop.md#static-get)
+* [set](_db_operation_.dbop.md#static-set)
+
+## Properties
+
+###  baseDBOp
+
+• **baseDBOp**: *DBOpData*
+
+*Defined in [db/operation.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L49)*
+
+___
+
+###  cacheString
+
+• **cacheString**: *string | undefined*
+
+*Defined in [db/operation.ts:50](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L50)*
+
+___
+
+###  operationTarget
+
+• **operationTarget**: *[DBTarget](../enums/_db_operation_.dbtarget.md)*
+
+*Defined in [db/operation.ts:48](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L48)*
+
+## Methods
+
+###  updateCache
+
+▸ **updateCache**(`cacheMap`: [CacheMap](../modules/_db_manager_.md#cachemap)): *void*
+
+*Defined in [db/operation.ts:128](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L128)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cacheMap` | [CacheMap](../modules/_db_manager_.md#cachemap) |
+
+**Returns:** *void*
+
+___
+
+### `Static` del
+
+▸ **del**(`operationTarget`: [DBTarget](../enums/_db_operation_.dbtarget.md), `key?`: [DatabaseKey](../modules/_db_operation_.md#databasekey)): *[DBOp](_db_helpers_.dbop.md)*
+
+*Defined in [db/operation.ts:122](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L122)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`operationTarget` | [DBTarget](../enums/_db_operation_.dbtarget.md) |
+`key?` | [DatabaseKey](../modules/_db_operation_.md#databasekey) |
+
+**Returns:** *[DBOp](_db_helpers_.dbop.md)*
+
+___
+
+### `Static` get
+
+▸ **get**(`operationTarget`: [DBTarget](../enums/_db_operation_.dbtarget.md), `key?`: [DatabaseKey](../modules/_db_operation_.md#databasekey)): *[DBOp](_db_helpers_.dbop.md)*
+
+*Defined in [db/operation.ts:103](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L103)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`operationTarget` | [DBTarget](../enums/_db_operation_.dbtarget.md) |
+`key?` | [DatabaseKey](../modules/_db_operation_.md#databasekey) |
+
+**Returns:** *[DBOp](_db_helpers_.dbop.md)*
+
+___
+
+### `Static` set
+
+▸ **set**(`operationTarget`: [DBTarget](../enums/_db_operation_.dbtarget.md), `value`: Buffer | object, `key?`: [DatabaseKey](../modules/_db_operation_.md#databasekey)): *[DBOp](_db_helpers_.dbop.md)*
+
+*Defined in [db/operation.ts:108](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L108)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`operationTarget` | [DBTarget](../enums/_db_operation_.dbtarget.md) |
+`value` | Buffer &#124; object |
+`key?` | [DatabaseKey](../modules/_db_operation_.md#databasekey) |
+
+**Returns:** *[DBOp](_db_helpers_.dbop.md)*

--- a/packages/blockchain/docs/classes/_index_.blockchain.md
+++ b/packages/blockchain/docs/classes/_index_.blockchain.md
@@ -20,9 +20,10 @@ This class stores and interacts with blocks.
 
 ### Properties
 
+* [_ethash](_index_.blockchain.md#optional-_ethash)
 * [db](_index_.blockchain.md#db)
 * [dbManager](_index_.blockchain.md#dbmanager)
-* [ethash](_index_.blockchain.md#optional-ethash)
+* [initPromise](_index_.blockchain.md#initpromise)
 
 ### Accessors
 
@@ -36,13 +37,15 @@ This class stores and interacts with blocks.
 * [getHead](_index_.blockchain.md#gethead)
 * [getLatestBlock](_index_.blockchain.md#getlatestblock)
 * [getLatestHeader](_index_.blockchain.md#getlatestheader)
+* [getTotalDifficulty](_index_.blockchain.md#gettotaldifficulty)
 * [iterator](_index_.blockchain.md#iterator)
 * [putBlock](_index_.blockchain.md#putblock)
 * [putBlocks](_index_.blockchain.md#putblocks)
-* [putGenesis](_index_.blockchain.md#putgenesis)
 * [putHeader](_index_.blockchain.md#putheader)
 * [putHeaders](_index_.blockchain.md#putheaders)
+* [safeNumberToHash](_index_.blockchain.md#safenumbertohash)
 * [selectNeededHashes](_index_.blockchain.md#selectneededhashes)
+* [create](_index_.blockchain.md#static-create)
 
 ## Constructors
 
@@ -50,7 +53,7 @@ This class stores and interacts with blocks.
 
 \+ **new Blockchain**(`opts`: [BlockchainOptions](../interfaces/_index_.blockchainoptions.md)): *[Blockchain](_index_.blockchain.md)*
 
-*Defined in [index.ts:106](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L106)*
+*Defined in [index.ts:119](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L119)*
 
 Creates new Blockchain object
 
@@ -64,11 +67,19 @@ Name | Type | Default | Description |
 
 ## Properties
 
+### `Optional` _ethash
+
+• **_ethash**? : *Ethash*
+
+*Defined in [index.ts:99](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L99)*
+
+___
+
 ###  db
 
 • **db**: *LevelUp*
 
-*Defined in [index.ts:90](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L90)*
+*Defined in [index.ts:96](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L96)*
 
 ___
 
@@ -76,15 +87,15 @@ ___
 
 • **dbManager**: *DBManager*
 
-*Defined in [index.ts:91](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L91)*
+*Defined in [index.ts:97](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L97)*
 
 ___
 
-### `Optional` ethash
+###  initPromise
 
-• **ethash**? : *Ethash*
+• **initPromise**: *Promise‹void›*
 
-*Defined in [index.ts:92](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L92)*
+*Defined in [index.ts:114](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L114)*
 
 ## Accessors
 
@@ -92,9 +103,10 @@ ___
 
 • **get meta**(): *object*
 
-*Defined in [index.ts:152](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L152)*
+*Defined in [index.ts:194](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L194)*
 
-Returns an object with metadata about the Blockchain. It's defined for backwards compatibility.
+Returns an object with metadata about the Blockchain. It's defined for
+backwards compatibility.
 
 **Returns:** *object*
 
@@ -102,7 +114,7 @@ Returns an object with metadata about the Blockchain. It's defined for backwards
 
 * **heads**(): *object*
 
-* **rawHead**: *undefined | Buffer‹›* = this._headHeader
+* **rawHead**: *undefined | Buffer‹›* = this._headHeaderHash
 
 ## Methods
 
@@ -112,10 +124,16 @@ Returns an object with metadata about the Blockchain. It's defined for backwards
 
 *Implementation of [BlockchainInterface](../interfaces/_index_.blockchaininterface.md)*
 
-*Defined in [index.ts:701](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L701)*
+*Defined in [index.ts:644](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L644)*
 
-Deletes a block from the blockchain. All child blocks in the chain are deleted and any
-encountered heads are set to the parent block.
+Completely deletes a block from the blockchain including any references to
+this block. If this block was in the canonical chain, then also each child
+block of this block is deleted Also, if this was a canonical block, each
+head header which is part of this now stale chain will be set to the
+parentHeader of this block An example reason to execute is when running the
+block in the VM invalidates this block: this will then reset the canonical
+head to the past block (which has been validated in the past by the VM, so
+we can be sure it is correct).
 
 **Parameters:**
 
@@ -133,7 +151,7 @@ ___
 
 *Implementation of [BlockchainInterface](../interfaces/_index_.blockchaininterface.md)*
 
-*Defined in [index.ts:454](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L454)*
+*Defined in [index.ts:527](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L527)*
 
 Gets a block by its hash.
 
@@ -141,7 +159,7 @@ Gets a block by its hash.
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`blockId` | Buffer &#124; number &#124; BN | The block's hash or number  |
+`blockId` | Buffer &#124; number &#124; BN | The block's hash or number. If a hash is provided, then this will be immediately looked up, otherwise it will wait until we have unlocked the DB  |
 
 **Returns:** *Promise‹Block›*
 
@@ -151,9 +169,10 @@ ___
 
 ▸ **getBlocks**(`blockId`: Buffer | BN | number, `maxBlocks`: number, `skip`: number, `reverse`: boolean): *Promise‹Block[]›*
 
-*Defined in [index.ts:477](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L477)*
+*Defined in [index.ts:562](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L562)*
 
-Looks up many blocks relative to blockId
+Looks up many blocks relative to blockId Note: due to `GetBlockHeaders
+(0x03)` (ETH wire protocol) we have to support skip/reverse as well.
 
 **Parameters:**
 
@@ -172,7 +191,7 @@ ___
 
 ▸ **getHead**(`name`: string): *Promise‹Block›*
 
-*Defined in [index.ts:243](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L243)*
+*Defined in [index.ts:321](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L321)*
 
 Returns the specified iterator head.
 
@@ -188,13 +207,13 @@ ___
 
 ###  getLatestBlock
 
-▸ **getLatestBlock**(): *Promise‹Block‹››*
+▸ **getLatestBlock**(): *Promise‹Block›*
 
-*Defined in [index.ts:276](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L276)*
+*Defined in [index.ts:351](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L351)*
 
 Returns the latest full block in the canonical chain.
 
-**Returns:** *Promise‹Block‹››*
+**Returns:** *Promise‹Block›*
 
 ___
 
@@ -202,11 +221,30 @@ ___
 
 ▸ **getLatestHeader**(): *Promise‹BlockHeader›*
 
-*Defined in [index.ts:260](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L260)*
+*Defined in [index.ts:337](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L337)*
 
 Returns the latest header in the canonical chain.
 
 **Returns:** *Promise‹BlockHeader›*
+
+___
+
+###  getTotalDifficulty
+
+▸ **getTotalDifficulty**(`hash`: Buffer, `number?`: BN): *Promise‹BN›*
+
+*Defined in [index.ts:547](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L547)*
+
+Gets total difficulty for a block specified by hash and number
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`hash` | Buffer |
+`number?` | BN |
+
+**Returns:** *Promise‹BN›*
 
 ___
 
@@ -216,11 +254,11 @@ ___
 
 *Implementation of [BlockchainInterface](../interfaces/_index_.blockchaininterface.md)*
 
-*Defined in [index.ts:814](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L814)*
+*Defined in [index.ts:740](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L740)*
 
-Iterates through blocks starting at the specified iterator head and calls the onBlock function
-on each block. The current location of an iterator head can be retrieved using the `getHead()`
-method.
+Iterates through blocks starting at the specified iterator head and calls
+the onBlock function on each block. The current location of an iterator
+head can be retrieved using the `getHead()` method.
 
 **Parameters:**
 
@@ -235,20 +273,23 @@ ___
 
 ###  putBlock
 
-▸ **putBlock**(`block`: Block, `isGenesis?`: undefined | false | true): *Promise‹void›*
+▸ **putBlock**(`block`: Block): *Promise‹void›*
 
 *Implementation of [BlockchainInterface](../interfaces/_index_.blockchaininterface.md)*
 
-*Defined in [index.ts:304](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L304)*
+*Defined in [index.ts:386](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L386)*
 
 Adds a block to the blockchain.
+
+If the block is valid and has a higher total difficulty than the current
+max total difficulty, the canonical chain is rebuilt and any stale
+heads/hashes are overwritten.
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
 `block` | Block | The block to be added to the blockchain  |
-`isGenesis?` | undefined &#124; false &#124; true | - |
 
 **Returns:** *Promise‹void›*
 
@@ -258,9 +299,14 @@ ___
 
 ▸ **putBlocks**(`blocks`: Block[]): *Promise‹void›*
 
-*Defined in [index.ts:293](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L293)*
+*Defined in [index.ts:371](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L371)*
 
-Adds many blocks to the blockchain.
+Adds blocks to the blockchain.
+
+If an invalid block is met the function will throw, blocks before will
+nevertheless remain in the DB. If any of the saved blocks has a higher
+total difficulty than the current max total difficulty the canonical
+chain is rebuilt and any stale heads/hashes are overwritten.
 
 **Parameters:**
 
@@ -272,31 +318,17 @@ Name | Type | Description |
 
 ___
 
-###  putGenesis
-
-▸ **putGenesis**(`genesis`: Block): *Promise‹void›*
-
-*Defined in [index.ts:234](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L234)*
-
-Puts the genesis block in the database
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-`genesis` | Block | The genesis block to be added  |
-
-**Returns:** *Promise‹void›*
-
-___
-
 ###  putHeader
 
 ▸ **putHeader**(`header`: BlockHeader): *Promise‹void›*
 
-*Defined in [index.ts:336](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L336)*
+*Defined in [index.ts:415](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L415)*
 
 Adds a header to the blockchain.
+
+If this header is valid and it has a higher total difficulty than the current
+max total difficulty, the canonical chain is rebuilt and any stale
+heads/hashes are overwritten.
 
 **Parameters:**
 
@@ -312,9 +344,14 @@ ___
 
 ▸ **putHeaders**(`headers`: Array‹any›): *Promise‹void›*
 
-*Defined in [index.ts:325](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L325)*
+*Defined in [index.ts:400](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L400)*
 
 Adds many headers to the blockchain.
+
+If an invalid header is met the function will throw, headers before will
+nevertheless remain in the DB. If any of the saved headers has a higher
+total difficulty than the current max total difficulty the canonical
+chain is rebuilt and any stale heads/hashes are overwritten.
 
 **Parameters:**
 
@@ -326,18 +363,61 @@ Name | Type | Description |
 
 ___
 
-###  selectNeededHashes
+###  safeNumberToHash
 
-▸ **selectNeededHashes**(`hashes`: Array‹Buffer›): *Promise‹Buffer‹›[]›*
+▸ **safeNumberToHash**(`number`: BN): *Promise‹Buffer | false›*
 
-*Defined in [index.ts:516](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L516)*
+*Defined in [index.ts:962](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L962)*
 
-Given an ordered array, returns an array of hashes that are not in the blockchain yet.
+This method either returns a Buffer if there exists one in the DB or if it
+does not exist (DB throws a `NotFoundError`) then return false If DB throws
+any other error, this function throws.
 
 **Parameters:**
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`hashes` | Array‹Buffer› | Ordered array of hashes  |
+`number` | BN |   |
 
-**Returns:** *Promise‹Buffer‹›[]›*
+**Returns:** *Promise‹Buffer | false›*
+
+___
+
+###  selectNeededHashes
+
+▸ **selectNeededHashes**(`hashes`: Array‹Buffer›): *Promise‹Buffer[]›*
+
+*Defined in [index.ts:604](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L604)*
+
+Given an ordered array, returns an array of hashes that are not in the
+blockchain yet. Uses binary search to find out what hashes are missing.
+Therefore, the array needs to be ordered upon number.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`hashes` | Array‹Buffer› | Ordered array of hashes (ordered on `number`).  |
+
+**Returns:** *Promise‹Buffer[]›*
+
+___
+
+### `Static` create
+
+▸ **create**(`opts`: [BlockchainOptions](../interfaces/_index_.blockchainoptions.md)): *Promise‹[Blockchain](_index_.blockchain.md)‹››*
+
+*Defined in [index.ts:182](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L182)*
+
+This static constructor safely creates a new Blockchain object, which also
+awaits the initialization function. If this initialization function throws,
+then this constructor will throw as well, and is therefore the encouraged
+method to use when creating a blockchain object.
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`opts` | [BlockchainOptions](../interfaces/_index_.blockchainoptions.md) | {} | Constructor options, see [BlockchainOptions](../interfaces/_index_.blockchainoptions.md)  |
+
+**Returns:** *Promise‹[Blockchain](_index_.blockchain.md)‹››*

--- a/packages/blockchain/docs/enums/_db_operation_.dbtarget.md
+++ b/packages/blockchain/docs/enums/_db_operation_.dbtarget.md
@@ -1,0 +1,80 @@
+[@ethereumjs/blockchain](../README.md) › ["db/operation"](../modules/_db_operation_.md) › [DBTarget](_db_operation_.dbtarget.md)
+
+# Enumeration: DBTarget
+
+## Index
+
+### Enumeration members
+
+* [Body](_db_operation_.dbtarget.md#body)
+* [HashToNumber](_db_operation_.dbtarget.md#hashtonumber)
+* [HeadBlock](_db_operation_.dbtarget.md#headblock)
+* [HeadHeader](_db_operation_.dbtarget.md#headheader)
+* [Header](_db_operation_.dbtarget.md#header)
+* [Heads](_db_operation_.dbtarget.md#heads)
+* [NumberToHash](_db_operation_.dbtarget.md#numbertohash)
+* [TotalDifficulty](_db_operation_.dbtarget.md#totaldifficulty)
+
+## Enumeration members
+
+###  Body
+
+• **Body**:
+
+*Defined in [db/operation.ts:22](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L22)*
+
+___
+
+###  HashToNumber
+
+• **HashToNumber**:
+
+*Defined in [db/operation.ts:19](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L19)*
+
+___
+
+###  HeadBlock
+
+• **HeadBlock**:
+
+*Defined in [db/operation.ts:18](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L18)*
+
+___
+
+###  HeadHeader
+
+• **HeadHeader**:
+
+*Defined in [db/operation.ts:17](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L17)*
+
+___
+
+###  Header
+
+• **Header**:
+
+*Defined in [db/operation.ts:23](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L23)*
+
+___
+
+###  Heads
+
+• **Heads**:
+
+*Defined in [db/operation.ts:16](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L16)*
+
+___
+
+###  NumberToHash
+
+• **NumberToHash**:
+
+*Defined in [db/operation.ts:20](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L20)*
+
+___
+
+###  TotalDifficulty
+
+• **TotalDifficulty**:
+
+*Defined in [db/operation.ts:21](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L21)*

--- a/packages/blockchain/docs/interfaces/_index_.blockchaininterface.md
+++ b/packages/blockchain/docs/interfaces/_index_.blockchaininterface.md
@@ -25,10 +25,10 @@
 
 ▸ **delBlock**(`blockHash`: Buffer): *Promise‹void›*
 
-*Defined in [index.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L39)*
+*Defined in [index.ts:29](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L29)*
 
-Deletes a block from the blockchain. All child blocks in the chain are deleted and any
-encountered heads are set to the parent block.
+Deletes a block from the blockchain. All child blocks in the chain are
+deleted and any encountered heads are set to the parent block.
 
 **Parameters:**
 
@@ -44,7 +44,7 @@ ___
 
 ▸ **getBlock**(`blockId`: Buffer | number | BN): *Promise‹Block | null›*
 
-*Defined in [index.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L44)*
+*Defined in [index.ts:34](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L34)*
 
 Returns a block by its hash or number.
 
@@ -62,10 +62,10 @@ ___
 
 ▸ **iterator**(`name`: string, `onBlock`: OnBlock): *Promise‹void›*
 
-*Defined in [index.ts:53](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L53)*
+*Defined in [index.ts:44](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L44)*
 
-Iterates through blocks starting at the specified iterator head and calls the onBlock function
-on each block.
+Iterates through blocks starting at the specified iterator head and calls
+the onBlock function on each block.
 
 **Parameters:**
 
@@ -80,9 +80,9 @@ ___
 
 ###  putBlock
 
-▸ **putBlock**(`block`: Block, `isGenesis?`: undefined | false | true): *Promise‹void›*
+▸ **putBlock**(`block`: Block): *Promise‹void›*
 
-*Defined in [index.ts:31](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L31)*
+*Defined in [index.ts:21](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L21)*
 
 Adds a block to the blockchain.
 
@@ -90,7 +90,6 @@ Adds a block to the blockchain.
 
 Name | Type | Description |
 ------ | ------ | ------ |
-`block` | Block | The block to be added to the blockchain. |
-`isGenesis?` | undefined &#124; false &#124; true | True if block is the genesis block.  |
+`block` | Block | The block to be added to the blockchain.  |
 
 **Returns:** *Promise‹void›*

--- a/packages/blockchain/docs/interfaces/_index_.blockchainoptions.md
+++ b/packages/blockchain/docs/interfaces/_index_.blockchainoptions.md
@@ -14,8 +14,9 @@ This are the options that the Blockchain constructor can receive.
 
 * [common](_index_.blockchainoptions.md#optional-common)
 * [db](_index_.blockchainoptions.md#optional-db)
+* [genesisBlock](_index_.blockchainoptions.md#optional-genesisblock)
 * [validateBlocks](_index_.blockchainoptions.md#optional-validateblocks)
-* [validatePow](_index_.blockchainoptions.md#optional-validatepow)
+* [validateConsensus](_index_.blockchainoptions.md#optional-validateconsensus)
 
 ## Properties
 
@@ -23,7 +24,7 @@ This are the options that the Blockchain constructor can receive.
 
 • **common**? : *Common*
 
-*Defined in [index.ts:66](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L66)*
+*Defined in [index.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L57)*
 
 Specify the chain and hardfork by passing a Common instance.
 
@@ -35,9 +36,24 @@ ___
 
 • **db**? : *LevelUp*
 
-*Defined in [index.ts:71](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L71)*
+*Defined in [index.ts:63](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L63)*
 
-Database to store blocks and metadata. Should be an abstract-leveldown compliant store.
+Database to store blocks and metadata. Should be an abstract-leveldown
+compliant store.
+
+___
+
+### `Optional` genesisBlock
+
+• **genesisBlock**? : *Block*
+
+*Defined in [index.ts:89](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L89)*
+
+The blockchain only initializes succesfully if it has a genesis block. If
+there is no block available in the DB and a `genesisBlock` is provided,
+then the provided `genesisBlock` will be used as genesis If no block is
+present in the DB and no block is provided, then the genesis block as
+provided from the `common` will be used
 
 ___
 
@@ -45,18 +61,22 @@ ___
 
 • **validateBlocks**? : *undefined | false | true*
 
-*Defined in [index.ts:83](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L83)*
+*Defined in [index.ts:80](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L80)*
 
-This flags indicates if blocks should be validated. See Block#validate for details. If
-`validate` is provided, this option takes its value. If neither `validate` nor this option are
-provided, it defaults to `true`.
+This flag indicates if protocol-given consistency checks on
+block headers and included uncles and transactions should be performed,
+see Block#validate for details.
 
 ___
 
-### `Optional` validatePow
+### `Optional` validateConsensus
 
-• **validatePow**? : *undefined | false | true*
+• **validateConsensus**? : *undefined | false | true*
 
-*Defined in [index.ts:76](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L76)*
+*Defined in [index.ts:72](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/index.ts#L72)*
 
-This flags indicates if Proof-of-work should be validated. Defaults to `true`.
+This flags indicates if a block should be validated along the consensus algorithm
+or protocol used by the chain, e.g. by verifying the PoW on the block.
+
+Supported: 'pow' with 'ethash' algorithm (taken from the `Common` instance)
+Default: `true`.

--- a/packages/blockchain/docs/modules/_db_cache_.md
+++ b/packages/blockchain/docs/modules/_db_cache_.md
@@ -1,0 +1,5 @@
+[@ethereumjs/blockchain](../README.md) › ["db/cache"](_db_cache_.md)
+
+# Module: "db/cache"
+
+

--- a/packages/blockchain/docs/modules/_db_constants_.md
+++ b/packages/blockchain/docs/modules/_db_constants_.md
@@ -1,0 +1,149 @@
+[@ethereumjs/blockchain](../README.md) › ["db/constants"](_db_constants_.md)
+
+# Module: "db/constants"
+
+## Index
+
+### Variables
+
+* [HEADS_KEY](_db_constants_.md#const-heads_key)
+* [HEAD_BLOCK_KEY](_db_constants_.md#const-head_block_key)
+* [HEAD_HEADER_KEY](_db_constants_.md#const-head_header_key)
+
+### Functions
+
+* [bodyKey](_db_constants_.md#const-bodykey)
+* [bufBE8](_db_constants_.md#const-bufbe8)
+* [hashToNumberKey](_db_constants_.md#const-hashtonumberkey)
+* [headerKey](_db_constants_.md#const-headerkey)
+* [numberToHashKey](_db_constants_.md#const-numbertohashkey)
+* [tdKey](_db_constants_.md#const-tdkey)
+
+## Variables
+
+### `Const` HEADS_KEY
+
+• **HEADS_KEY**: *"heads"* = "heads"
+
+*Defined in [db/constants.ts:5](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L5)*
+
+___
+
+### `Const` HEAD_BLOCK_KEY
+
+• **HEAD_BLOCK_KEY**: *"LastBlock"* = "LastBlock"
+
+*Defined in [db/constants.ts:15](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L15)*
+
+Current canonical head for full sync
+
+___
+
+### `Const` HEAD_HEADER_KEY
+
+• **HEAD_HEADER_KEY**: *"LastHeader"* = "LastHeader"
+
+*Defined in [db/constants.ts:10](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L10)*
+
+Current canonical head for light sync
+
+## Functions
+
+### `Const` bodyKey
+
+▸ **bodyKey**(`n`: BN, `hash`: Buffer): *Buffer‹›*
+
+*Defined in [db/constants.ts:53](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L53)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`n` | BN |
+`hash` | Buffer |
+
+**Returns:** *Buffer‹›*
+
+___
+
+### `Const` bufBE8
+
+▸ **bufBE8**(`n`: BN): *Buffer‹›*
+
+*Defined in [db/constants.ts:47](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L47)*
+
+Convert BN to big endian Buffer
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`n` | BN |
+
+**Returns:** *Buffer‹›*
+
+___
+
+### `Const` hashToNumberKey
+
+▸ **hashToNumberKey**(`hash`: Buffer): *Buffer‹›*
+
+*Defined in [db/constants.ts:57](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L57)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`hash` | Buffer |
+
+**Returns:** *Buffer‹›*
+
+___
+
+### `Const` headerKey
+
+▸ **headerKey**(`n`: BN, `hash`: Buffer): *Buffer‹›*
+
+*Defined in [db/constants.ts:51](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L51)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`n` | BN |
+`hash` | Buffer |
+
+**Returns:** *Buffer‹›*
+
+___
+
+### `Const` numberToHashKey
+
+▸ **numberToHashKey**(`n`: BN): *Buffer‹›*
+
+*Defined in [db/constants.ts:55](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L55)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`n` | BN |
+
+**Returns:** *Buffer‹›*
+
+___
+
+### `Const` tdKey
+
+▸ **tdKey**(`n`: BN, `hash`: Buffer): *Buffer‹›*
+
+*Defined in [db/constants.ts:49](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/constants.ts#L49)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`n` | BN |
+`hash` | Buffer |
+
+**Returns:** *Buffer‹›*

--- a/packages/blockchain/docs/modules/_db_helpers_.md
+++ b/packages/blockchain/docs/modules/_db_helpers_.md
@@ -1,0 +1,84 @@
+[@ethereumjs/blockchain](../README.md) › ["db/helpers"](_db_helpers_.md)
+
+# Module: "db/helpers"
+
+## Index
+
+### Classes
+
+* [DBOp](../classes/_db_helpers_.dbop.md)
+
+### Functions
+
+* [DBSaveLookups](_db_helpers_.md#dbsavelookups)
+* [DBSetBlockOrHeader](_db_helpers_.md#dbsetblockorheader)
+* [DBSetHashToNumber](_db_helpers_.md#dbsethashtonumber)
+* [DBSetTD](_db_helpers_.md#dbsettd)
+
+## Functions
+
+###  DBSaveLookups
+
+▸ **DBSaveLookups**(`blockHash`: Buffer, `blockNumber`: BN): *[DBOp](../classes/_db_helpers_.dbop.md)[]*
+
+*Defined in [db/helpers.ts:65](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/helpers.ts#L65)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`blockHash` | Buffer |
+`blockNumber` | BN |
+
+**Returns:** *[DBOp](../classes/_db_helpers_.dbop.md)[]*
+
+___
+
+###  DBSetBlockOrHeader
+
+▸ **DBSetBlockOrHeader**(`blockBody`: Block | BlockHeader): *[DBOp](../classes/_db_helpers_.dbop.md)[]*
+
+*Defined in [db/helpers.ts:25](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/helpers.ts#L25)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`blockBody` | Block &#124; BlockHeader |
+
+**Returns:** *[DBOp](../classes/_db_helpers_.dbop.md)[]*
+
+___
+
+###  DBSetHashToNumber
+
+▸ **DBSetHashToNumber**(`blockHash`: Buffer, `blockNumber`: BN): *[DBOp](../classes/_db_helpers_.dbop.md)*
+
+*Defined in [db/helpers.ts:58](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/helpers.ts#L58)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`blockHash` | Buffer |
+`blockNumber` | BN |
+
+**Returns:** *[DBOp](../classes/_db_helpers_.dbop.md)*
+
+___
+
+###  DBSetTD
+
+▸ **DBSetTD**(`TD`: BN, `blockNumber`: BN, `blockHash`: Buffer): *[DBOp](../classes/_db_helpers_.dbop.md)*
+
+*Defined in [db/helpers.ts:11](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/helpers.ts#L11)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`TD` | BN |
+`blockNumber` | BN |
+`blockHash` | Buffer |
+
+**Returns:** *[DBOp](../classes/_db_helpers_.dbop.md)*

--- a/packages/blockchain/docs/modules/_db_manager_.md
+++ b/packages/blockchain/docs/modules/_db_manager_.md
@@ -1,0 +1,21 @@
+[@ethereumjs/blockchain](../README.md) › ["db/manager"](_db_manager_.md)
+
+# Module: "db/manager"
+
+## Index
+
+### Type aliases
+
+* [CacheMap](_db_manager_.md#cachemap)
+
+## Type aliases
+
+###  CacheMap
+
+Ƭ **CacheMap**: *object*
+
+*Defined in [db/manager.ts:27](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/manager.ts#L27)*
+
+#### Type declaration:
+
+* \[ **key**: *string*\]: Cache‹Buffer›

--- a/packages/blockchain/docs/modules/_db_operation_.md
+++ b/packages/blockchain/docs/modules/_db_operation_.md
@@ -1,0 +1,31 @@
+[@ethereumjs/blockchain](../README.md) › ["db/operation"](_db_operation_.md)
+
+# Module: "db/operation"
+
+## Index
+
+### Enumerations
+
+* [DBTarget](../enums/_db_operation_.dbtarget.md)
+
+### Classes
+
+* [DBOp](../classes/_db_operation_.dbop.md)
+
+### Type aliases
+
+* [DatabaseKey](_db_operation_.md#databasekey)
+
+## Type aliases
+
+###  DatabaseKey
+
+Ƭ **DatabaseKey**: *object*
+
+*Defined in [db/operation.ts:39](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/blockchain/src/db/operation.ts#L39)*
+
+#### Type declaration:
+
+* **blockHash**? : *Buffer*
+
+* **blockNumber**? : *BN*

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -128,7 +128,7 @@ export class DBManager {
   /**
    * Fetches total difficulty for a block given its hash and number.
    */
-  async getTd(blockHash: Buffer, blockNumber: BN): Promise<BN> {
+  async getTotalDifficulty(blockHash: Buffer, blockNumber: BN): Promise<BN> {
     const td = await this.get(DBTarget.TotalDifficulty, { blockHash, blockNumber })
     return new BN(rlp.decode(td))
   }

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -467,14 +467,14 @@ export default class Blockchain implements BlockchainInterface {
 
       // set total difficulty in the current context scope
       if (this._headHeaderHash) {
-        currentTd.header = await this._getTd(this._headHeaderHash)
+        currentTd.header = await this.getTotalDifficulty(this._headHeaderHash)
       }
       if (this._headBlockHash) {
-        currentTd.block = await this._getTd(this._headBlockHash)
+        currentTd.block = await this.getTotalDifficulty(this._headBlockHash)
       }
 
       // calculate the total difficulty of the new block
-      const parentTd = await this._getTd(header.parentHash, blockNumber.subn(1))
+      const parentTd = await this.getTotalDifficulty(header.parentHash, blockNumber.subn(1))
       td.iadd(parentTd)
 
       // save block and total difficulty to the database
@@ -539,6 +539,16 @@ export default class Blockchain implements BlockchainInterface {
    */
   private async _getBlock(blockId: Buffer | number | BN) {
     return this.dbManager.getBlock(blockId)
+  }
+
+  /**
+   * Gets total difficulty for a block specified by hash and number
+   */
+  public async getTotalDifficulty(hash: Buffer, number?: BN): Promise<BN> {
+    if (!number) {
+      number = await this.dbManager.hashToNumber(hash)
+    }
+    return this.dbManager.getTotalDifficulty(hash, number)
   }
 
   /**
@@ -941,18 +951,6 @@ export default class Blockchain implements BlockchainInterface {
   private async _getCanonicalHeader(number: BN) {
     const hash = await this.dbManager.numberToHash(number)
     return this._getHeader(hash, number)
-  }
-
-  /**
-   * Gets total difficulty for a block specified by hash and number
-   *
-   * @hidden
-   */
-  private async _getTd(hash: Buffer, number?: BN) {
-    if (!number) {
-      number = await this.dbManager.hashToNumber(hash)
-    }
-    return this.dbManager.getTd(hash, number)
   }
 
   /**

--- a/packages/blockchain/test/index.ts
+++ b/packages/blockchain/test/index.ts
@@ -564,9 +564,9 @@ tape('blockchain test', (t) => {
     const hash = await blockchain.dbManager.numberToHash(new BN(0))
     st.ok(genesis.hash().equals(hash), 'should perform _numberToHash correctly')
 
-    // cast the blockchain as <any> in order to get access to the private _getTd
-    const td = await (<any>blockchain)._getTd(genesis.hash(), new BN(0))
-    st.ok(td.eq(genesis.header.difficulty), 'should perform _getTd correctly')
+    // cast the blockchain as <any> in order to get access to the private getTotalDifficulty
+    const td = await (<any>blockchain).getTotalDifficulty(genesis.hash(), new BN(0))
+    st.ok(td.eq(genesis.header.difficulty), 'should perform getTotalDifficulty correctly')
     st.end()
   })
 


### PR DESCRIPTION
Intended to be included in the `rc.1` release.

Addresses comment from @jochem-brouwer from here https://github.com/ethereumjs/ethereumjs-vm/issues/923#issuecomment-726891053 to make `Blockchain._getTd()` public. Function is renamed to `getTotalDifficulty()` for better clarity, CHANGELOG entry has been added and the blockchain docs rebuild.