### PR TITLE
VM: add selectHardforkByBlockNumber option

### DIFF
--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -89,6 +89,14 @@ export interface VMOpts {
    * Default: `false` [ONLY set to `true` during debugging]
    */
   allowUnlimitedContractSize?: boolean
+
+  /**
+   * Select hardfork based upon block number. This automatically switches to the right hard fork based upon the block number.
+   *
+   * Default: `true`
+   */
+
+  selectHardforkByBlockNumber?: boolean
 }
 
 /**
@@ -113,6 +121,7 @@ export default class VM extends AsyncEventEmitter {
   protected _isInitialized: boolean = false
   protected readonly _allowUnlimitedContractSize: boolean
   protected _opcodes: OpcodeList
+  protected readonly _selectHardforkByBlockNumber: boolean
 
   /**
    * Cached emit() function, not for public usage
@@ -202,6 +211,8 @@ export default class VM extends AsyncEventEmitter {
     this.blockchain = opts.blockchain || new Blockchain({ common: this._common })
 
     this._allowUnlimitedContractSize = opts.allowUnlimitedContractSize || false
+
+    this._selectHardforkByBlockNumber = opts.selectHardforkByBlockNumber ?? true
 
     if (this._common.eips().includes(2537)) {
       if (IS_BROWSER) {

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -95,7 +95,6 @@ export interface VMOpts {
    *
    * Default: `true`
    */
-
   selectHardforkByBlockNumber?: boolean
 }
 

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -122,6 +122,14 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
    */
   await this._emit('beforeBlock', block)
 
+  if (this._selectHardforkByBlockNumber) {
+    const currentHf = this._common.hardfork()
+    this._common.setHardforkByBlockNumber(block.header.number.toNumber())
+    if (this._common.hardfork() != currentHf) {
+      this._updateOpcodes()
+    }
+  }
+
   // Set state root if provided
   if (root) {
     await state.setStateRoot(root)

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -71,6 +71,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
     state,
     blockchain,
     common,
+    selectHardforkByBlockNumber: false,
   })
 
   // set up pre-state

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -22,5 +22,8 @@ export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
       genesisBlock,
     })
   }
-  return new VM(opts)
+  return new VM({
+    selectHardforkByBlockNumber: false,
+    ...opts,
+  })
 }


### PR DESCRIPTION
This PR adds an option to make the VM automatically switch to the right hardfork in `runBlock`.