### PR TITLE
Blockchain client requests

### DIFF
--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -130,9 +130,9 @@ Our `TypeScript` VM is implemented as an [AsyncEventEmitter](https://github.com/
 You can subscribe to the following events:
 
 - `beforeBlock`: Emits a `Block` right before running it.
-- `afterBlock`: Emits `RunBlockResult` right after running a block.
+- `afterBlock`: Emits `AfterBlockEvent` right after running a block.
 - `beforeTx`: Emits a `Transaction` right before running it.
-- `afterTx`: Emits a `RunTxResult` right after running a transaction.
+- `afterTx`: Emits a `AfterTxEvent` right after running a transaction.
 - `beforeMessage`: Emits a `Message` right after running it.
 - `afterMessage`: Emits an `EVMResult` right after running a message.
 - `step`: Emits an `InterpreterStep` right before running an EVM step.

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -104,6 +104,11 @@ export interface PostByzantiumTxReceipt extends TxReceipt {
   status: 0 | 1
 }
 
+export interface AfterBlockEvent extends RunBlockResult {
+  // The block which just finished processing
+  block: Block
+}
+
 /**
  * @ignore
  */
@@ -183,14 +188,20 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
 
   const { receipts, results } = result
 
+  const afterBlockEvent: AfterBlockEvent = {
+    receipts,
+    results,
+    block,
+  }
+
   /**
    * The `afterBlock` event
    *
    * @event Event: afterBlock
-   * @type {Object}
-   * @property {Object} result emits the results of processing a block
+   * @type {AfterBlockEvent}
+   * @property {AfterBlockEvent} result emits the results of processing a block
    */
-  await this._emit('afterBlock', { receipts, results })
+  await this._emit('afterBlock', afterBlockEvent)
 
   return { receipts, results }
 }

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -47,6 +47,13 @@ export interface RunTxResult extends EVMResult {
   gasRefund?: BN
 }
 
+export interface AfterTxEvent extends RunTxResult {
+  /**
+   * The transaction which just got finished
+   */
+  transaction: Transaction
+}
+
 /**
  * @ignore
  */
@@ -199,7 +206,8 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    * @type {Object}
    * @property {Object} result result of the transaction
    */
-  await this._emit('afterTx', results)
+  const event: AfterTxEvent = { transaction: tx, ...results }
+  await this._emit('afterTx', event)
 
   return results
 }


### PR DESCRIPTION
Related: #960 

This PR introduces some handy things: `afterBlock` and `afterTx` now get access to which block/tx is finished. Blockchain `iterator` gets an optional parameter which specifies how many blocks should (at most) be ran. It also adds a `setHead` method which allows updating the head of a certain tag, and this is saved in the DB. Related issue: #691.