### PR TITLE
blockchain: fix heads for leveldown

### DIFF
--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -52,7 +52,7 @@ export class DBManager {
    * Fetches iterator heads from the db.
    */
   async getHeads(): Promise<{ [key: string]: Buffer }> {
-    const heads = await this.get(DBTarget.Heads)
+    const heads = JSON.parse((await this.get(DBTarget.Heads)).toString())
     Object.keys(heads).forEach((key) => {
       heads[key] = Buffer.from(heads[key])
     })
@@ -185,7 +185,12 @@ export class DBManager {
    * Performs a batch operation on db.
    */
   async batch(ops: DBOp[]) {
-    const convertedOps: DBOpData[] = ops.map((op) => op.baseDBOp)
+    const convertedOps = ops.map((op) => {
+      return {
+        ...op.baseDBOp,
+        value: op.baseDBOp.value instanceof Buffer ? op.baseDBOp.value : JSON.stringify(op.baseDBOp.value)
+      }
+    })
     // update the current cache for each operation
     ops.map((op) => op.updateCache(this._cache))
 

--- a/packages/blockchain/src/db/operation.ts
+++ b/packages/blockchain/src/db/operation.ts
@@ -105,6 +105,8 @@ export class DBOp {
   }
 
   // set operation: note: value/key is not in default order
+  public static set(operationTarget: DBTarget.Heads, value: object, key?: DatabaseKey): DBOp;
+  public static set(operationTarget: DBTarget, value: Buffer, key?: DatabaseKey): DBOp;
   public static set(operationTarget: DBTarget, value: Buffer | object, key?: DatabaseKey): DBOp {
     const dbOperation = new DBOp(operationTarget, key)
     dbOperation.baseDBOp.value = value


### PR DESCRIPTION
Leveldown does not support storing objects. Objects must first be converted to a string.

Example(copy from packages/vm/examples/run-blockchain/index.ts):

```
import { Account, Address, toBuffer, setLengthLeft } from 'ethereumjs-util'
import { Block } from '@ethereumjs/block'
import Blockchain from '@ethereumjs/blockchain'
import Common from '@ethereumjs/common'
import VM from '../../'

const testData = require('./test-data')
import levelUp from 'levelup';
import levelDown from 'leveldown';

async function main() {
  const levelDB = levelUp(levelDown('./db'))
  const common = new Common({ chain: testData.network.toLowerCase(), hardfork: 'chainstart' })
  const validatePow = false
  const validateBlocks = false

  const blockchain = await Blockchain.create({
    db: levelDB,
    common,
    validateConsensus: validatePow,
    validateBlocks,
    genesisBlock: getGenesisBlock(common)
  })

  // When verifying PoW, setting this cache improves the
  // performance of subsequent runs of this script.
  // Note that this optimization is a bit hacky and might
  // not be working in the future though. :-)
  // if (validatePow) {
  //   blockchain._ethash!.cacheDB = level('./.cachedb')
  // }

  const vm = new VM({ blockchain, common })

  await setupPreConditions(vm, testData)

  await putBlocks(blockchain, common, testData)

  await vm.runBlockchain(blockchain)

  const blockchainHead = await vm.blockchain.getHead()

  console.log('--- Finished processing the BlockChain ---')
  console.log('New head:', '0x' + blockchainHead.hash().toString('hex'))
  console.log('Expected:', testData.lastblockhash)

  // pay attention to this line
  console.log('heads', await vm.blockchain.dbManager.getHeads())
}

async function setupPreConditions(vm: VM, testData: any) {
  await vm.stateManager.checkpoint()

  for (const addr of Object.keys(testData.pre)) {
    const { nonce, balance, storage, code } = testData.pre[addr]

    const address = new Address(Buffer.from(addr.slice(2), 'hex'))
    const account = Account.fromAccountData({ nonce, balance })
    await vm.stateManager.putAccount(address, account)

    for (const hexStorageKey of Object.keys(storage)) {
      const val = Buffer.from(storage[hexStorageKey], 'hex')
      const storageKey = setLengthLeft(Buffer.from(hexStorageKey, 'hex'), 32)

      await vm.stateManager.putContractStorage(address, storageKey, val)
    }

    const codeBuf = Buffer.from(code.slice(2), 'hex')

    await vm.stateManager.putContractCode(address, codeBuf)
  }

  await vm.stateManager.commit()
}

function getGenesisBlock(common: Common) {
  const header = testData.genesisBlockHeader
  const genesis = Block.genesis({ header }, { common })
  return genesis
}

async function putBlocks(blockchain: any, common: Common, testData: any) {
  for (const blockData of testData.blocks) {
    const blockRlp = toBuffer(blockData.rlp)
    const block = Block.fromRLPSerializedBlock(blockRlp, { common })
    await blockchain.putBlock(block)
  }
}

main()
  .then(() => process.exit(0))
  .catch((err) => {
    console.error(err)
    process.exit(1)
  })

```

You will get this error:

```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type number (91)
    at Function.from (buffer.js:329:9)
    at /Users/samlior/Git/ethereumjs-vm/packages/blockchain/src/db/manager.ts:58:27
    at Array.forEach (<anonymous>)
    at DBManager.getHeads (/Users/samlior/Git/ethereumjs-vm/packages/blockchain/src/db/manager.ts:57:24)
    at main (/Users/samlior/Git/ethereumjs-vm/packages/vm/examples/run-blockchain/index.ts:49:17) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

Now the value in the leveldb database is 0x5b6f626a656374204f626a6563745d(string '[object Object]'), because leveldown converts the object when it is stored.