### PR TITLE
Use vm's common when creating default blocks in `runCall` and `runCode`

### DIFF
--- a/packages/vm/lib/runCall.ts
+++ b/packages/vm/lib/runCall.ts
@@ -33,27 +33,29 @@ export interface RunCallOpts {
  * @ignore
  */
 export default function runCall(this: VM, opts: RunCallOpts): Promise<EVMResult> {
-  const block = opts.block || new Block()
+  const block = opts.block ?? Block.fromBlockData({}, { common: this._common })
 
   const txContext = new TxContext(
-    opts.gasPrice || new BN(0),
-    opts.origin || opts.caller || Address.zero()
+    opts.gasPrice ?? new BN(0),
+    opts.origin ?? opts.caller ?? Address.zero()
   )
+
   const message = new Message({
     caller: opts.caller,
-    gasLimit: opts.gasLimit ? opts.gasLimit : new BN(0xffffff),
-    to: opts.to ? opts.to : undefined,
+    gasLimit: opts.gasLimit ?? new BN(0xffffff),
+    to: opts.to ?? undefined,
     value: opts.value,
     data: opts.data,
     code: opts.code,
-    depth: opts.depth || 0,
-    isCompiled: opts.compiled || false,
-    isStatic: opts.static || false,
-    salt: opts.salt || null,
-    selfdestruct: opts.selfdestruct || {},
-    delegatecall: opts.delegatecall || false,
+    depth: opts.depth ?? 0,
+    isCompiled: opts.compiled ?? false,
+    isStatic: opts.static ?? false,
+    salt: opts.salt ?? null,
+    selfdestruct: opts.selfdestruct ?? {},
+    delegatecall: opts.delegatecall ?? false,
   })
 
   const evm = new EVM(this, txContext, block)
+
   return evm.executeMessage(message)
 }

--- a/packages/vm/lib/runCall.ts
+++ b/packages/vm/lib/runCall.ts
@@ -18,7 +18,7 @@ export interface RunCallOpts {
   value?: BN
   data?: Buffer
   /**
-   * This is for CALLCODE where the code to load is different than the code from the to account
+   * This is for CALLCODE where the code to load is different than the code from the `opts.to` address.
    */
   code?: Buffer
   depth?: number

--- a/packages/vm/lib/runCode.ts
+++ b/packages/vm/lib/runCode.ts
@@ -71,35 +71,28 @@ export interface RunCodeOpts {
  * @ignore
  */
 export default function runCode(this: VM, opts: RunCodeOpts): Promise<ExecResult> {
-  if (!opts.block) {
-    opts.block = new Block()
-  }
+  const block = opts.block ?? Block.fromBlockData({}, { common: this._common })
 
   // Backwards compatibility
-  if (!opts.txContext) {
-    opts.txContext = new TxContext(
-      opts.gasPrice || new BN(0),
-      opts.origin || opts.caller || Address.zero()
-    )
-  }
-  if (!opts.message) {
-    opts.message = new Message({
+  const txContext =
+    opts.txContext ??
+    new TxContext(opts.gasPrice ?? new BN(0), opts.origin ?? opts.caller ?? Address.zero())
+
+  const message =
+    opts.message ??
+    new Message({
       code: opts.code,
       data: opts.data,
       gasLimit: opts.gasLimit,
-      to: opts.address || Address.zero(),
+      to: opts.address ?? Address.zero(),
       caller: opts.caller,
       value: opts.value,
-      depth: opts.depth || 0,
-      selfdestruct: opts.selfdestruct || {},
-      isStatic: opts.isStatic || false,
+      depth: opts.depth ?? 0,
+      selfdestruct: opts.selfdestruct ?? {},
+      isStatic: opts.isStatic ?? false,
     })
-  }
 
-  let evm = opts.evm
-  if (!evm) {
-    evm = new EVM(this, opts.txContext, opts.block)
-  }
+  const evm = opts.evm ?? new EVM(this, txContext, block)
 
-  return evm.runInterpreter(opts.message, { pc: opts.pc })
+  return evm.runInterpreter(message, { pc: opts.pc })
 }

--- a/packages/vm/lib/runCode.ts
+++ b/packages/vm/lib/runCode.ts
@@ -4,12 +4,12 @@ This is the core of the Ethereum Virtual Machine (EVM or just VM).
 
 NOTES:
 
-stack items are lazily duplicated.
-So you must never directly change a buffer from the stack,
-instead you should `copy` it first
+1. Stack items are lazily duplicated, so you must never directly change a buffer
+from the stack, instead you should `copy` it first.
 
-not all stack items are 32 bytes, so if the operation relies on the stack
-item length then you must use utils.pad(<item>, 32) first.
+2. Not all stack items are 32 bytes, so if the operation relies on the stack
+item length then you must use `utils.pad(<item>, 32)` first.
+
 */
 import { Address, BN } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
@@ -23,7 +23,7 @@ import { default as EVM, ExecResult } from './evm/evm'
  */
 export interface RunCodeOpts {
   /**
-   * The [`Block`](https://github.com/ethereumjs/ethereumjs-block) the `tx` belongs to. If omitted a blank block will be used
+   * The `@ethereumjs/block` the `tx` belongs to. If omitted a default blank block will be used.
    */
   block?: Block
   evm?: EVM

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -57,10 +57,7 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
   }
 
   // create a reasonable default if no block is given
-  if (!opts.block) {
-    const common = opts.tx.common
-    opts.block = Block.fromBlockData({}, { common })
-  }
+  opts.block = opts.block ?? Block.fromBlockData({}, { common: opts.tx.common })
 
   if (opts.block.header.gasLimit.lt(opts.tx.gasLimit)) {
     throw new Error('tx has a higher gas limit than the block')

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -12,11 +12,11 @@ import TxContext from './evm/txContext'
  */
 export interface RunTxOpts {
   /**
-   * The block to which the `tx` belongs
+   * The `@ethereumjs/block` the `tx` belongs to. If omitted a default blank block will be used.
    */
   block?: Block
   /**
-   * An [`@ethereumjs/tx`](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/tx) to run
+   * An `@ethereumjs/tx` to run
    */
   tx: Transaction
   /**


### PR DESCRIPTION
This PR resolves #530 by using the vm's common for default blocks created in `runCall` and `runCode`. It also updates some of the code to prefer using the nullish coalescing operator.