### PR TITLE
Final releases

### DIFF
--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,6 +6,226 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 - 2020-11-24
+
+### New Package Name
+
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a new scoped package name format. In this case the library is renamed as follows:
+
+- `ethereumjs-block` -> `@ethereumjs/block`
+
+Please update your library references accordingly or install with:
+
+```shell
+npm i @ethereumjs/block
+```
+
+### TypeScript/Library Import
+
+This is the first TypeScript based release of the library, see PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72).
+The import structure has slightly changed along:
+
+**TypeScript**
+
+```typescript
+import { BlockHeader } from 'ethereumjs-block'
+import { Block } from 'ethereumjs-block'
+```
+
+**JavaScript/Node.js**
+
+```javascript
+const BlockHeader = require('ethereumjs-block').BlockHeader
+const Block = require('ethereumjs-block').Block
+```
+
+The library now also comes with a **type declaration file** distributed
+along with the package published.
+
+### Major Refactoring - Breaking Changes
+
+This release is a major refactoring of the block library to simplify and strengthen its code base.
+Refactoring work has been done along PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+(Promises) and PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883) (refactoring of API
+and internal code structure).
+
+#### New Constructor Params
+
+The way to instantiate a new `BlockHeader` or `Block` object has been completely reworked and is
+now more explicit, less error prone and produces more `TypeScript` friendly and readable code.
+
+The old direct constructor usage is now discouraged in favor of different dedicated static
+factory methods to create new objects.
+
+**Breaking**: While the main constructors can still be called, signatures changed significantly and
+your old `new Block(...)`, `new BlockHeader(...)` instantiations won't work any more and needs to be
+updated.
+
+**BlockHeader Class**
+
+There are three new factory methods to create a new `BlockHeader`:
+
+1. Pass in a Header-attribute named dictionary to `BlockHeader.fromHeaderData(headerData: HeaderData = {}, opts?: BlockOptions)`:
+
+```typescript
+const headerData = {
+  number: 15,
+  parentHash: '0x6bfee7294bf44572b7266358e627f3c35105e1c3851f3de09e6d646f955725a7',
+  difficulty: 131072,
+  gasLimit: 8000000,
+  timestamp: 1562422144,
+}
+const header = BlockHeader.fromHeaderData(headerData)
+```
+
+2. Create a `BlockHeader` from an RLP-serialized header `Buffer` with `BlockHeader.fromRLPSerializedHeader(serialized: Buffer, opts: BlockOptions)`.
+
+```typescript
+const serialized = Buffer.from(
+  'f901f7a06bfee7294bf44572b7266358e627f3c35105e1c3851f3de09e6d646f955725a7a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000830200000f837a120080845d20ab8080a00000000000000000000000000000000000000000000000000000000000000000880000000000000000',
+  'hex'
+)
+const header = BlockHeader.fromRLPSerializedHeader(serialized)
+```
+
+3. Create a `BlockHeader` from an array of `Buffer` values, you can do a first short roundtrip test with:
+
+```typescript
+const valuesArray = header.raw()
+BlockHeader.fromValuesArray(valuesArray)
+```
+
+Generally internal types representing block header values are now closer to their domain representation
+(number, difficulty, gasLimit) instead of having everthing represented as a `Buffer`.
+
+**Block Class**
+
+There are analogue new static factories for the `Block` class:
+
+- `Block.fromBlockData(blockData: BlockData = {}, opts?: BlockOptions)`
+- `Block.fromRLPSerializedBlock(serialized: Buffer, opts?: BlockOptions)`
+- `Block.fromValuesArray(values: BlockBuffer, opts?: BlockOptions)`
+
+Learn more about the full API in the [docs](./docs/README.md).
+
+#### Immutability
+
+The returned block is now frozen and immutable. To work with a maliable block, copy it with `const fakeBlock = Object.create(block)`.
+
+If you need `Block` mutability - e.g. because you want to subclass `Block` and modifiy its behavior - there is a `freeze` option to prevent the `Object.freeze()` call on initialization, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941).
+
+#### Promise-based API
+
+The API of this library is now completely promise-based and the old callback-style interface
+has been dropped.
+
+This affects the following methods of the API now being defined as `async` and
+returning a `Promise`:
+
+**Header Class**
+
+- `BlockHeader.validate(blockchain: Blockchain, height?: BN): Promise<void>`
+
+**Block Class**
+
+- `Block.genTxTrie(): Promise<void>`
+- `Block.validate(blockChain: Blockchain): Promise<void>`
+- `Block.validateUncles(blockchain: Blockchain): Promise<void>`
+
+Usage example:
+
+```javascript
+try {
+  await block.validate(blockchain)
+  // Block validation has passed
+} catch (err) {
+  // handle errors appropriately
+}
+```
+
+### Header Validation Methods > Signature Changes
+
+**Breaking**: The signatures of the following header validation methods have been updated to take a `parentBlockHeader` instead of a
+`parentBlock` input parameter for consistency and removing a circling dependency with `Block`:
+
+- `BlockHeader.canonicalDifficulty(parentBlockHeader: BlockHeader): BN`
+- `BlockHeader.validateDifficulty(parentBlockHeader: BlockHeader): boolean`
+- `BlockHeader.validateGasLimit(parentBlockHeader: BlockHeader): boolean`
+
+On the `Block` library new corresponding methods have been added which both operate on a block instance and expect a `parentBlock`
+as an input parameter.
+
+**Breaking:** Note that `canonicalDifficulty()` and `validateDifficulty()` in block and header now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937).
+
+**Breaking:** Non-blockchain dependent validation checks have been extracted from `validate()` to its own `Block.validateData()` function. For the `validate()` method in block and header `blockchain` is now a mandatory parameter, see PR [#942](https://github.com/ethereumjs/ethereumjs-vm/pull/942)
+
+### New Default Hardfork
+
+**Breaking:** The default HF on the library has been updated from `petersburg` to `istanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
+see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
+### Dual ES5 and ES2017 Builds
+
+We significantly updated our internal tool and CI setup along the work on
+PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint`
+for code linting and formatting and the introduction of a new build setup.
+
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
+a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
+PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
+in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+
+### Other Changes
+
+**Features**
+
+- Added `Block.genesis()` and `BlockHeader.genesis()` aliases to create
+  a genesis block or header,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Added `DAO` hardfork support (check for `extraData` attribute if `DAO` HF is active),
+  PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
+- Added the `calcDifficultyFromHeader` constructor option. If this `BlockHeader` is supplied, then the `difficulty` of the constructed `BlockHeader` will be set to the canonical difficulty (also if `difficulty` is set as parameter in the constructor). See [#929](https://github.com/ethereumjs/ethereumjs-vm/pull/929)
+- Added full uncle validation, which verifies if the uncles' `parentHash` points to the canonical chain, is not yet included and also is an uncle and not a canonical block. See PR [#935](https://github.com/ethereumjs/ethereumjs-vm/pull/935)
+- Additional consistency and validation checks in `Block.validateUncles()` for included uncle headers, PR [#935](https://github.com/ethereumjs/ethereumjs-vm/pull/935)
+
+**Changes and Refactoring**
+
+- Added Node `10`, `12` support, dropped Node `7` support,
+  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Passing in a blockchain is now optional on `Block.validate()`,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: `Block.validateTransactions(stringError: true)` now returns a `string[]`,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: Decoupling of the `Block.serialize()` and `Block.raw()` methods,
+  `Block.serialize()` now always returns the RLP-encoded block (signature change!),
+  `Block.raw()` always returns the pure `Buffer` array,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: `Block.toJSON()` now always returns the labeled `JSON` representation,
+  removal of the `labeled` function parameter,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Updated `merkle-patricia-tree` dependency to `v4`,
+  PR [#787](https://github.com/ethereumjs/ethereumjs-vm/pull/787)
+- Updated `ethereumjs-util` dependency to `v7`,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Removal of the `async` dependency,
+  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+
+**CI and Testing**
+
+- Browser test run on CI,
+  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Karma browser test run config modernization and simplification
+  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Updated test source files to `TypeScript`,
+  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+
+**Bug Fixes**
+
+- Signature fix for pre-homestead blocks,
+  PR [#67](https://github.com/ethereumjs/ethereumjs-block/issues/67)
+- Fixed bug where block options have not been passed on to the main constructor from the static factory methods, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
+
 ## 3.0.0-rc.1 - 2020-11-19
 
 This is the first release candidate towards a final library release, see [beta.2](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fblock%403.0.0-beta.2) and especially [beta.1](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fblock%403.0.0-beta.1) release notes for an overview on the full changes since the last publicly released version.

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -39,27 +39,19 @@ const BlockHeader = require('ethereumjs-block').BlockHeader
 const Block = require('ethereumjs-block').Block
 ```
 
-The library now also comes with a **type declaration file** distributed
-along with the package published.
+The library now also comes with a **type declaration file** distributed along with the package published.
 
 ### Major Refactoring - Breaking Changes
 
-This release is a major refactoring of the block library to simplify and strengthen its code base.
-Refactoring work has been done along PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-(Promises) and PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883) (refactoring of API
-and internal code structure).
+This release is a major refactoring of the block library to simplify and strengthen its code base. Refactoring work has been done along PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72) (Promises) and PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883) (refactoring of API and internal code structure).
 
 #### New Constructor Params
 
-The way to instantiate a new `BlockHeader` or `Block` object has been completely reworked and is
-now more explicit, less error prone and produces more `TypeScript` friendly and readable code.
+The way to instantiate a new `BlockHeader` or `Block` object has been completely reworked and is now more explicit, less error prone and produces more `TypeScript` friendly and readable code.
 
-The old direct constructor usage is now discouraged in favor of different dedicated static
-factory methods to create new objects.
+The old direct constructor usage is now discouraged in favor of different dedicated static factory methods to create new objects.
 
-**Breaking**: While the main constructors can still be called, signatures changed significantly and
-your old `new Block(...)`, `new BlockHeader(...)` instantiations won't work any more and needs to be
-updated.
+**Breaking**: While the main constructors can still be called, signatures changed significantly and your old `new Block(...)`, `new BlockHeader(...)` instantiations won't work any more and needs to be updated.
 
 **BlockHeader Class**
 
@@ -95,8 +87,7 @@ const valuesArray = header.raw()
 BlockHeader.fromValuesArray(valuesArray)
 ```
 
-Generally internal types representing block header values are now closer to their domain representation
-(number, difficulty, gasLimit) instead of having everthing represented as a `Buffer`.
+Generally internal types representing block header values are now closer to their domain representation (number, difficulty, gasLimit) instead of having everthing represented as a `Buffer`.
 
 **Block Class**
 
@@ -116,11 +107,9 @@ If you need `Block` mutability - e.g. because you want to subclass `Block` and m
 
 #### Promise-based API
 
-The API of this library is now completely promise-based and the old callback-style interface
-has been dropped.
+The API of this library is now completely promise-based and the old callback-style interface has been dropped.
 
-This affects the following methods of the API now being defined as `async` and
-returning a `Promise`:
+This affects the following methods of the API now being defined as `async` and returning a `Promise`:
 
 **Header Class**
 
@@ -145,15 +134,13 @@ try {
 
 ### Header Validation Methods > Signature Changes
 
-**Breaking**: The signatures of the following header validation methods have been updated to take a `parentBlockHeader` instead of a
-`parentBlock` input parameter for consistency and removing a circling dependency with `Block`:
+**Breaking**: The signatures of the following header validation methods have been updated to take a `parentBlockHeader` instead of a `parentBlock` input parameter for consistency and removing a circling dependency with `Block`:
 
 - `BlockHeader.canonicalDifficulty(parentBlockHeader: BlockHeader): BN`
 - `BlockHeader.validateDifficulty(parentBlockHeader: BlockHeader): boolean`
 - `BlockHeader.validateGasLimit(parentBlockHeader: BlockHeader): boolean`
 
-On the `Block` library new corresponding methods have been added which both operate on a block instance and expect a `parentBlock`
-as an input parameter.
+On the `Block` library new corresponding methods have been added which both operate on a block instance and expect a `parentBlock` as an input parameter.
 
 **Breaking:** Note that `canonicalDifficulty()` and `validateDifficulty()` in block and header now throw on non-PoW chains, see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937).
 
@@ -162,68 +149,45 @@ as an input parameter.
 ### New Default Hardfork
 
 **Breaking:** The default HF on the library has been updated from `petersburg` to `istanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
-The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
-see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
+The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`, see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint`
-for code linting and formatting and the introduction of a new build setup.
+We significantly updated our internal tool and CI setup along the work on PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` for code linting and formatting and the introduction of a new build setup.
 
-Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
-a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
-PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
-in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
 
 ### Other Changes
 
 **Features**
 
-- Added `Block.genesis()` and `BlockHeader.genesis()` aliases to create
-  a genesis block or header,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- Added `DAO` hardfork support (check for `extraData` attribute if `DAO` HF is active),
-  PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
+- Added `Block.genesis()` and `BlockHeader.genesis()` aliases to create a genesis block or header, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Added `DAO` hardfork support (check for `extraData` attribute if `DAO` HF is active), PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
 - Added the `calcDifficultyFromHeader` constructor option. If this `BlockHeader` is supplied, then the `difficulty` of the constructed `BlockHeader` will be set to the canonical difficulty (also if `difficulty` is set as parameter in the constructor). See [#929](https://github.com/ethereumjs/ethereumjs-vm/pull/929)
 - Added full uncle validation, which verifies if the uncles' `parentHash` points to the canonical chain, is not yet included and also is an uncle and not a canonical block. See PR [#935](https://github.com/ethereumjs/ethereumjs-vm/pull/935)
 - Additional consistency and validation checks in `Block.validateUncles()` for included uncle headers, PR [#935](https://github.com/ethereumjs/ethereumjs-vm/pull/935)
 
 **Changes and Refactoring**
 
-- Added Node `10`, `12` support, dropped Node `7` support,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-- Passing in a blockchain is now optional on `Block.validate()`,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- **Breaking**: `Block.validateTransactions(stringError: true)` now returns a `string[]`,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- **Breaking**: Decoupling of the `Block.serialize()` and `Block.raw()` methods,
-  `Block.serialize()` now always returns the RLP-encoded block (signature change!),
-  `Block.raw()` always returns the pure `Buffer` array,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- **Breaking**: `Block.toJSON()` now always returns the labeled `JSON` representation,
-  removal of the `labeled` function parameter,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- Updated `merkle-patricia-tree` dependency to `v4`,
-  PR [#787](https://github.com/ethereumjs/ethereumjs-vm/pull/787)
-- Updated `ethereumjs-util` dependency to `v7`,
-  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
-- Removal of the `async` dependency,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Added Node `10`, `12` support, dropped Node `7` support, PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Passing in a blockchain is now optional on `Block.validate()`, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: `Block.validateTransactions(stringError: true)` now returns a `string[]`, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: Decoupling of the `Block.serialize()` and `Block.raw()` methods, `Block.serialize()` now always returns the RLP-encoded block (signature change!), `Block.raw()` always returns the pure `Buffer` array, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- **Breaking**: `Block.toJSON()` now always returns the labeled `JSON` representation, removal of the `labeled` function parameter, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Updated `merkle-patricia-tree` dependency to `v4`, PR [#787](https://github.com/ethereumjs/ethereumjs-vm/pull/787)
+- Updated `ethereumjs-util` dependency to `v7`, PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Removal of the `async` dependency, PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
 
 **CI and Testing**
 
-- Browser test run on CI,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-- Karma browser test run config modernization and simplification
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
-- Updated test source files to `TypeScript`,
-  PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Browser test run on CI, PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Karma browser test run config modernization and simplification, PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
+- Updated test source files to `TypeScript`, PR [#72](https://github.com/ethereumjs/ethereumjs-block/pull/72)
 
 **Bug Fixes**
 
-- Signature fix for pre-homestead blocks,
-  PR [#67](https://github.com/ethereumjs/ethereumjs-block/issues/67)
+- Signature fix for pre-homestead blocks, PR [#67](https://github.com/ethereumjs/ethereumjs-block/issues/67)
 - Fixed bug where block options have not been passed on to the main constructor from the static factory methods, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941)
 
 ## 3.0.0-rc.1 - 2020-11-19

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/block",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0",
   "description": "Provides Block serialization and help functions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,8 +39,8 @@
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/block#readme",
   "dependencies": {
-    "@ethereumjs/common": "2.0.0-rc.1",
-    "@ethereumjs/tx": "3.0.0-rc.1",
+    "@ethereumjs/common": "^2.0.0",
+    "@ethereumjs/tx": "^3.0.0",
     "@types/bn.js": "^4.11.6",
     "ethereumjs-util": "^7.0.7",
     "merkle-patricia-tree": "^4.0.0"

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,105 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.0.0 - 2020-11-24
+
+### New Package Name
+
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a new scoped package name format. In this case the library is renamed as follows:
+
+- `ethereumjs-blockchain` -> `@ethereumjs/blockchain`
+
+Please update your library references accordingly or install with:
+
+```shell
+npm i @ethereumjs/blockchain
+```
+
+### Library Promisification
+
+The `Blockchain` library has been promisified and callbacks have been removed along
+PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833) and preceeding PR
+[#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779).
+
+Old API example:
+
+```typescript
+blockchain.getBlock(blockId, (block) => {
+  console.log(block)
+})
+```
+
+New API example:
+
+```typescript
+const block = await blockchain.getBlock(blockId)
+console.log(block)
+```
+
+See `Blockchain` [README](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/blockchain#example) for a complete example.
+
+**Safe Static Constructor**
+
+The library now has an additional safe static constructor `Blockchain.create()` which awaits the init method and throws if the init method throws:
+
+```typescript
+import Blockchain from '@ethereumjs/blockchain'
+const common = new Common({ chain: 'ropsten' })
+const blockchain = await Blockchain.create({ common })
+```
+
+This is the new recommended way to instantiate a `Blockchain` object, see PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930).
+
+Constructor options (both for the static and the main constructor) for chain setup on all VM monorepo libraries have been simplified and the plain `chain` and `hardfork` options have been removed. Passing in a `Common` instance is now the single way to switch to a non-default chain (`mainnet`) or start a blockchain with a higher than `chainstart` hardfork, see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
+**Refactored Genesis Block Handling Mechanism**
+
+Genesis handling has been reworked to now be safer and reduce the risk of wiping a blockchain by setting a new genesis, see PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930).
+
+**Breaking**: The dedicated `setGenesisBlock()` methods and the optional `isGenesis` option on `Blockchain.putBlock()` have been removed. Instead the genesis block is created on initialization either from the `Common` library instance passed or a custom genesis block passed along with the `genesisBlock` option. If a custom genesis block is used, this custom block now always has to be passed along on `Blockchain` initialization, also when operating on an already existing DB. 
+
+### Removed deprecated `validate` option
+
+The deprecated `validate` option has been removed, please use `valdiateBlock` and `validatePow` for options when instantiating a new `Blockchain`.
+
+### Dual ES5 and ES2017 Builds
+
+We significantly updated our internal tool and CI setup along the work on 
+PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
+for code linting and formatting and the introduction of a new build setup.
+
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
+a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
+PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
+in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+
+### Other Changes
+
+**Changes and Refactoring**
+
+- **Breaking:** `validatePow` option has been renamed to `validateConsensus` to prepare for a future integration of non-PoW (PoA) consensus mechanisms, `validateConsensus` as well as `validateBlocks` options now throw when set to `true` for validation on a non-PoW chain (determined by `Common`, e.g. 'goerli'), see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
+- Exposed private `Blockchain._getTd()` total difficulty function as `Blockchain.getTotalDifficulty()`, PR [#956](https://github.com/ethereumjs/ethereumjs-vm/issues/956)
+- Refactored `DBManager` with the introduction of an abstract DB operation handling mechanism, if you have modified `DBManager` in your code this will be a **potentially breaking** change for you, PR [#927](https://github.com/ethereumjs/ethereumjs-vm/pull/927)
+- Renaming of internal variables like `Blockchain._headBlock`, if you are using these variables in your code this will be a **potentially breaking** change for you, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Made internal `_` methods like `_saveHeads()` private, if you are using these functions in your code this will be a **potentially breaking** change for you, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Improved code documentation, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Fixed potential blockchain DB concurrency issues along PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
+- Use `@ethereumjs/block` `v3.0.0` block library version,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Removed `async` dependency,
+  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+
+**Bug Fixes**
+
+- Fixed blockchain hanging forever in case code throws between a semaphore `lock`/`unlock`,
+  Issue [#877](https://github.com/ethereumjs/ethereumjs-vm/issues/877)
+
+**Testing and CI**
+
+- Dedicated `blockchain` reorg test setup and executable test, PR [#926](https://github.com/ethereumjs/ethereumjs-vm/pull/926)
+
 ## 5.0.0-rc.1 2020-11-19
 
 This is the first release candidate towards a final library release, see [beta.2](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fblockchain%405.0.0-beta.2) and especially [beta.1](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fblockchain%405.0.0-beta.1) release notes for an overview on the full changes since the last publicly released version.

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -22,9 +22,7 @@ npm i @ethereumjs/blockchain
 
 ### Library Promisification
 
-The `Blockchain` library has been promisified and callbacks have been removed along
-PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833) and preceeding PR
-[#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779).
+The `Blockchain` library has been promisified and callbacks have been removed along PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833) and preceeding PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779).
 
 Old API example:
 
@@ -69,14 +67,9 @@ The deprecated `validate` option has been removed, please use `valdiateBlock` an
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on 
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
-for code linting and formatting and the introduction of a new build setup.
+We significantly updated our internal tool and CI setup along the work on PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` for code linting and formatting and the introduction of a new build setup.
 
-Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
-a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
-PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
-in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
 
 ### Other Changes
 
@@ -89,12 +82,9 @@ in performance benefits for Node.js consumers, see [here](https://github.com/eth
 - Made internal `_` methods like `_saveHeads()` private, if you are using these functions in your code this will be a **potentially breaking** change for you, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
 - Improved code documentation, PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
 - Fixed potential blockchain DB concurrency issues along PR [#930](https://github.com/ethereumjs/ethereumjs-vm/pull/930)
-- Use `@ethereumjs/block` `v3.0.0` block library version,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- Removed `async` dependency,
-  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
-- Updated `ethereumjs-util` to v7,
-  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Use `@ethereumjs/block` `v3.0.0` block library version, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Removed `async` dependency, PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+- Updated `ethereumjs-util` to v7, PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
 
 **Bug Fixes**
 

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/blockchain",
-  "version": "5.0.0-rc.1",
+  "version": "5.0.0",
   "description": "A module to store and interact with blocks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -36,9 +36,9 @@
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/blockchain#readme",
   "dependencies": {
-    "@ethereumjs/block": "3.0.0-rc.1",
-    "@ethereumjs/common": "2.0.0-rc.1",
-    "@ethereumjs/ethash": "1.0.0-rc.1",
+    "@ethereumjs/block": "^3.0.0",
+    "@ethereumjs/common": "^2.0.0",
+    "@ethereumjs/ethash": "^1.0.0",
     "ethereumjs-util": "^7.0.7",
     "level-mem": "^5.0.1",
     "lru-cache": "^5.1.1",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,108 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2020-11-24
+
+### New Package Name
+
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a new scoped package name format. In this case the library is renamed as follows:
+
+- `ethereumjs-common` -> `@ethereumjs/common`
+
+Please update your library references accordingly or install with:
+
+```shell
+npm i @ethereumjs/common
+```
+
+### New constructor
+
+**Breaking**: The constructor has been changed to require an options dict to be passed, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863)
+
+Example:
+
+```typescript
+import Common from '@ethereumjs/common'
+const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+```
+
+### EIP Support
+
+EIPs are now native citizens within the `Common` library, see PRs [#856](https://github.com/ethereumjs/ethereumjs-vm/pull/856), [#869](https://github.com/ethereumjs/ethereumjs-vm/pull/869) and [#872](https://github.com/ethereumjs/ethereumjs-vm/pull/872). Supported EIPs have their own configuration file like the [eips/2537.json](https://github.com/ethereumjs/ethereumjs-vm/blob/master/packages/common/src/eips/2537.json) file for the BLS precompile EIP and EIP settings can be activated by passing supported EIP numbers to the constructor:
+
+```typescript
+const c = new Common({ chain: 'mainnet', eips: [2537] })
+```
+
+The following EIPs are initially supported within this release:
+
+- [EIP-2537](https://eips.ethereum.org/EIPS/eip-2315) BLS Precompiles
+- [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) EVM Subroutines (PR [#876](https://github.com/ethereumjs/ethereumjs-vm/pull/876))
+
+EIPs provided are then activated and parameters requested with `Common.param()` being present in these EIPs take precedence over the setting from the latest hardfork.
+
+There are two new utility functions which return hardfork and EIP values respectively:
+
+- `Common.paramByHardfork()`
+- `Common.paramByEIP()`
+
+**Breaking**: It is now not possible any more to pass a dedicated HF setting to `Common.param()`. Please update your code to explicitly use `Common.paramByHardfork()` for requesting a parameter for a HF deviating from the HF currently set within your `Common` instance.
+
+For setting and requesting active EIPs there is `Common.setEIPs()` and `Common.eips()` added to the mix.
+
+There is also a new EIP-based hardfork file format which delegates parameter definition to dedicated EIP files (see PR [#876](https://github.com/ethereumjs/ethereumjs-vm/pull/876)). This is in preparation for an upcoming `Yolo v2` testnet integration.
+
+Side note: with this new structural setup it gets now possible for all EIPs still implicitly contained within the hardfork files to be extracted as an EIP parameter set within its own dedicated EIP file (which can then be activated via the `eip` parameter on initialization) without loosing on functionality. If you have a need there feel free to open a PR!
+
+### Gas Parameter Completeness for all Hardforks
+
+Remaining gas base fees which still resided in the VM have been moved over to `Common` along PR [#806](https://github.com/ethereumjs/ethereumjs-vm/pull/806).
+Gas fees for all hardforks up to `MuirGlacier` are now completely present within the `Common` library.
+
+### Eth/64 Forkhash Support
+
+There is a new `Common.forkHash()` method returning pre-calculated Forkhash values or alternatively use the internal `Common._calcForkHash()` implementation to calculate a forkhash on the fly.
+
+Forkhashes are used to uniquely identify a set of hardforks passed to be able to better differentiate between different dedicated chains. This is used for the `Eth/64` devp2p protocol update and specificed in [EIP-2124](https://eips.ethereum.org/EIPS/eip-2124) to help improve the devp2p networking stack.
+
+### New Block/Hardfork related Utility Functions
+
+The following block and hardfork related utility functions have been added with PRs [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863) and [#805](https://github.com/ethereumjs/ethereumjs-vm/pull/805) respectively:
+
+- `setHardforkByBlockNumber()` - Sets the hardfork determined by the block number passed
+- `nextHardforkBlock()` - Returns the next HF block for a HF provided or set
+- `isNextHardforkBlock()` - Some convenience additional utility method, matching the existing `hardforkBlock()` / `isHardforkBlock()` method setup
+- `hardforkForForkHash()` - Returns the data available for a HF given a specific forkHash
+
+### Default Hardfork
+
+The default hardfork has been added as an accessible readonly property `DEFAULT_HARDFORK`, PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863). This setting is used starting with the latest major releases of the monorepo libraries like the VM to keep the HF setting in sync across the different libraries.
+
+Current default hardfork is set to `istanbul`, PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+
+### Dual ES5 and ES2017 Builds
+
+We significantly updated our internal tool and CI setup along the work on 
+PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
+for code linting and formatting and the introduction of a new build setup.
+
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
+a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
+PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
+in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+
+### Other Changes
+
+**Changes and Refactoring**
+
+- Added consensus information to chains, new functions `Common.consensusType()` for consensus type access ("pow" or "poa") and `Common.consensusAlgorithm()` to get the associated algorithm or protocol (e.g. "ethash" PoW algorithm or "clique" PoA protocol), see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
+- Removed old `consensus` and `finality` fields,
+  PR [#758](https://github.com/ethereumjs/ethereumjs-vm/pull/758)
+- Removed old `casper` and `sharding` fields,
+  PR [#762](https://github.com/ethereumjs/ethereumjs-vm/pull/762)
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+
 ## 2.0.0-rc.1 2020-11-19
 
 This is the first release candidate towards a final library release, see [beta.2](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fcommon%402.0.0-beta.2) and especially [beta.1](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fcommon%402.0.0-beta.1) release notes for an overview on the full changes since the last publicly released version.

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -62,6 +62,7 @@ Side note: with this new structural setup it gets now possible for all EIPs stil
 ### Gas Parameter Completeness for all Hardforks
 
 Remaining gas base fees which still resided in the VM have been moved over to `Common` along PR [#806](https://github.com/ethereumjs/ethereumjs-vm/pull/806).
+
 Gas fees for all hardforks up to `MuirGlacier` are now completely present within the `Common` library.
 
 ### Eth/64 Forkhash Support
@@ -87,26 +88,18 @@ Current default hardfork is set to `istanbul`, PR [#906](https://github.com/ethe
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on 
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
-for code linting and formatting and the introduction of a new build setup.
+We significantly updated our internal tool and CI setup along the work on PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` for code linting and formatting and the introduction of a new build setup.
 
-Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
-a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
-PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
-in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
 
 ### Other Changes
 
 **Changes and Refactoring**
 
 - Added consensus information to chains, new functions `Common.consensusType()` for consensus type access ("pow" or "poa") and `Common.consensusAlgorithm()` to get the associated algorithm or protocol (e.g. "ethash" PoW algorithm or "clique" PoA protocol), see PR [#937](https://github.com/ethereumjs/ethereumjs-vm/pull/937)
-- Removed old `consensus` and `finality` fields,
-  PR [#758](https://github.com/ethereumjs/ethereumjs-vm/pull/758)
-- Removed old `casper` and `sharding` fields,
-  PR [#762](https://github.com/ethereumjs/ethereumjs-vm/pull/762)
-- Updated `ethereumjs-util` to v7,
-  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Removed old `consensus` and `finality` fields, PR [#758](https://github.com/ethereumjs/ethereumjs-vm/pull/758)
+- Removed old `casper` and `sharding` fields, PR [#762](https://github.com/ethereumjs/ethereumjs-vm/pull/762)
+- Updated `ethereumjs-util` to v7, PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
 
 ## 2.0.0-rc.1 2020-11-19
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/common",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0",
   "description": "Resources common to all Ethereum implementations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -10,8 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### New Package Name
 
-**Attention!** This new version is part of a series of EthereumJS releases all moving to a
-new scoped package name format. In this case the library is renamed as follows:
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a new scoped package name format. In this case the library is renamed as follows:
 
 - `ethashjs` -> `@ethereumjs/ethash`
 
@@ -23,9 +22,7 @@ npm i @ethereumjs/ethash
 
 ### Library Promisification
 
-The `Ethash` library has been promisified and callbacks have been removed along
-PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833) and preceeding PR
-[#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779).
+The `Ethash` library has been promisified and callbacks have been removed along PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833) and preceeding PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779).
 
 Old API:
 
@@ -42,28 +39,20 @@ const result = await ethash.verifyPOW(validBlock)
 console.log(result) // => true
 ```
 
-See `Ethash` [README](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/ethash#usage)
-for a complete example.
+See `Ethash` [README](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/ethash#usage) for a complete example.
 
 [1.0.0]: https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fethash%401.0.0
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on 
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
-for code linting and formatting and the introduction of a new build setup.
+We significantly updated our internal tool and CI setup along the work on PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` for code linting and formatting and the introduction of a new build setup.
 
-Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
-a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
-PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
-in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
 
 ### Other Changes
 
-- Updated Block dependency to `@ethereumjs/block` `v3.0.0`,
-  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
-- Removed `async` dependency,
-  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+- Updated Block dependency to `@ethereumjs/block` `v3.0.0`, PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Removed `async` dependency, PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
 
 ## 1.0.0-rc.1 - 2020-11-19
 

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,6 +6,65 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2020-11-24
+
+### New Package Name
+
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a
+new scoped package name format. In this case the library is renamed as follows:
+
+- `ethashjs` -> `@ethereumjs/ethash`
+
+Please update your library references accordingly or install with:
+
+```shell
+npm i @ethereumjs/ethash
+```
+
+### Library Promisification
+
+The `Ethash` library has been promisified and callbacks have been removed along
+PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833) and preceeding PR
+[#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779).
+
+Old API:
+
+```typescript
+ethash.verifyPOW(validblock, (result) => {
+  console.log(result)
+})
+```
+
+New API:
+
+```typescript
+const result = await ethash.verifyPOW(validBlock)
+console.log(result) // => true
+```
+
+See `Ethash` [README](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/ethash#usage)
+for a complete example.
+
+[1.0.0]: https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fethash%401.0.0
+
+### Dual ES5 and ES2017 Builds
+
+We significantly updated our internal tool and CI setup along the work on 
+PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
+for code linting and formatting and the introduction of a new build setup.
+
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
+a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
+PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
+in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+
+### Other Changes
+
+- Updated Block dependency to `@ethereumjs/block` `v3.0.0`,
+  PR [#883](https://github.com/ethereumjs/ethereumjs-vm/pull/883)
+- Removed `async` dependency,
+  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+
 ## 1.0.0-rc.1 - 2020-11-19
 
 This is the first release candidate towards a final library release, see [beta.1](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Fethash%401.0.0-beta.1) release notes for an overview on the full changes since the last publicly released version.

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/ethash",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "description": "An ethash implementation in JS.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,7 +40,7 @@
     "miller-rabin": "^4.0.0"
   },
   "devDependencies": {
-    "@ethereumjs/block": "3.0.0-rc.1",
+    "@ethereumjs/block": "^3.0.0",
     "@ethereumjs/config-coverage": "^2.0.0",
     "@ethereumjs/config-typescript": "^2.0.0",
     "@ethereumjs/eslint-config-defaults": "^2.0.0",

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -74,28 +74,21 @@ The `FakeTransaction` class was removed since its functionality can now be imple
 ### New Default Hardfork
 
 **Breaking:** The default HF on the library has been updated from `petersburg` to `istanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
-The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
-see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
+The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`, see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on 
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
-for code linting and formatting and the introduction of a new build setup.
+We significantly updated our internal tool and CI setup along the work on PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` for code linting and formatting and the introduction of a new build setup.
 
-Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
-a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
-PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
-in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
 
 ### Other Changes
 
 **Changes and Refactoring**
 
-- Updated `ethereumjs-util` to v7,
-  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
-- Replaced `new Buffer()` (deprecated) statements with `Buffer.from()`,
-  PR [#721](https://github.com/ethereumjs/ethereumjs-vm/pull/721)
+- Updated `ethereumjs-util` to v7, PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Replaced `new Buffer()` (deprecated) statements with `Buffer.from()`, PR [#721](https://github.com/ethereumjs/ethereumjs-vm/pull/721)
 - Dropped `ethereumjs-testing` dev dependency, PR [#953](https://github.com/ethereumjs/ethereumjs-vm/pull/953)
 
 ## 3.0.0-rc.1 - 2020-11-19

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,6 +6,98 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 - 2020-11-24
+
+### New Package Name
+
+**Attention!** This new version is part of a series of EthereumJS releases all moving to a new scoped package name format. In this case the library is renamed as follows:
+
+- `ethereumjs-tx` -> `@ethereumjs/tx`
+
+Please update your library references accordingly or install with:
+
+```shell
+npm i @ethereumjs/tx
+```
+
+### Major Refactoring - Breaking Changes
+
+This release is a major refactoring of the transaction library to simplify and strengthen its code base. Refactoring work has been done along PR [#812](https://github.com/ethereumjs/ethereumjs-vm/pull/812) and PR [#887](https://github.com/ethereumjs/ethereumjs-vm/pull/887).
+
+#### New Constructor Params
+
+The constructor has been reworked and new static factory methods `fromTxData`, `fromRlpSerializedTx`, and `fromValuesArray` have been added for a more `TypeScript` friendly and less error-prone way to initialize a `Transaction` object. The direct usage of the main constructor (now just being an alias to `Tx.fromTxData()`, see PR [#944](https://github.com/ethereumjs/ethereumjs-vm/pull/944)) is now discouraged and the static factory methods should be used.
+
+**Breaking:** Note that you **need** to adopt your `Transaction` initialization code since the constructor API has changed!
+
+Examples:
+
+```typescript
+// Initializing from serialized data
+const s1 = tx1.serialize().toString('hex')
+const tx = Transaction.fromRlpSerializedTx(toBuffer('0x' + s1))
+
+// Initializing with object
+const txData = {
+  gasPrice: 1000,
+  gasLimit: 10000000,
+  value: 42,
+}
+const tx = Transaction.fromTxData(txData)
+
+// Initializing from array of 0x-prefixed strings.
+// First, convert to array of Buffers.
+const arr = txFixture.raw.map(toBuffer)
+const tx = Transaction.fromValuesArray(arr)
+```
+
+Learn more about the full API in the [docs](./docs/README.md).
+
+#### Immutability
+
+The returned transaction is now frozen and immutable. To work with a maliable transaction, copy it with `const fakeTx = Object.create(tx)`. For security reasons it is highly recommended to stay in a freezed `Transaction` context on usage.
+
+If you need `Transaction` mutability - e.g. because you want to subclass `Transaction` and modifiy its behavior - there is a `freeze` option to prevent the `Object.freeze()` call on initialization, see PR [#941](https://github.com/ethereumjs/ethereumjs-vm/pull/941).
+
+#### from
+
+The `tx.from` alias was removed, please use `const from = tx.getSenderAddress()`.
+
+#### Message to sign
+
+Getting a message to sign has been changed from calling `tx.hash(false)` to `tx.getMessageToSign()`.
+
+#### Fake Transaction
+
+The `FakeTransaction` class was removed since its functionality can now be implemented with less code. To create a fake tansaction for use in e.g. `VM.runTx()` overwrite `getSenderAddress` with your own `Address`. See a full example in the section in the [README](./README.md#fake-transaction).
+
+### New Default Hardfork
+
+**Breaking:** The default HF on the library has been updated from `petersburg` to `istanbul`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
+see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863).
+
+### Dual ES5 and ES2017 Builds
+
+We significantly updated our internal tool and CI setup along the work on 
+PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
+for code linting and formatting and the introduction of a new build setup.
+
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
+a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
+PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
+in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+
+### Other Changes
+
+**Changes and Refactoring**
+
+- Updated `ethereumjs-util` to v7,
+  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Replaced `new Buffer()` (deprecated) statements with `Buffer.from()`,
+  PR [#721](https://github.com/ethereumjs/ethereumjs-vm/pull/721)
+- Dropped `ethereumjs-testing` dev dependency, PR [#953](https://github.com/ethereumjs/ethereumjs-vm/pull/953)
+
 ## 3.0.0-rc.1 - 2020-11-19
 
 This is the first release candidate towards a final library release, see [beta.2](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Ftx%403.0.0-beta.2) and especially [beta.1](https://github.com/ethereumjs/ethereumjs-vm/releases/tag/%40ethereumjs%2Ftx%403.0.0-beta.1) release notes for an overview on the full changes since the last publicly released version.

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/tx",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0",
   "description": "A simple module for creating, manipulating and signing Ethereum transactions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
   "author": "mjbecze <mb@ethdev.com>",
   "license": "MPL-2.0",
   "dependencies": {
-    "@ethereumjs/common": "2.0.0-rc.1",
+    "@ethereumjs/common": "^2.0.0",
     "ethereumjs-util": "^7.0.7"
   },
   "devDependencies": {

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -22,25 +22,17 @@ npm i @ethereumjs/vm
 
 ### Support for all current Hardforks / HF API Changes
 
-This is the first release of the VM which supports all hardforks
-currently applied on mainnet starting with the support of the
-Frontier HF rules all along up to MuirGlacier. 🎉
+This is the first release of the VM which supports all hardforks currently applied on mainnet starting with the support of the Frontier HF rules all along up to MuirGlacier. 🎉
 
 The following HFs have been added:
 
-- **Spurious Dragon**,
-  PR [#791](https://github.com/ethereumjs/ethereumjs-vm/pull/791)
-- **Tangerine Whistle**,
-  PR [#807](https://github.com/ethereumjs/ethereumjs-vm/pull/807)
-- **DAO**,
-  PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
-- **Homestead**,
-  PR [#815](https://github.com/ethereumjs/ethereumjs-vm/pull/815)
-- **Frontier**,
-  PR [#828](https://github.com/ethereumjs/ethereumjs-vm/pull/828)
+- **Spurious Dragon**, PR [#791](https://github.com/ethereumjs/ethereumjs-vm/pull/791)
+- **Tangerine Whistle**, PR [#807](https://github.com/ethereumjs/ethereumjs-vm/pull/807)
+- **DAO**, PR [#843](https://github.com/ethereumjs/ethereumjs-vm/pull/843)
+- **Homestead**, PR [#815](https://github.com/ethereumjs/ethereumjs-vm/pull/815)
+- **Frontier**, PR [#828](https://github.com/ethereumjs/ethereumjs-vm/pull/828)
 
-A VM with the specific HF rules (on the chain provided) can be instantiated
-by passing in a `Common` instance:
+A VM with the specific HF rules (on the chain provided) can be instantiated by passing in a `Common` instance:
 
 ```typescript
 import VM from '@ethereumjs/vm'
@@ -50,38 +42,21 @@ const common = new Common({ chain: 'mainnet', hardfork: 'spuriousDragon' })
 const vm = new VM({ common })
 ```
 
-**Breaking**: The default HF from the VM has been updated from `petersburg` to `istanbul`.
-The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`,
-see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
+**Breaking**: The default HF from the VM has been updated from `petersburg` to `istanbul`. The HF setting is now automatically taken from the HF set for `Common.DEAULT_HARDFORK`, see PR [#906](https://github.com/ethereumjs/ethereumjs-vm/pull/906).
 
-**Breaking**: Please note that the options to directly pass in
-`chain` and `hardfork` strings have been removed to simplify the API.
-Providing a `Common` instance is now the only way to change
-the chain setup, see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863)
+**Breaking**: Please note that the options to directly pass in `chain` and `hardfork` strings have been removed to simplify the API. Providing a `Common` instance is now the only way to change the chain setup, see PR [#863](https://github.com/ethereumjs/ethereumjs-vm/pull/863)
 
 ### Berlin HF Support / HF-independent EIPs
 
-This releases adds support for subroutines (`EIP-2315`) which gets
-activated under the `berlin` HF setting which can now be used
-as a `hardfork` instantiation option, see
-PR [#754](https://github.com/ethereumjs/ethereumjs-vm/pull/754).
+This releases adds support for subroutines (`EIP-2315`) which gets activated under the `berlin` HF setting which can now be used as a `hardfork` instantiation option, see PR [#754](https://github.com/ethereumjs/ethereumjs-vm/pull/754).
 
-**Attention!** Berlin HF support is still considered experimental
-and implementations can change on non-major VM releases!
+**Attention!** Berlin HF support is still considered experimental and implementations can change on non-major VM releases!
 
-Support for BLS12-381 precompiles (`EIP-2537`) is added as an independent EIP
-implementation - see PR [#785](https://github.com/ethereumjs/ethereumjs-vm/pull/785) -
-since there is still an ongoing discussion on taking this EIP in for Berlin or
-using a more generalized approach on curve computation with the Ethereum EVM
-(`evm384` by the eWASM team).
+Support for BLS12-381 precompiles (`EIP-2537`) is added as an independent EIP implementation - see PR [#785](https://github.com/ethereumjs/ethereumjs-vm/pull/785) - since there is still an ongoing discussion on taking this EIP in for Berlin or using a more generalized approach on curve computation with the Ethereum EVM (`evm384` by the eWASM team).
 
-Another new EIP added is the `EIP-2929` with gas cost increases for state access
-opcodes, see PR [#889](https://github.com/ethereumjs/ethereumjs-vm/pull/889).
+Another new EIP added is the `EIP-2929` with gas cost increases for state access opcodes, see PR [#889](https://github.com/ethereumjs/ethereumjs-vm/pull/889).
 
-These integrations come along with an API addition to the VM to support the activation
-of specific EIPs, see PR [#856](https://github.com/ethereumjs/ethereumjs-vm/pull/856),
-PR [#869](https://github.com/ethereumjs/ethereumjs-vm/pull/869) and
-PR [#872](https://github.com/ethereumjs/ethereumjs-vm/pull/872).
+These integrations come along with an API addition to the VM to support the activation of specific EIPs, see PR [#856](https://github.com/ethereumjs/ethereumjs-vm/pull/856), PR [#869](https://github.com/ethereumjs/ethereumjs-vm/pull/869) and PR [#872](https://github.com/ethereumjs/ethereumjs-vm/pull/872).
 
 This API can be used as follows:
 
@@ -95,125 +70,70 @@ const vm = new VM({ common })
 
 ### API Change: New Major Library Versions
 
-The following `EthereumJS` libraries which are used within the VM internally
-and can be passed in on instantiation have been updated to new major versions.
+The following `EthereumJS` libraries which are used within the VM internally and can be passed in on instantiation have been updated to new major versions.
 
-- `merkle-patricia-tree` `v3` (VM option `state`) -> `merkle-patricia-tree` `v4`,
-  PR [#787](https://github.com/ethereumjs/ethereumjs-vm/pull/787)
-- `ethereumjs-blockchain` `v4`-> `@ethereumjs/blockchain` `v5`,
-  PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833)
+- `merkle-patricia-tree` `v3` (VM option `state`) -> `merkle-patricia-tree` `v4`, PR [#787](https://github.com/ethereumjs/ethereumjs-vm/pull/787)
+- `ethereumjs-blockchain` `v4`-> `@ethereumjs/blockchain` `v5`, PR [#833](https://github.com/ethereumjs/ethereumjs-vm/pull/833)
 - `ethereumjs-common` `v1` -> `@ethereumjs/common` `v2`
 
-**Breaking**: If you pass in instances of these libraries to the VM please make sure to
-update these library versions as stated. Please also take a note on the
-package name changes!
+**Breaking**: If you pass in instances of these libraries to the VM please make sure to update these library versions as stated. Please also take a note on the package name changes!
 
-All these libraries are now written in `TypeScript` and use promises instead of
-callbacks for accessing their APIs.
+All these libraries are now written in `TypeScript` and use promises instead of callbacks for accessing their APIs.
 
 ### New StateManager Interface / StateManager API Changes
 
-There is now a new `TypeScript` interface for the `StateManager`, see
-PR [#763](https://github.com/ethereumjs/ethereumjs-vm/pull/763). If you are
-using a custom `StateManager` you can use this interface to get better
-assurance that you are using a `StateManager` which conforms with the current
-`StateManager` API and will run in the VM without problems.
+There is now a new `TypeScript` interface for the `StateManager`, see PR [#763](https://github.com/ethereumjs/ethereumjs-vm/pull/763). If you are
+using a custom `StateManager` you can use this interface to get better assurance that you are using a `StateManager` which conforms with the current `StateManager` API and will run in the VM without problems.
 
-The integration of this new interface is highly encouraged since this release
-also comes with `StateManager` API changes. Usage of the old
-[ethereumjs-account](https://github.com/ethereumjs/ethereumjs-account) package
-(this package will be retired) has been replaced by the new
-[Account class](https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_account_.md)
-from the `ethereumjs-util` package. This affects all `Account` related
-`StateManager` methods, see PR [#911](https://github.com/ethereumjs/ethereumjs-vm/pull/911).
+The integration of this new interface is highly encouraged since this release also comes with `StateManager` API changes. Usage of the old
+[ethereumjs-account](https://github.com/ethereumjs/ethereumjs-account) package (this package will be retired) has been replaced by the new
+[Account class](https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_account_.md) from the `ethereumjs-util` package. This affects all `Account` related `StateManager` methods, see PR [#911](https://github.com/ethereumjs/ethereumjs-vm/pull/911).
 
-The Util package also introduces a new 
-[Address class](https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_address_.md).
-This class replaces all current `Buffer` inputs on `StateManager` methods representing an address.
+The Util package also introduces a new  [Address class](https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_address_.md). This class replaces all current `Buffer` inputs on `StateManager` methods representing an address.
 
 ### Dual ES5 and ES2017 Builds
 
-We significantly updated our internal tool and CI setup along the work on 
-PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` 
-for code linting and formatting and the introduction of a new build setup.
+We significantly updated our internal tool and CI setup along the work on PR [#913](https://github.com/ethereumjs/ethereumjs-vm/pull/913) with an update to `ESLint` from `TSLint` for code linting and formatting and the introduction of a new build setup.
 
-Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce
-a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see
-PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result
-in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
+Packages now target `ES2017` for Node.js builds (the `main` entrypoint from `package.json`) and introduce a separate `ES5` build distributed along using the `browser` directive as an entrypoint, see PR [#921](https://github.com/ethereumjs/ethereumjs-vm/pull/921). This will result in performance benefits for Node.js consumers, see [here](https://github.com/ethereumjs/merkle-patricia-tree/pull/117) for a releated discussion.
 
 ### Other Changes
 
 **Changes and Refactoring**
 
-- Group opcodes based upon hardfork,
-  PR [#798](https://github.com/ethereumjs/ethereumjs-vm/pull/798)
-- Split opcodes logic into codes, fns, and utils files,
-  PR [#896](https://github.com/ethereumjs/ethereumjs-vm/pull/896)
-- Group precompiles based upon hardfork,
-  PR [#783](https://github.com/ethereumjs/ethereumjs-vm/pull/783)
-- **Breaking:** the `step` event now emits an `ethereumjs-util`
-[Account](https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_account_.md)
-object instead of an [ethereumjs-account](https://github.com/ethereumjs/ethereumjs-account)
+- Group opcodes based upon hardfork, PR [#798](https://github.com/ethereumjs/ethereumjs-vm/pull/798)
+- Split opcodes logic into codes, fns, and utils files, PR [#896](https://github.com/ethereumjs/ethereumjs-vm/pull/896)
+- Group precompiles based upon hardfork, PR [#783](https://github.com/ethereumjs/ethereumjs-vm/pull/783)
+- **Breaking:** the `step` event now emits an `ethereumjs-util` [Account](https://github.com/ethereumjs/ethereumjs-util/blob/master/docs/modules/_account_.md) object instead of an [ethereumjs-account](https://github.com/ethereumjs/ethereumjs-account)
 (package retired) object
-- **Breaking:** `NewContractEvent` now emits an `address` of 
-  type `Address` (see `ethereumjs-util`) instead of a `Buffer`,
-  PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
-- **Breaking:** `EVMResult` now returns a `createdAddress` of
-  type `Address` (see `ethereumjs-util`) instead of a `Buffer`,
-  PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
-- **Breaking:** `RunTxResult` now returns a `createdAddress` of
-  type `Address` (see `ethereumjs-util`) instead of a `Buffer`,
-  PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
-- **Breaking:** `RunCallOpts` now expects `origin`, `caller` and
-  `to` inputs to be of
-  type `Address` (see `ethereumjs-util`) instead of a `Buffer`,
-  PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
-- **Breaking:** `RunCodeOpts` now expects `origin`, `caller` and
-  `address` inputs to be of
-  type `Address` (see `ethereumjs-util`) instead of a `Buffer`,
-  PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
+- **Breaking:** `NewContractEvent` now emits an `address` of type `Address` (see `ethereumjs-util`) instead of a `Buffer`, PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
+- **Breaking:** `EVMResult` now returns a `createdAddress` of type `Address` (see `ethereumjs-util`) instead of a `Buffer`, PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
+- **Breaking:** `RunTxResult` now returns a `createdAddress` of type `Address` (see `ethereumjs-util`) instead of a `Buffer`, PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
+- **Breaking:** `RunCallOpts` now expects `origin`, `caller` and `to` inputs to be of type `Address` (see `ethereumjs-util`) instead of a `Buffer`, PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
+- **Breaking:** `RunCodeOpts` now expects `origin`, `caller` and `address` inputs to be of type `Address` (see `ethereumjs-util`) instead of a `Buffer`, PR [#919](https://github.com/ethereumjs/ethereumjs-vm/pull/919)
 - Visibility cleanup (Renaming and/or code docs additions) for class members not being part of the API, PR [#925](https://github.com/ethereumjs/ethereumjs-vm/pull/925)
-- Make `memory.ts` use Buffers instead of Arrays,
-  PR [#850](https://github.com/ethereumjs/ethereumjs-vm/pull/850)
-- Use `Map` for `OpcodeList` and `opcode` handlers,
-  PR [#852](https://github.com/ethereumjs/ethereumjs-vm/pull/852)
-- Compare buffers directly,
-  PR [#851](https://github.com/ethereumjs/ethereumjs-vm/pull/851)
-- Moved gas base fees from VM to Common,
-  PR [#806](https://github.com/ethereumjs/ethereumjs-vm/pull/806)
-- Return precompiles on `getPrecompile()` based on hardfork,
-  PR [#783](https://github.com/ethereumjs/ethereumjs-vm/pull/783)
-- Removed `async` dependency,
-  PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
-- Updated `ethereumjs-util` to v7,
-  PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
+- Make `memory.ts` use Buffers instead of Arrays, PR [#850](https://github.com/ethereumjs/ethereumjs-vm/pull/850)
+- Use `Map` for `OpcodeList` and `opcode` handlers, PR [#852](https://github.com/ethereumjs/ethereumjs-vm/pull/852)
+- Compare buffers directly, PR [#851](https://github.com/ethereumjs/ethereumjs-vm/pull/851)
+- Moved gas base fees from VM to Common, PR [#806](https://github.com/ethereumjs/ethereumjs-vm/pull/806)
+- Return precompiles on `getPrecompile()` based on hardfork, PR [#783](https://github.com/ethereumjs/ethereumjs-vm/pull/783)
+- Removed `async` dependency, PR [#779](https://github.com/ethereumjs/ethereumjs-vm/pull/779)
+- Updated `ethereumjs-util` to v7, PR [#748](https://github.com/ethereumjs/ethereumjs-vm/pull/748)
 
 **CI and Test Improvements**
 
-- New benchmarking tool for the VM, CI integration on GitHub actions,
-  PR [#794](https://github.com/ethereumjs/ethereumjs-vm/pull/794) and
-  PR [#830](https://github.com/ethereumjs/ethereumjs-vm/pull/830)
-- Various updates, fixes and refactoring work on the test runner,
-  PR [#752](https://github.com/ethereumjs/ethereumjs-vm/pull/752) and
-  PR [#849](https://github.com/ethereumjs/ethereumjs-vm/pull/849)
-- Integrated `ethereumjs-testing` code logic into VM for more
-  flexible future test load optimizations,
-  PR [#808](https://github.com/ethereumjs/ethereumjs-vm/pull/808)
-- Transition VM tests to TypeScript,
-  PR [#881](https://github.com/ethereumjs/ethereumjs-vm/pull/881) and
-  PR [#882](https://github.com/ethereumjs/ethereumjs-vm/pull/882)
+- New benchmarking tool for the VM, CI integration on GitHub actions, PR [#794](https://github.com/ethereumjs/ethereumjs-vm/pull/794) and PR [#830](https://github.com/ethereumjs/ethereumjs-vm/pull/830)
+- Various updates, fixes and refactoring work on the test runner, PR [#752](https://github.com/ethereumjs/ethereumjs-vm/pull/752) and PR [#849](https://github.com/ethereumjs/ethereumjs-vm/pull/849)
+- Integrated `ethereumjs-testing` code logic into VM for more flexible future test load optimizations, PR [#808](https://github.com/ethereumjs/ethereumjs-vm/pull/808)
+- Transition VM tests to TypeScript, PR [#881](https://github.com/ethereumjs/ethereumjs-vm/pull/881) and PR [#882](https://github.com/ethereumjs/ethereumjs-vm/pull/882)
 - On-demand state and blockchain test runs for all hardforks triggered by PR label, PR [#951](https://github.com/ethereumjs/ethereumjs-vm/pull/951) 
 - Dropped `ethereumjs-testing` dev dependency, PR [#953](https://github.com/ethereumjs/ethereumjs-vm/pull/953)
 
 **Bug Fixes**
 
-- Fix `activatePrecompiles`,
-  PR [#797](https://github.com/ethereumjs/ethereumjs-vm/pull/797)
-- Strip zeros when putting contract storage in StateManager,
-  PR [#880](https://github.com/ethereumjs/ethereumjs-vm/pull/880)
-- Two bug fixes along `istanbul` `SSTORE` gas calculation,
-  PR [#870](https://github.com/ethereumjs/ethereumjs-vm/pull/870)
+- Fix `activatePrecompiles`, PR [#797](https://github.com/ethereumjs/ethereumjs-vm/pull/797)
+- Strip zeros when putting contract storage in StateManager, PR [#880](https://github.com/ethereumjs/ethereumjs-vm/pull/880)
+- Two bug fixes along `istanbul` `SSTORE` gas calculation, PR [#870](https://github.com/ethereumjs/ethereumjs-vm/pull/870)
 - Security fixes by `mcl-wasm` package dependency update, PR [#955](https://github.com/ethereumjs/ethereumjs-vm/pull/955)
 
 ## 5.0.0-rc.1 - 2020-11-19

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/vm",
-  "version": "5.0.0-rc.1",
+  "version": "5.0.0",
   "description": "An Ethereum VM implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -45,10 +45,10 @@
   "dependencies": {
     "async-eventemitter": "^0.2.4",
     "core-js-pure": "^3.0.1",
-    "@ethereumjs/block": "3.0.0-rc.1",
-    "@ethereumjs/blockchain": "5.0.0-rc.1",
-    "@ethereumjs/common": "2.0.0-rc.1",
-    "@ethereumjs/tx": "3.0.0-rc.1",
+    "@ethereumjs/block": "^3.0.0",
+    "@ethereumjs/blockchain": "^5.0.0",
+    "@ethereumjs/common": "^2.0.0",
+    "@ethereumjs/tx": "^3.0.0",
     "ethereumjs-util": "^7.0.7",
     "functional-red-black-tree": "^1.0.1",
     "merkle-patricia-tree": "^4.0.0",


### PR DESCRIPTION
Part of #907 

Final release series 🎉   for the VM v5 and other monorepo libraries following #958 

Note: I first wondered if I should just point to the beta and RC release notes in the CHANGELOG or do aggregated new release note entries. Already had a tendency towards the new release notes version also for the sake of user friendliness on reading when the decision was taken from me when I further realized that some sections from the extensive `beta.1` release notes actually had to be rewritten and not just appended together to continuedly make sense. The damage (if there is any) from redundancy should be very limited in this case I would say.