### PR TITLE
VM: fix selectHardforkByBlockNumber default value

### DIFF
--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -93,7 +93,7 @@ export interface VMOpts {
   /**
    * Select hardfork based upon block number. This automatically switches to the right hard fork based upon the block number.
    *
-   * Default: `true`
+   * Default: `false`
    */
   selectHardforkByBlockNumber?: boolean
 }
@@ -211,7 +211,7 @@ export default class VM extends AsyncEventEmitter {
 
     this._allowUnlimitedContractSize = opts.allowUnlimitedContractSize || false
 
-    this._selectHardforkByBlockNumber = opts.selectHardforkByBlockNumber ?? true
+    this._selectHardforkByBlockNumber = opts.selectHardforkByBlockNumber ?? false
 
     if (this._common.eips().includes(2537)) {
       if (IS_BROWSER) {

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -71,7 +71,6 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
     state,
     blockchain,
     common,
-    selectHardforkByBlockNumber: false,
   })
 
   // set up pre-state

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -148,8 +148,8 @@ tape('should correctly use the selectHardforkByBlockNumber option', async (t) =>
     )
   }
 
-  const vm = new VM({ common: common1 })
-  const vm_noSelect = new VM({ common: common2, selectHardforkByBlockNumber: false })
+  const vm = new VM({ common: common1, selectHardforkByBlockNumber: true })
+  const vm_noSelect = new VM({ common: common2 })
 
   const txResultMuirGlacier = await vm.runBlock({
     block: getBlock(common1),

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -23,7 +23,6 @@ export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
     })
   }
   return new VM({
-    selectHardforkByBlockNumber: false,
     ...opts,
   })
 }


### PR DESCRIPTION
Fixes the default value of the `selectHardforkByBlockNumber` as pointed out by @holgerd77 in #966.