### PR TITLE
Client: add VM execution (old)

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -102,6 +102,8 @@ async function runNode(config: Config) {
   const client = new EthereumClient({
     config,
     chainDB: level(syncDataDir),
+    // TODO rework to have a consistent dynamic base directory with chainDB
+    stateDB: level('./statedir')
   })
   client.on('error', (err: any) => config.logger.error(err))
   client.on('listening', (details: any) => {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -91,9 +91,12 @@ let logger: Logger | null = null
  * @param config
  */
 async function runNode(config: Config) {
-  const syncDataDir = config.getSyncDataDirectory()
-  fs.ensureDirSync(syncDataDir)
-  config.logger.info(`Sync data directory: ${syncDataDir}`)
+  const chainDataDir = config.getChainDataDirectory()
+  fs.ensureDirSync(chainDataDir)
+  const stateDataDir = config.getStateDataDirectory()
+  fs.ensureDirSync(stateDataDir)
+
+  config.logger.info(`Data directory: ${config.datadir}`)
 
   config.logger.info('Initializing Ethereumjs client...')
   if (config.lightserv) {
@@ -101,9 +104,9 @@ async function runNode(config: Config) {
   }
   const client = new EthereumClient({
     config,
-    chainDB: level(syncDataDir),
+    chainDB: level(chainDataDir),
     // TODO rework to have a consistent dynamic base directory with chainDB
-    stateDB: level('./statedir')
+    stateDB: level(stateDataDir),
   })
   client.on('error', (err: any) => config.logger.error(err))
   client.on('listening', (details: any) => {
@@ -147,7 +150,7 @@ async function run() {
     common,
     syncmode: args.syncmode,
     lightserv: args.lightserv,
-    datadir: `${os.homedir()}/Library/Ethereum`,
+    datadir: `${os.homedir()}/Library/Ethereum/ethereumjs`,
     transports: args.transports,
     rpc: args.rpc,
     rpcport: args.rpcport,

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -101,7 +101,7 @@ async function runNode(config: Config) {
   }
   const client = new EthereumClient({
     config,
-    db: level(syncDataDir),
+    chainDB: level(syncDataDir),
   })
   client.on('error', (err: any) => config.logger.error(err))
   client.on('listening', (details: any) => {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -105,7 +105,6 @@ async function runNode(config: Config) {
   const client = new EthereumClient({
     config,
     chainDB: level(chainDataDir),
-    // TODO rework to have a consistent dynamic base directory with chainDB
     stateDB: level(stateDataDir),
   })
   client.on('error', (err: any) => config.logger.error(err))

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -17,7 +17,7 @@ export interface ChainOptions {
   /**
    * Database to store blocks and metadata. Should be an abstract-leveldown compliant store.
    */
-  db?: LevelUp
+  chainDB?: LevelUp
 
   /**
    * Specify a blockchain which implements the Chain interface
@@ -79,7 +79,7 @@ export interface GenesisBlockParams {
 export class Chain extends EventEmitter {
   public config: Config
 
-  public db: LevelUp
+  public chainDB: LevelUp
   public blockchain: Blockchain
   public opened: boolean
 
@@ -107,13 +107,13 @@ export class Chain extends EventEmitter {
     this.blockchain =
       options.blockchain ??
       new Blockchain({
-        db: options.db,
+        db: options.chainDB,
         common: this.config.common,
         validateBlocks: false,
         validateConsensus: false,
       })
 
-    this.db = this.blockchain.db
+    this.chainDB = this.blockchain.db
     this.opened = false
   }
 

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -13,7 +13,7 @@ export interface EthereumClientOptions {
    *
    * Default: Database created by the Blockchain class
    */
-  db?: LevelUp
+  chainDB?: LevelUp
 
   /* List of bootnodes to use for discovery */
   bootnodes?: BootnodeLike[]
@@ -51,11 +51,11 @@ export default class EthereumClient extends events.EventEmitter {
       this.config.syncmode === 'full'
         ? new FullEthereumService({
             config: this.config,
-            db: options.db,
+            chainDB: options.chainDB,
           })
         : new LightEthereumService({
             config: this.config,
-            db: options.db,
+            chainDB: options.chainDB,
           }),
     ]
     this.opened = false

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -17,7 +17,7 @@ export interface EthereumClientOptions {
 
   /**
    * Database to store the state. Should be an abstract-leveldown compliant store.
-   * 
+   *
    * Default: Database created by the Trie class
    */
   stateDB?: LevelUp

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -15,6 +15,13 @@ export interface EthereumClientOptions {
    */
   chainDB?: LevelUp
 
+  /**
+   * Database to store the state. Should be an abstract-leveldown compliant store.
+   * 
+   * Default: Database created by the Trie class
+   */
+  stateDB?: LevelUp
+
   /* List of bootnodes to use for discovery */
   bootnodes?: BootnodeLike[]
 
@@ -52,10 +59,12 @@ export default class EthereumClient extends events.EventEmitter {
         ? new FullEthereumService({
             config: this.config,
             chainDB: options.chainDB,
+            stateDB: options.stateDB,
           })
         : new LightEthereumService({
             config: this.config,
             chainDB: options.chainDB,
+            stateDB: options.stateDB,
           }),
     ]
     this.opened = false

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -184,15 +184,25 @@ export class Config {
   }
 
   /**
-   * Returns the directory for storing the client sync data
+   * Returns the directory for storing the client chain data
    * based on syncmode and selected chain (subdirectory of 'datadir')
    */
-  getSyncDataDirectory(): string {
-    const syncDirName = this.syncmode === 'light' ? 'lightchaindata' : 'chaindata'
-    const chain = this.common.chainName()
-    const networkDirName = chain === 'mainnet' ? '' : `${chain}/`
+  getChainDataDirectory(): string {
+    const networkDirName = this.common.chainName()
+    const chainDataDirName = this.syncmode === 'light' ? 'lightchain' : 'chain'
 
-    const dataDir = `${this.datadir}/${networkDirName}ethereumjs/${syncDirName}`
+    const dataDir = `${this.datadir}/${networkDirName}/${chainDataDirName}`
+    return dataDir
+  }
+
+  /**
+   * Returns the directory for storing the client state data
+   * based selected chain (subdirectory of 'datadir')
+   */
+  getStateDataDirectory(): string {
+    const networkDirName = this.common.chainName()
+
+    const dataDir = `${this.datadir}/${networkDirName}/state`
     return dataDir
   }
 }

--- a/packages/client/lib/service/ethereumservice.ts
+++ b/packages/client/lib/service/ethereumservice.ts
@@ -9,7 +9,7 @@ export interface EthereumServiceOptions extends ServiceOptions {
   chain?: Chain
 
   /* Blockchain database */
-  db?: LevelUp
+  chainDB?: LevelUp
 
   /* Protocol timeout in ms (default: 8000) */
   timeout?: number

--- a/packages/client/lib/service/ethereumservice.ts
+++ b/packages/client/lib/service/ethereumservice.ts
@@ -11,6 +11,9 @@ export interface EthereumServiceOptions extends ServiceOptions {
   /* Blockchain database */
   chainDB?: LevelUp
 
+  /* State database */
+  stateDB?: LevelUp
+
   /* Protocol timeout in ms (default: 8000) */
   timeout?: number
 

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -33,6 +33,7 @@ export class FullEthereumService extends EthereumService {
       config: this.config,
       pool: this.pool,
       chain: this.chain,
+      stateDB: options.stateDB,
       interval: this.interval,
     })
   }

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -1,60 +1,19 @@
 import { Fetcher, FetcherOptions } from './fetcher'
 import { Block, BlockBodyBuffer } from '@ethereumjs/block'
-import { BN } from 'ethereumjs-util'
 import { Peer } from '../../net/peer'
 import { EthProtocolMethods } from '../../net/protocol'
-import { Chain } from '../../blockchain'
-
-export interface BlockFetcherOptions extends FetcherOptions {
-  /* Blockchain */
-  chain: Chain
-
-  /* Block number to start fetching from */
-  first: BN
-
-  /* How many blocks to fetch */
-  count: BN
-}
 
 /**
  * Implements an eth/62 based block fetcher
  * @memberof module:sync/fetcher
  */
 export class BlockFetcher extends Fetcher {
-  protected chain: Chain
-  protected first: BN
-  protected count: BN
-
   /**
    * Create new block fetcher
-   * @param {BlockFetcherOptions}
+   * @param {FetcherOptions}
    */
-  constructor(options: BlockFetcherOptions) {
+  constructor(options: FetcherOptions) {
     super(options)
-
-    this.chain = options.chain
-    this.maxPerRequest = options.maxPerRequest ?? 128
-    this.first = options.first
-    this.count = options.count
-  }
-
-  /**
-   * Generate list of tasks to fetch
-   * @return {Object[]} tasks
-   */
-  tasks(): object[] {
-    const { first, count } = this
-    const max = this.maxPerRequest
-    const tasks = []
-    while (count.gten(max)) {
-      tasks.push({ first: first.clone(), count: max })
-      first.iaddn(max)
-      count.isubn(max)
-    }
-    if (count.gtn(0)) {
-      tasks.push({ first: first.clone(), count: count.toNumber() })
-    }
-    return tasks
   }
 
   /**

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -30,7 +30,7 @@ export interface FetcherOptions {
   /* Max write queue size (default: 16) */
   maxQueue?: number
 
-  /* Max items per request (default: 25) */
+  /* Max items per request (default: 250) */
   maxPerRequest?: number
 
   /* Retry interval in ms (default: 1000) */
@@ -84,7 +84,7 @@ export class Fetcher extends Readable {
     this.interval = options.interval ?? 1000
     this.banTime = options.banTime ?? 60000
     this.maxQueue = options.maxQueue ?? 16
-    this.maxPerRequest = options.maxPerRequest ?? 25
+    this.maxPerRequest = options.maxPerRequest ?? 250
 
     this.in = new Heap({ comparBefore: (a: any, b: any) => a.index < b.index })
     this.out = new Heap({ comparBefore: (a: any, b: any) => a.index < b.index })

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -30,7 +30,7 @@ export interface FetcherOptions {
   /* Max write queue size (default: 16) */
   maxQueue?: number
 
-  /* Max items per request (default: 250) */
+  /* Max items per request (default: 50) */
   maxPerRequest?: number
 
   /* Retry interval in ms (default: 1000) */
@@ -84,7 +84,7 @@ export class Fetcher extends Readable {
     this.interval = options.interval ?? 1000
     this.banTime = options.banTime ?? 60000
     this.maxQueue = options.maxQueue ?? 16
-    this.maxPerRequest = options.maxPerRequest ?? 250
+    this.maxPerRequest = options.maxPerRequest ?? 50
 
     this.in = new Heap({ comparBefore: (a: any, b: any) => a.index < b.index })
     this.out = new Heap({ comparBefore: (a: any, b: any) => a.index < b.index })

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -30,7 +30,7 @@ export interface FetcherOptions {
   /* Max write queue size (default: 16) */
   maxQueue?: number
 
-  /* Max items per request (default: 128) */
+  /* Max items per request (default: 25) */
   maxPerRequest?: number
 
   /* Retry interval in ms (default: 1000) */
@@ -84,7 +84,7 @@ export class Fetcher extends Readable {
     this.interval = options.interval ?? 1000
     this.banTime = options.banTime ?? 60000
     this.maxQueue = options.maxQueue ?? 16
-    this.maxPerRequest = options.maxPerRequest ?? 128
+    this.maxPerRequest = options.maxPerRequest ?? 25
 
     this.in = new Heap({ comparBefore: (a: any, b: any) => a.index < b.index })
     this.out = new Heap({ comparBefore: (a: any, b: any) => a.index < b.index })

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -1,8 +1,8 @@
-import { BlockFetcher, BlockFetcherOptions } from './blockfetcher'
+import { Fetcher, FetcherOptions } from './fetcher'
 import { Peer } from '../../net/peer'
 import { FlowControl, LesProtocolMethods } from '../../net/protocol'
 
-export interface HeaderFetcherOptions extends BlockFetcherOptions {
+export interface HeaderFetcherOptions extends FetcherOptions {
   /* Flow control manager */
   flow: FlowControl
 }
@@ -11,7 +11,7 @@ export interface HeaderFetcherOptions extends BlockFetcherOptions {
  * Implements an les/1 based header fetcher
  * @memberof module:sync/fetcher
  */
-export class HeaderFetcher extends BlockFetcher {
+export class HeaderFetcher extends Fetcher {
   private flow: FlowControl
 
   /**

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -1,5 +1,4 @@
 import { BN } from 'ethereumjs-util'
-import VM from '@ethereumjs/vm'
 import { Peer } from '../net/peer/peer'
 import { short } from '../util'
 import { Synchronizer, SynchronizerOptions } from './sync'
@@ -10,24 +9,11 @@ import { BlockFetcher } from './fetcher'
  * @memberof module:sync
  */
 export class FullSynchronizer extends Synchronizer {
-  public vm: VM
-
   private blockFetcher: BlockFetcher | null
 
   constructor(options: SynchronizerOptions) {
     super(options)
     this.blockFetcher = null
-
-    if (!this.config.vm) {
-      this.vm = new VM({
-        common: this.config.common,
-        blockchain: this.chain.blockchain,
-      })
-    } else {
-      this.vm = this.config.vm
-      //@ts-ignore blockchain has readonly property
-      this.vm.blockchain = this.chain.blockchain
-    }
   }
 
   /**

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -21,6 +21,10 @@ export class FullSynchronizer extends Synchronizer {
   private stopSyncing: boolean
   private vmPromise?: Promise<void>
 
+  // Tracking vars for log msg condensation on zero tx blocks
+  private NUM_ZERO_TXS_PER_LOG_MSG = 250
+  private zeroTxsBlockLogMsgCounter: number = 0
+
   constructor(options: SynchronizerOptions) {
     super(options)
     this.blockFetcher = null
@@ -69,17 +73,29 @@ export class FullSynchronizer extends Synchronizer {
       let oldHead = (await this.vm.blockchain.getHead()).hash()
       let newHead = Buffer.alloc(0)
       while (!newHead.equals(oldHead) && !this.stopSyncing) {
-        newHead = oldHead
+        oldHead = newHead
         this.vmPromise = this.vm.runBlockchain(this.vm.blockchain, 1)
         await this.vmPromise
         const headBlock = await this.vm.blockchain.getHead()
-        oldHead = headBlock.hash()
+        newHead = headBlock.hash()
         // check if we did run a new block:
-        if (!oldHead.equals(newHead)) {
-          const hash = short(oldHead)
-          this.config.logger.info(
-            `Executed block number=${headBlock.header.number.toNumber()} hash=${hash} txs=${headBlock.transactions.length}`
-          )
+        if (!newHead.equals(oldHead)) {
+          const number = headBlock.header.number.toNumber()
+          const hash = short(newHead)
+          const numTxs = headBlock.transactions.length
+          if (numTxs === 0) {
+            this.zeroTxsBlockLogMsgCounter += 1
+          }
+          if (
+            (numTxs > 0 && this.zeroTxsBlockLogMsgCounter > 0) ||
+            (numTxs === 0 && this.zeroTxsBlockLogMsgCounter >= this.NUM_ZERO_TXS_PER_LOG_MSG)
+          ) {
+            this.config.logger.info(`Processed ${this.zeroTxsBlockLogMsgCounter} blocks with 0 txs`)
+            this.zeroTxsBlockLogMsgCounter = 0
+          }
+          if (numTxs > 0) {
+            this.config.logger.info(`Executed block number=${number} hash=${hash} txs=${numTxs}`)
+          }
         }
       }
     } finally {

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -78,7 +78,7 @@ export class FullSynchronizer extends Synchronizer {
         if (!oldHead.equals(newHead)) {
           const hash = short(oldHead)
           this.config.logger.info(
-            `Executed block number=${headBlock.header.number.toNumber()} hash=${hash}`
+            `Executed block number=${headBlock.header.number.toNumber()} hash=${hash} txs=${headBlock.transactions.length}`
           )
         }
       }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -22,7 +22,7 @@ export class FullSynchronizer extends Synchronizer {
   private vmPromise?: Promise<void>
 
   // Tracking vars for log msg condensation on zero tx blocks
-  private NUM_ZERO_TXS_PER_LOG_MSG = 250
+  private NUM_ZERO_TXS_PER_LOG_MSG = 50
   private zeroTxsBlockLogMsgCounter: number = 0
 
   constructor(options: SynchronizerOptions) {

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -70,8 +70,8 @@ export class FullSynchronizer extends Synchronizer {
     }
     this.runningBlocks = true
     try {
-      let oldHead = (await this.vm.blockchain.getHead()).hash()
-      let newHead = Buffer.alloc(0)
+      let oldHead = Buffer.alloc(0)
+      let newHead = (await this.vm.blockchain.getHead()).hash()
       while (!newHead.equals(oldHead) && !this.stopSyncing) {
         oldHead = newHead
         this.vmPromise = this.vm.runBlockchain(this.vm.blockchain, 1)

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -6,7 +6,6 @@ import { BlockFetcher } from './fetcher'
 import VM from '@ethereumjs/vm'
 import { DefaultStateManager } from '@ethereumjs/vm/dist/state'
 import { SecureTrie as Trie } from '@ethereumjs/trie'
-import { LevelUp } from 'levelup'
 const level = require('level')
 
 /**
@@ -17,7 +16,6 @@ export class FullSynchronizer extends Synchronizer {
   private blockFetcher: BlockFetcher | null
 
   public vm: VM
-  private stateDB?: LevelUp
   public runningBlocks: boolean
 
   private stopSyncing: boolean
@@ -32,7 +30,6 @@ export class FullSynchronizer extends Synchronizer {
     this.blockFetcher = null
 
     if (!this.config.vm) {
-      this.stateDB = level('./statedir')
       const trie = new Trie(this.stateDB)
 
       const stateManager = new DefaultStateManager({

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -22,7 +22,7 @@ export class FullSynchronizer extends Synchronizer {
 
   // Tracking vars for log msg condensation on zero tx blocks
   private NUM_ZERO_TXS_PER_LOG_MSG = 50
-  private zeroTxsBlockLogMsgCounter: number = 0
+  public zeroTxsBlockLogMsgCounter: number = 0
 
   constructor(options: SynchronizerOptions) {
     super(options)

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -18,7 +18,7 @@ export class FullSynchronizer extends Synchronizer {
 
   public vm: VM
   private stateDB?: LevelUp
-  private runningBlocks: boolean
+  public runningBlocks: boolean
 
   private stopSyncing: boolean
   private vmPromise?: Promise<void>

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -14,7 +14,12 @@ const level = require('level')
  */
 export class FullSynchronizer extends Synchronizer {
   private blockFetcher: BlockFetcher | null
+
   public vm: VM
+  private runningBlocks: boolean
+
+  private stopSyncing: boolean
+  private vmPromise?: Promise<void>
 
   constructor(options: SynchronizerOptions) {
     super(options)
@@ -40,11 +45,13 @@ export class FullSynchronizer extends Synchronizer {
       this.vm.blockchain = this.chain.blockchain
     }
 
+    this.runningBlocks = false
+    this.stopSyncing = false
+
     const self = this
-    this.chain.on('updated', function () {
+    this.chain.on('updated', async function () {
       // for some reason, if we use .on('updated', this.runBlocks), it runs in the context of the Chain and not in the FullSync context..?
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      self.runBlocks()
+      await self.runBlocks()
     })
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.chain.update()
@@ -54,19 +61,29 @@ export class FullSynchronizer extends Synchronizer {
    * This updates the VM once blocks were put in the VM
    */
   async runBlocks() {
-    let oldHead = (await this.vm.blockchain.getHead()).hash()
-    let newHead = Buffer.alloc(0)
-    while (!newHead.equals(oldHead)) {
-      newHead = oldHead
-      await this.vm.runBlockchain(this.vm.blockchain, 1)
-      const headBlock = await this.vm.blockchain.getHead()
-      oldHead = headBlock.hash()
-      // check if we did run a new block:
-      if (!oldHead.equals(newHead)) {
-        this.config.logger.info(
-          `Imported new chain segment: number=${headBlock.header.number.toNumber()}`
-        )
+    if (this.runningBlocks) {
+      return
+    }
+    this.runningBlocks = true
+    try {
+      let oldHead = (await this.vm.blockchain.getHead()).hash()
+      let newHead = Buffer.alloc(0)
+      while (!newHead.equals(oldHead) && !this.stopSyncing) {
+        newHead = oldHead
+        this.vmPromise = this.vm.runBlockchain(this.vm.blockchain, 1)
+        await this.vmPromise
+        const headBlock = await this.vm.blockchain.getHead()
+        oldHead = headBlock.hash()
+        // check if we did run a new block:
+        if (!oldHead.equals(newHead)) {
+          const hash = short(oldHead)
+          this.config.logger.info(
+            `Executed block number=${headBlock.header.number.toNumber()} hash=${hash}`
+          )
+        }
       }
+    } finally {
+      this.runningBlocks = false
     }
   }
 
@@ -209,6 +226,7 @@ export class FullSynchronizer extends Synchronizer {
     if (!this.running) {
       return false
     }
+    this.stopSyncing = true
     if (this.blockFetcher) {
       this.blockFetcher.destroy()
       // TODO: Should this be deleted?
@@ -216,6 +234,11 @@ export class FullSynchronizer extends Synchronizer {
       delete this.blockFetcher
     }
     await super.stop()
+
+    if (this.vmPromise) {
+      // ensure that we wait that the VM finishes executing the block (and flushes the trie cache)
+      await this.vmPromise
+    }
     return true
   }
 }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -63,7 +63,7 @@ export class FullSynchronizer extends Synchronizer {
    * This updates the VM once blocks were put in the VM
    */
   async runBlocks() {
-    if (this.runningBlocks) {
+    if (!this.running || this.runningBlocks) {
       return
     }
     this.runningBlocks = true
@@ -237,6 +237,7 @@ export class FullSynchronizer extends Synchronizer {
    * @return {Promise}
    */
   async stop(): Promise<boolean> {
+    this.stopSyncing = true
     if (this.vmPromise) {
       // ensure that we wait that the VM finishes executing the block (and flushes the trie cache)
       await this.vmPromise
@@ -246,7 +247,6 @@ export class FullSynchronizer extends Synchronizer {
     if (!this.running) {
       return false
     }
-    this.stopSyncing = true
     if (this.blockFetcher) {
       this.blockFetcher.destroy()
       // TODO: Should this be deleted?

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -6,7 +6,6 @@ import { BlockFetcher } from './fetcher'
 import VM from '@ethereumjs/vm'
 import { DefaultStateManager } from '@ethereumjs/vm/dist/state'
 import { SecureTrie as Trie } from '@ethereumjs/trie'
-const level = require('level')
 
 /**
  * Implements an ethereum full sync synchronizer

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -4,6 +4,7 @@ import { Peer } from '../net/peer/peer'
 import { FlowControl } from '../net/protocol'
 import { Config } from '../config'
 import { Chain } from '../blockchain'
+import { LevelUp } from 'levelup'
 
 export interface SynchronizerOptions {
   /* Config */
@@ -14,6 +15,9 @@ export interface SynchronizerOptions {
 
   /* Blockchain */
   chain: Chain
+
+  /* State database */
+  stateDB?: LevelUp
 
   /* Flow control manager */
   flow?: FlowControl
@@ -31,6 +35,7 @@ export class Synchronizer extends EventEmitter {
 
   protected pool: PeerPool
   protected chain: Chain
+  protected stateDB?: LevelUp
   protected flow: FlowControl
   protected interval: number
   protected running: boolean
@@ -47,6 +52,7 @@ export class Synchronizer extends EventEmitter {
 
     this.pool = options.pool
     this.chain = options.chain
+    this.stateDB = options.stateDB
     this.flow = options.flow ?? new FlowControl()
     this.interval = options.interval ?? 1000
     this.running = false

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -38,7 +38,7 @@ export class Synchronizer extends EventEmitter {
   protected stateDB?: LevelUp
   protected flow: FlowControl
   protected interval: number
-  protected running: boolean
+  public running: boolean
   protected forceSync: boolean
 
   /**

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "ethereumjs-config-lint-fix",
     "tape": "tape -r ts-node/register",
     "test": "npm run test:unit && npm run test:integration && npm run test:browser",
-    "test:unit": "npm run tape -- 'test/!(integration)/**/*.spec.ts'",
+    "test:unit": "npm run tape -- 'test/!(integration)/**/*.spec.ts' 'test/*.spec.ts'",
     "test:integration": "npm run tape -- 'test/integration/**/*.spec.ts'",
     "test:browser": "karma start karma.conf.js"
   },

--- a/packages/client/test/blockchain/chain.spec.ts
+++ b/packages/client/test/blockchain/chain.spec.ts
@@ -15,7 +15,7 @@ tape('[Chain]', (t) => {
   t.test('should test blockchain DB is initialized', async (t) => {
     const chain = new Chain({ config })
 
-    const db = chain.db
+    const db = chain.chainDB
     const testKey = 'name'
     const testValue = 'test'
 

--- a/packages/client/test/config.spec.ts
+++ b/packages/client/test/config.spec.ts
@@ -13,4 +13,16 @@ tape('[Config]', (t) => {
     t.equal(config.maxPeers, 10)
     t.end()
   })
+
+  t.test('getChainDataDirectory() default directory', (t) => {
+    const config = new Config()
+    t.equal(config.getChainDataDirectory(), './datadir/mainnet/chain')
+    t.end()
+  })
+
+  t.test('getStateDataDirectory() default directory', (t) => {
+    const config = new Config()
+    t.equal(config.getStateDataDirectory(), './datadir/mainnet/state')
+    t.end()
+  })
 })

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -17,6 +17,8 @@ tape('[Integration:FullEthereumService]', async (t) => {
       config: serviceConfig,
       chain,
     })
+    // Set runningBlocks to true to skip VM execution
+    service.synchronizer.runningBlocks = true
     await service.open()
     await server.start()
     await service.start()

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -30,13 +30,16 @@ export async function setup(
     interval: interval ?? 10,
   }
 
-  const service =
-    syncmode === 'light'
-      ? new LightEthereumService(serviceOpts)
-      : new FullEthereumService({
-          ...serviceOpts,
-          lightserv: true,
-        })
+  let service
+  if (syncmode === 'light') {
+    service = new LightEthereumService(serviceOpts)
+  } else {
+    service = new FullEthereumService({
+      ...serviceOpts,
+      lightserv: true,
+    })
+    service.synchronizer.runningBlocks = true
+  }
   await service.open()
   await service.start()
 

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -4,6 +4,7 @@ import td from 'testdouble'
 import { BN } from 'ethereumjs-util'
 import { Config } from '../../../lib/config'
 import { Chain } from '../../../lib/blockchain/chain'
+import VM from '@ethereumjs/vm'
 
 async function wait(delay?: number) {
   await new Promise((resolve) => setTimeout(resolve, delay ?? 10))
@@ -43,6 +44,22 @@ tape('[BlockFetcher]', async (t) => {
     fetcher.destroy()
     await wait()
     t.notOk((fetcher as any).running, 'stopped')
+    t.end()
+  })
+
+  t.test('should initialize with VM provided by config', async (t) => {
+    const vm = new VM()
+    const config = new Config({ vm, loglevel: 'error', transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const fetcher = new BlockFetcher({
+      config,
+      pool,
+      chain,
+      first: new BN(0),
+      count: new BN(0),
+    })
+    t.equals(fetcher.vm, vm, 'provided VM is used')
     t.end()
   })
 

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -4,7 +4,6 @@ import td from 'testdouble'
 import { BN } from 'ethereumjs-util'
 import { Config } from '../../../lib/config'
 import { Chain } from '../../../lib/blockchain/chain'
-import VM from '@ethereumjs/vm'
 
 async function wait(delay?: number) {
   await new Promise((resolve) => setTimeout(resolve, delay ?? 10))
@@ -44,22 +43,6 @@ tape('[BlockFetcher]', async (t) => {
     fetcher.destroy()
     await wait()
     t.notOk((fetcher as any).running, 'stopped')
-    t.end()
-  })
-
-  t.test('should initialize with VM provided by config', async (t) => {
-    const vm = new VM()
-    const config = new Config({ vm, loglevel: 'error', transports: [] })
-    const pool = new PeerPool() as any
-    const chain = new Chain({ config })
-    const fetcher = new BlockFetcher({
-      config,
-      pool,
-      chain,
-      first: new BN(0),
-      count: new BN(0),
-    })
-    t.equals(fetcher.vm, vm, 'provided VM is used')
     t.end()
   })
 

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -1,5 +1,7 @@
+import { BN } from 'ethereumjs-util'
 import tape from 'tape-catch'
 import td from 'testdouble'
+import { Chain } from '../../../lib/blockchain/chain'
 import { Config } from '../../../lib/config'
 import { Fetcher } from '../../../lib/sync/fetcher/fetcher'
 
@@ -7,7 +9,14 @@ tape('[Fetcher]', (t) => {
   t.test('should handle bad result', (t) => {
     t.plan(2)
     const config = new Config({ loglevel: 'error', transports: [] })
-    const fetcher = new Fetcher({ config, pool: td.object() })
+    const chain = new Chain({ config })
+    const fetcher = new Fetcher({
+      config,
+      chain,
+      pool: td.object(),
+      first: new BN(0),
+      count: new BN(0),
+    })
     const job: any = { peer: {}, state: 'active' }
     ;(fetcher as any).running = true
     fetcher.next = td.func<Fetcher['next']>()
@@ -21,7 +30,14 @@ tape('[Fetcher]', (t) => {
   t.test('should handle failure', (t) => {
     t.plan(2)
     const config = new Config({ loglevel: 'error', transports: [] })
-    const fetcher = new Fetcher({ config, pool: td.object() })
+    const chain = new Chain({ config })
+    const fetcher = new Fetcher({
+      config,
+      chain,
+      pool: td.object(),
+      first: new BN(0),
+      count: new BN(0),
+    })
     const job = { peer: {}, state: 'active' }
     ;(fetcher as any).running = true
     fetcher.next = td.func<Fetcher['next']>()
@@ -33,9 +49,13 @@ tape('[Fetcher]', (t) => {
   t.test('should handle expiration', (t) => {
     t.plan(2)
     const config = new Config({ loglevel: 'error', transports: [] })
+    const chain = new Chain({ config })
     const fetcher = new Fetcher({
       config,
+      chain,
       pool: td.object(),
+      first: new BN(0),
+      count: new BN(0),
       timeout: 5,
     })
     const job = { index: 0 }

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events'
 import tape from 'tape-catch'
 import td from 'testdouble'
-import VM from '@ethereumjs/vm'
 import { BN } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
@@ -29,16 +28,6 @@ tape('[FullSynchronizer]', async (t) => {
     const sync = new FullSynchronizer({ config, pool, chain })
     pool.emit('added', { eth: true })
     t.equals(sync.type, 'full', 'full type')
-    t.end()
-  })
-
-  t.test('should initialize with VM provided by config', async (t) => {
-    const vm = new VM()
-    const config = new Config({ vm, loglevel: 'error', transports: [] })
-    const pool = new PeerPool() as any
-    const chain = new Chain({ config })
-    const sync = new FullSynchronizer({ config, pool, chain })
-    t.equals(sync.vm, vm, 'provided VM is used')
     t.end()
   })
 

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -169,6 +169,7 @@ tape('[FullSynchronizer]', async (t) => {
       chain,
     })
     const oldHead = sync.vm.blockchain.getHead()
+    sync.running = true
     await sync.runBlocks()
     t.deepEqual(sync.vm.blockchain.getHead(), oldHead, 'should not modify blockchain on emtpy run')
 

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -29,7 +29,6 @@ tape('[FullSynchronizer]', async (t) => {
     const sync = new FullSynchronizer({ config, pool, chain })
     pool.emit('added', { eth: true })
     t.equals(sync.type, 'full', 'full type')
-    await sync.stop()
     t.end()
   })
 
@@ -44,7 +43,6 @@ tape('[FullSynchronizer]', async (t) => {
       chain,
     })
     t.equals(sync.vm, vm, 'provided VM is used')
-    await sync.stop()
     t.end()
   })
 
@@ -154,6 +152,22 @@ tape('[FullSynchronizer]', async (t) => {
 
   t.test('should reset td', (t) => {
     td.reset()
+    t.end()
+  })
+
+  t.test('should run blocks', async (t) => {
+    const vm = new VM()
+    const config = new Config({ vm, loglevel: 'error', transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const sync = new FullSynchronizer({
+      config,
+      pool,
+      chain,
+    })
+    const oldHead = sync.vm.blockchain.getHead()
+    await sync.runBlocks()
+    t.deepEqual(sync.vm.blockchain.getHead(), oldHead, 'should not modify blockchain on emtpy run')
     t.end()
   })
 })

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -29,6 +29,7 @@ tape('[FullSynchronizer]', async (t) => {
     const sync = new FullSynchronizer({ config, pool, chain })
     pool.emit('added', { eth: true })
     t.equals(sync.type, 'full', 'full type')
+    await sync.stop()
     t.end()
   })
 
@@ -43,6 +44,7 @@ tape('[FullSynchronizer]', async (t) => {
       chain,
     })
     t.equals(sync.vm, vm, 'provided VM is used')
+    await sync.stop()
     t.end()
   })
 
@@ -68,6 +70,7 @@ tape('[FullSynchronizer]', async (t) => {
     td.when((sync as any).pool.open()).thenResolve(null)
     await sync.open()
     t.pass('opened')
+    await sync.stop()
     t.end()
   })
 
@@ -81,6 +84,7 @@ tape('[FullSynchronizer]', async (t) => {
     td.when(peer.eth.getBlockHeaders({ block: 'hash', max: 1 })).thenResolve(headers)
     const latest = await sync.latest(peer as any)
     t.equals(new BN(latest!.number).toNumber(), 5, 'got height')
+    await sync.stop()
     t.end()
   })
 
@@ -110,6 +114,7 @@ tape('[FullSynchronizer]', async (t) => {
       Promise.resolve(peer.eth.status.td)
     )
     t.equals(sync.best(), peers[1], 'found best')
+    await sync.stop()
     t.end()
   })
 
@@ -131,15 +136,19 @@ tape('[FullSynchronizer]', async (t) => {
     td.when((BlockFetcher.prototype as any).fetch(), { delay: 20 }).thenResolve(undefined)
     ;(sync as any).chain = { blocks: { height: new BN(3) } }
     t.notOk(await sync.sync(), 'local height > remote height')
+    await sync.stop()
     ;(sync as any).chain = {
       blocks: { height: new BN(0) },
     }
     t.ok(await sync.sync(), 'local height < remote height')
+    await sync.stop()
+
     td.when((BlockFetcher.prototype as any).fetch()).thenReject(new Error('err0'))
     try {
       await sync.sync()
     } catch (err) {
       t.equals(err.message, 'err0', 'got error')
+      await sync.stop()
     }
   })
 

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import tape from 'tape-catch'
 import td from 'testdouble'
 import { BN } from 'ethereumjs-util'
+import VM from '@ethereumjs/vm'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
 
@@ -28,6 +29,20 @@ tape('[FullSynchronizer]', async (t) => {
     const sync = new FullSynchronizer({ config, pool, chain })
     pool.emit('added', { eth: true })
     t.equals(sync.type, 'full', 'full type')
+    t.end()
+  })
+
+  t.test('should initialize with VM provided by config', async (t) => {
+    const vm = new VM()
+    const config = new Config({ vm, loglevel: 'error', transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const sync = new FullSynchronizer({
+      config,
+      pool,
+      chain,
+    })
+    t.equals(sync.vm, vm, 'provided VM is used')
     t.end()
   })
 

--- a/packages/devp2p/src/dpt/dpt.ts
+++ b/packages/devp2p/src/dpt/dpt.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import { publicKeyCreate } from 'secp256k1'
 import { randomBytes } from 'crypto'
 import { debug as createDebugLogger } from 'debug'
-import { pk2id } from '../util'
+import { buffer2int, pk2id } from '../util'
 import { KBucket } from './kbucket'
 import { BanList } from './ban-list'
 import { Server as DPTServer } from './server'
@@ -18,6 +18,7 @@ export class DPT extends EventEmitter {
   private _kbucket: KBucket
   private _server: DPTServer
   private _refreshIntervalId: NodeJS.Timeout
+  private _refreshIntervalSelectionCounter: number = 0
 
   constructor(privateKey: Buffer, options: any) {
     super()
@@ -42,8 +43,8 @@ export class DPT extends EventEmitter {
     this._server.on('peers', (peers) => this._onServerPeers(peers))
     this._server.on('error', (err) => this.emit('error', err))
 
-    const refreshInterval = options.refreshInterval || ms('60s')
-    this._refreshIntervalId = setInterval(() => this.refresh(), refreshInterval)
+    const refreshIntervalSubdivided = Math.floor((options.refreshInterval || ms('60s')) / 10)
+    this._refreshIntervalId = setInterval(() => this.refresh(), refreshIntervalSubdivided)
   }
 
   bind(...args: any[]): void {
@@ -131,9 +132,19 @@ export class DPT extends EventEmitter {
   }
 
   refresh(): void {
+    // Rotating selection counter going in loop from 0..9
+    this._refreshIntervalSelectionCounter = (this._refreshIntervalSelectionCounter + 1) % 10
+
     const peers = this.getPeers()
     debug(`call .refresh (${peers.length} peers in table)`)
 
-    for (const peer of peers) this._server.findneighbours(peer, randomBytes(64))
+    for (const peer of peers) {
+      // Randomly distributed selector based on peer ID
+      // to decide on subdivided execution
+      const selector = buffer2int(peer.id.slice(0, 1)) % 10
+      if (selector === this._refreshIntervalSelectionCounter) {
+        this._server.findneighbours(peer, randomBytes(64))
+      }
+    }
   }
 }

--- a/packages/devp2p/test/integration/dpt-simulator.ts
+++ b/packages/devp2p/test/integration/dpt-simulator.ts
@@ -143,7 +143,9 @@ test('DPT: simulate bootstrap', async (t) => {
   }
 
   for (const dpt of dpts) {
-    dpt.refresh()
+    for (let i = 0; i < 10; i++) {
+      dpt.refresh()
+    }
     await delay(400)
   }
 

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -272,9 +272,9 @@ export default class VM extends AsyncEventEmitter {
    *
    * @param blockchain -  An [@ethereumjs/blockchain](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/blockchain) object to process
    */
-  async runBlockchain(blockchain?: Blockchain): Promise<void> {
+  async runBlockchain(blockchain?: Blockchain, maxBlocks?: number): Promise<void> {
     await this.init()
-    return runBlockchain.bind(this)(blockchain)
+    return runBlockchain.bind(this)(blockchain, maxBlocks)
   }
 
   /**

--- a/packages/vm/lib/runBlockchain.ts
+++ b/packages/vm/lib/runBlockchain.ts
@@ -5,7 +5,7 @@ import VM from './index'
 /**
  * @ignore
  */
-export default async function runBlockchain(this: VM, blockchain?: Blockchain) {
+export default async function runBlockchain(this: VM, blockchain?: Blockchain, maxBlocks?: number) {
   let headBlock: Block
   let parentState: Buffer
 
@@ -36,5 +36,5 @@ export default async function runBlockchain(this: VM, blockchain?: Blockchain) {
       await blockchain!.delBlock(block.header.hash())
       throw error
     }
-  })
+  }, maxBlocks)
 }

--- a/packages/vm/lib/runBlockchain.ts
+++ b/packages/vm/lib/runBlockchain.ts
@@ -11,30 +11,34 @@ export default async function runBlockchain(this: VM, blockchain?: Blockchain, m
 
   blockchain = blockchain || this.blockchain
 
-  await blockchain.iterator('vm', async (block: Block, reorg: boolean) => {
-    // determine starting state for block run
-    // if we are just starting or if a chain re-org has happened
-    if (!headBlock || reorg) {
-      const parentBlock = await blockchain!.getBlock(block.header.parentHash)
-      parentState = parentBlock.header.stateRoot
-      // generate genesis state if we are at the genesis block
-      // we don't have the genesis state
-      if (!headBlock) {
-        await this.stateManager.generateCanonicalGenesis()
-      } else {
-        parentState = headBlock.header.stateRoot
+  await blockchain.iterator(
+    'vm',
+    async (block: Block, reorg: boolean) => {
+      // determine starting state for block run
+      // if we are just starting or if a chain re-org has happened
+      if (!headBlock || reorg) {
+        const parentBlock = await blockchain!.getBlock(block.header.parentHash)
+        parentState = parentBlock.header.stateRoot
+        // generate genesis state if we are at the genesis block
+        // we don't have the genesis state
+        if (!headBlock) {
+          await this.stateManager.generateCanonicalGenesis()
+        } else {
+          parentState = headBlock.header.stateRoot
+        }
       }
-    }
 
-    // run block, update head if valid
-    try {
-      await this.runBlock({ block, root: parentState })
-      // set as new head block
-      headBlock = block
-    } catch (error) {
-      // remove invalid block
-      await blockchain!.delBlock(block.header.hash())
-      throw error
-    }
-  }, maxBlocks)
+      // run block, update head if valid
+      try {
+        await this.runBlock({ block, root: parentState })
+        // set as new head block
+        headBlock = block
+      } catch (error) {
+        // remove invalid block
+        await blockchain!.delBlock(block.header.hash())
+        throw error
+      }
+    },
+    maxBlocks
+  )
 }


### PR DESCRIPTION
Ok, i did some back-and-forth experimentation on where/how to integrate VM execution in the client and I think this should finally do it.

This PR first removes the HeaderFetcher -> BlockFetcher inheritance dependency. This frees the Fetcher classes to now have a clean object relationship to the respective synchronizers (so BlockFetcher <-> FullSynchronizer, HeaderFetcher <-> LightSynchronizer) and subsequently allows for a direct integration of the VM execution into the BlockFetcher, the VM (another time 😄 ) also further moved into this class.

In the `BlockFetcher.store()` function the functionality from `Chain.putBlocks()` is then drawn in and decomposed (this should be no problem since this class is going away anyhow with the wrapper class removal @jochem-brouwer is planning). 
This allows for atomic alternate block execution and blockchain storage (I've also drawn in the three line `Blockchain.putBlocks()` functionality) and assures that only successfully executed upon blocks are stored in the chain.

PR is not running yet. Unit tests are passing but integration tests need some modification since the mock setup now triggers some validation checks to fail along the `vm.runBlock()` run, not sure how to fix this yet.

Client run is also triggering the following error at the moment once a block with transactions is hit: `ERROR [12-16|00:31:58] Error: sender doesn't have enough funds to send tx. The upfront cost is: 996205183388591000 and the sender's account only has: 0` (another error `ERROR [12-16|00:30:46] TypeError: Cannot read property 'map' of undefined
    at BlockFetcher.request (/EthereumJS/ethereumjs-vm/packages/client/dist/lib/sync/fetcher/blockfetcher.js:41:62)` seems unrelated to this PR and might rather be introduced along the type improvements from @ryanio in some previous PRs, at least that's my current unproven suspicion).

So this is rather open to be picked up and further continued.