### PR TITLE
Integrate ETH/64 Protocol into Client

### DIFF
--- a/packages/client/lib/net/peer/libp2ppeer.ts
+++ b/packages/client/lib/net/peer/libp2ppeer.ts
@@ -5,6 +5,8 @@ import { parseMultiaddrs } from '../../util'
 import { Libp2pSender } from '../protocol/libp2psender'
 import { Peer, PeerOptions } from './peer'
 import { Libp2pNode } from './libp2pnode'
+import { Protocol } from '../protocol'
+import { Libp2pServer } from '../server'
 
 export interface Libp2pPeerOptions extends Omit<PeerOptions, 'address' | 'transport'> {
   /* Multiaddrs to listen on (can be a comma separated string or list) */
@@ -73,7 +75,7 @@ export class Libp2pPeer extends Peer {
    * @private
    * @return {Promise}
    */
-  async accept(protocol: any, connection: any, server: any): Promise<void> {
+  async accept(protocol: Protocol, connection: any, server: Libp2pServer): Promise<void> {
     await this.bindProtocol(protocol, new Libp2pSender(connection))
     this.inbound = true
     this.server = server
@@ -87,7 +89,7 @@ export class Libp2pPeer extends Peer {
    * @param  {Server}     [server] optional server that initiated connection
    * @return {Promise}
    */
-  async bindProtocols(node: any, peerInfo: any, server: any = null): Promise<void> {
+  async bindProtocols(node: Libp2pNode, peerInfo: any, server?: Libp2pServer): Promise<void> {
     await Promise.all(
       this.protocols.map(async (p: any) => {
         await p.open()

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -10,8 +10,8 @@ import { Protocol, RlpxSender } from '../protocol'
 import { Peer, PeerOptions } from './peer'
 
 const devp2pCapabilities: any = {
-  eth62: Devp2pETH.eth62,
   eth63: Devp2pETH.eth63,
+  eth64: Devp2pETH.eth64,
   les2: Devp2pLES.les2,
 }
 
@@ -157,9 +157,9 @@ export class RlpxPeer extends Peer {
   async bindProtocols(rlpxPeer: Devp2pRlpxPeer): Promise<void> {
     this.rlpxPeer = rlpxPeer
     await Promise.all(
-      rlpxPeer.getProtocols().map((rlpxProtocol: any) => {
+      rlpxPeer.getProtocols().map((rlpxProtocol) => {
         const name = rlpxProtocol.constructor.name.toLowerCase()
-        const protocol = this.protocols.find((p: any) => p.name === name)
+        const protocol = this.protocols.find((p) => p.name === name)
         if (protocol) {
           return this.bindProtocol(protocol, new RlpxSender(rlpxProtocol))
         }

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -8,6 +8,7 @@ import {
 } from '@ethereumjs/devp2p'
 import { Protocol, RlpxSender } from '../protocol'
 import { Peer, PeerOptions } from './peer'
+import { RlpxServer } from '../server'
 
 const devp2pCapabilities: any = {
   eth63: Devp2pETH.eth63,
@@ -140,7 +141,7 @@ export class RlpxPeer extends Peer {
    * @private
    * @return {Promise}
    */
-  async accept(rlpxPeer: Devp2pRlpxPeer, server: any): Promise<void> {
+  async accept(rlpxPeer: Devp2pRlpxPeer, server: RlpxServer): Promise<void> {
     if (this.connected) {
       return
     }

--- a/packages/client/lib/net/protocol/boundprotocol.ts
+++ b/packages/client/lib/net/protocol/boundprotocol.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events'
-import { Protocol } from '../protocol/protocol'
+import { Message, Protocol } from '../protocol/protocol'
 import { Peer } from '../peer/peer'
 import { Sender } from './sender'
 import { Config } from '../../config'
@@ -31,7 +31,7 @@ export class BoundProtocol extends EventEmitter {
   private versions: number[]
   private timeout: number
   private _status: any
-  private resolvers: Map<string, any>
+  private resolvers: Map<string | number, any>
 
   /**
    * Create bound protocol
@@ -80,9 +80,9 @@ export class BoundProtocol extends EventEmitter {
    * @param  {Object} message message object
    * @emits  message
    */
-  handle(incoming: any) {
+  handle(incoming: Message) {
     const messages = this.protocol.messages
-    const message = messages.find((m: any) => m.code === incoming.code)
+    const message = messages.find((m) => m.code === incoming.code)
     if (!message) {
       return
     }
@@ -117,16 +117,16 @@ export class BoundProtocol extends EventEmitter {
    * @param  name message name
    * @param  args message arguments
    */
-  send(name: string, args?: any): any {
+  send(name: string, args?: any) {
     const messages = this.protocol.messages
-    const message = messages.find((m: any) => m.name === name)
+    const message = messages.find((m) => m.name === name)
     if (message) {
       const encoded = this.protocol.encode(message, args)
       this.sender.sendMessage(message.code, encoded)
-      return message
     } else {
       throw new Error(`Unknown message: ${name}`)
     }
+    return message
   }
 
   /**
@@ -143,14 +143,14 @@ export class BoundProtocol extends EventEmitter {
       resolve: null,
       reject: null,
     }
-    if (this.resolvers.get(message.response)) {
+    if (this.resolvers.get(message.response!)) {
       throw new Error(`Only one active request allowed per message type (${name})`)
     }
-    this.resolvers.set(message.response, resolver)
+    this.resolvers.set(message.response!, resolver)
     return new Promise((resolve, reject) => {
       resolver.timeout = setTimeout(() => {
         resolver.timeout = null
-        this.resolvers.delete(message.response)
+        this.resolvers.delete(message.response!)
         reject(new Error(`Request timed out after ${this.timeout}ms`))
       }, this.timeout)
       resolver.resolve = resolve
@@ -163,9 +163,9 @@ export class BoundProtocol extends EventEmitter {
    * corresponding response message.
    */
   addMethods() {
-    const messages = this.protocol.messages.filter((m: any) => m.response)
+    const messages = this.protocol.messages.filter((m) => m.response)
     for (const message of messages) {
-      const name = message.name as string
+      const name = message.name
       const camel = name[0].toLowerCase() + name.slice(1)
       ;(this as any)[camel] = async (args: any[]) =>
         this.request(name, args).catch((error: Error) => {

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -99,7 +99,7 @@ export class EthProtocol extends Protocol {
    * @type {number[]}
    */
   get versions(): number[] {
-    return [63, 62]
+    return [64, 63]
   }
 
   /**
@@ -127,6 +127,7 @@ export class EthProtocol extends Protocol {
    * @return {Object}
    */
   encodeStatus(): any {
+    // TODO: add latestBlock for more precise ETH/64 forkhash switch
     return {
       networkId: this.chain.networkId,
       td: this.chain.blocks.td.toArrayLike(Buffer),

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -130,7 +130,7 @@ export class LesProtocol extends Protocol {
    * Messages defined by this protocol
    * @type {Protocol~Message[]}
    */
-  get messages(): any {
+  get messages(): Message[] {
     return messages
   }
 
@@ -161,8 +161,8 @@ export class LesProtocol extends Protocol {
         txRelay: 1,
         'flowControl/BL': new BN(this.flow.bl).toArrayLike(Buffer),
         'flowControl/MRR': new BN(this.flow.mrr).toArrayLike(Buffer),
-        'flowControl/MRC': Object.entries(this.flow.mrc).map(([name, { base, req }]: any) => {
-          const { code }: any = messages.find((m) => m.name === name)
+        'flowControl/MRC': Object.entries(this.flow.mrc).map(([name, { base, req }]) => {
+          const { code } = messages.find((m) => m.name === name)!
           return [code, base, req]
         }),
       }

--- a/packages/client/lib/net/protocol/protocol.ts
+++ b/packages/client/lib/net/protocol/protocol.ts
@@ -14,6 +14,7 @@ export interface ProtocolOptions {
 export type Message = {
   name: string
   code: number
+  payload?: any
   // TODO: check semantics of this field
   response?: number
   // TODO: check if this should be optional

--- a/packages/client/lib/net/protocol/rlpxsender.ts
+++ b/packages/client/lib/net/protocol/rlpxsender.ts
@@ -1,5 +1,6 @@
 import { Sender } from './sender'
 import { rlp } from 'ethereumjs-util'
+import { ETH as Devp2pETH, LES as Devp2pLES } from '@ethereumjs/devp2p'
 
 /**
  * DevP2P/RLPx protocol sender
@@ -8,12 +9,12 @@ import { rlp } from 'ethereumjs-util'
  * @memberof module:net/protocol
  */
 export class RlpxSender extends Sender {
-  private sender: any
+  private sender: Devp2pETH | Devp2pLES
   /**
    * Creates a new DevP2P/Rlpx protocol sender
-   * @param {Object} rlpxProtocol protocol object from ethereumjs-devp2p
+   * @param {Object} rlpxProtocol protocol object from @ethereumjs/devp2p
    */
-  constructor(rlpxProtocol: any) {
+  constructor(rlpxProtocol: Devp2pETH | Devp2pLES) {
     super()
 
     this.sender = rlpxProtocol

--- a/packages/client/lib/net/server/libp2pserver.ts
+++ b/packages/client/lib/net/server/libp2pserver.ts
@@ -85,7 +85,7 @@ export class Libp2pServer extends Server {
           return
         }
         const peer = this.createPeer(peerInfo)
-        await peer.bindProtocols(this.node, peerInfo, this)
+        await peer.bindProtocols(this.node as Libp2pNode, peerInfo, this)
         this.config.logger.debug(`Peer discovered: ${peer}`)
         this.emit('connected', peer)
       } catch (e) {

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -34,7 +34,7 @@ tape('[Integration:FullEthereumService]', async (t) => {
     t.ok(headers![1].hash().equals(hash), 'handled GetBlockHeaders')
     const bodies = await peer.eth!.getBlockBodies([hash])
     t.deepEquals(bodies, [[[], []]], 'handled GetBlockBodies')
-    await peer.eth!.send('NewBlockHashes', [[hash, new BN(2)]])
+    peer.eth!.send('NewBlockHashes', [[hash, new BN(2)]])
     t.pass('handled NewBlockHashes')
     await destroy(server, service)
     t.end()

--- a/packages/client/test/net/peer/libp2ppeer.spec.ts
+++ b/packages/client/test/net/peer/libp2ppeer.spec.ts
@@ -59,9 +59,9 @@ tape('[Libp2pPeer]', async (t) => {
 
   t.test('should connect to peer', async (t) => {
     const config = new Config({ loglevel: 'error' })
-    const peer = new Libp2pPeer({ config })
+    const peer: any = new Libp2pPeer({ config })
     peer.bindProtocols = td.func<typeof peer['bindProtocol']>()
-    td.when(peer.bindProtocols(td.matchers.anything(), peerInfo)).thenResolve()
+    td.when(peer.bindProtocols(td.matchers.anything(), peerInfo)).thenResolve(null)
     peer.on('connected', () => {
       t.pass('connected')
       t.end()
@@ -71,9 +71,9 @@ tape('[Libp2pPeer]', async (t) => {
 
   t.test('should accept peer connection', async (t) => {
     const config = new Config({ loglevel: 'error' })
-    const peer = new Libp2pPeer({ config })
+    const peer: any = new Libp2pPeer({ config })
     peer.bindProtocol = td.func<typeof peer['bindProtocol']>()
-    td.when(peer.bindProtocol('proto' as any, 'conn' as any)).thenResolve()
+    td.when(peer.bindProtocol('proto' as any, 'conn' as any)).thenResolve(null)
     await peer.accept('proto', 'conn', 'server')
     t.equals(peer.server, 'server', 'server set')
     t.ok(peer.inbound, 'inbound set to true')
@@ -84,12 +84,12 @@ tape('[Libp2pPeer]', async (t) => {
     const config = new Config({ loglevel: 'error' })
     const protocol = { name: 'proto', versions: [1], open: () => {} } as Protocol
     const badProto = { name: 'bad', versions: [1], open: () => {} } as Protocol
-    const peer = new Libp2pPeer({ config, protocols: [protocol, badProto] })
+    const peer: any = new Libp2pPeer({ config, protocols: [protocol, badProto] })
     const node = new Libp2pNode() as any
     peer.bindProtocol = td.func<typeof peer['bindProtocol']>()
     protocol.open = td.func<Protocol['open']>()
     badProto.open = td.func<Protocol['open']>()
-    td.when(peer.bindProtocol(protocol, td.matchers.isA(Libp2pSender))).thenResolve()
+    td.when(peer.bindProtocol(protocol, td.matchers.isA(Libp2pSender))).thenResolve(null)
     td.when(protocol.open()).thenResolve()
     td.when(node.asyncDialProtocol(peerInfo, '/proto/1')).thenResolve(null)
     td.when(node.asyncDialProtocol(peerInfo, '/bad/1')).thenReject(new Error('bad'))

--- a/packages/client/test/net/peer/rlpxpeer.spec.ts
+++ b/packages/client/test/net/peer/rlpxpeer.spec.ts
@@ -98,9 +98,9 @@ tape('[RlpxPeer]', async (t) => {
 
   t.test('should accept peer connection', async (t) => {
     const config = new Config({ transports: [], loglevel: 'error' })
-    const peer = new RlpxPeer({ config, id: 'abcdef0123', host: '10.0.0.1', port: 1234 })
+    const peer: any = new RlpxPeer({ config, id: 'abcdef0123', host: '10.0.0.1', port: 1234 })
     peer.bindProtocols = td.func<typeof peer['bindProtocols']>()
-    td.when(peer.bindProtocols('rlpxpeer' as any)).thenResolve()
+    td.when(peer.bindProtocols('rlpxpeer' as any)).thenResolve(null)
     await peer.accept('rlpxpeer' as any, 'server')
     t.equals(peer.server, 'server', 'server set')
     t.end()

--- a/packages/client/test/net/peer/rlpxpeer.spec.ts
+++ b/packages/client/test/net/peer/rlpxpeer.spec.ts
@@ -28,7 +28,7 @@ tape('[RlpxPeer]', async (t) => {
 
   t.test('should compute capabilities', (t) => {
     const protocols: any = [
-      { name: 'eth', versions: [62, 63] },
+      { name: 'eth', versions: [63, 64] },
       { name: 'les', versions: [2] },
     ]
     const caps = RlpxPeer.capabilities(protocols).map(({ name, version, length }) => ({
@@ -39,8 +39,8 @@ tape('[RlpxPeer]', async (t) => {
     t.deepEquals(
       caps,
       [
-        { name: 'eth', version: 62, length: 8 },
         { name: 'eth', version: 63, length: 17 },
+        { name: 'eth', version: 64, length: 29 },
         { name: 'les', version: 2, length: 21 },
       ],
       'correct capabilities'

--- a/packages/client/test/net/protocol/boundprotocol.spec.ts
+++ b/packages/client/test/net/protocol/boundprotocol.spec.ts
@@ -76,17 +76,16 @@ tape('[BoundProtocol]', (t) => {
       peer,
       sender,
     })
-    t.notOk(bound.handle({}), 'missing message.code')
     bound.once('error', (err: any) => {
       t.ok(/error0/.test(err.message), 'decode error')
     })
     td.when(protocol.decode(testMessage, '1')).thenThrow(new Error('error0'))
-    bound.handle({ code: 0x01, payload: '1' })
+    bound.handle({ name: 'TestMessage', code: 0x01, payload: '1' })
     bound.once('message', (message: any) => {
       t.deepEquals(message, { name: 'TestMessage', data: 2 }, 'correct message')
     })
     td.when(protocol.decode(testMessage, '2')).thenReturn(2)
-    bound.handle({ code: 0x01, payload: '2' })
+    bound.handle({ name: 'TestMessage', code: 0x01, payload: '2' })
     t.end()
   })
 

--- a/packages/client/test/net/protocol/rlpxsender.spec.ts
+++ b/packages/client/test/net/protocol/rlpxsender.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import tape from 'tape-catch'
 import td from 'testdouble'
 import * as rlp from 'rlp'
+import { ETH as Devp2pETH } from '@ethereumjs/devp2p'
 import { RlpxSender } from '../../../lib/net/protocol'
 
 tape('[RlpxSender]', (t) => {
@@ -28,7 +29,7 @@ tape('[RlpxSender]', (t) => {
 
   t.test('should receive status', (t) => {
     const rlpxProtocol = new EventEmitter()
-    const sender = new RlpxSender(rlpxProtocol)
+    const sender = new RlpxSender(rlpxProtocol as Devp2pETH)
     sender.on('status', (status: any) => {
       t.equal(status.id, 5, 'status received')
       t.equal(sender.status.id, 5, 'status getter')
@@ -39,7 +40,7 @@ tape('[RlpxSender]', (t) => {
 
   t.test('should receive message', (t) => {
     const rlpxProtocol = new EventEmitter()
-    const sender = new RlpxSender(rlpxProtocol)
+    const sender = new RlpxSender(rlpxProtocol as Devp2pETH)
     sender.on('message', (message: any) => {
       t.equal(message.code, 1, 'message received (code)')
       t.equal(message.payload, 5, 'message received (payload)')
@@ -50,7 +51,7 @@ tape('[RlpxSender]', (t) => {
 
   t.test('should catch errors', (t) => {
     const rlpxProtocol = new EventEmitter()
-    const sender = new RlpxSender(rlpxProtocol)
+    const sender = new RlpxSender(rlpxProtocol as Devp2pETH)
     t.throws(() => sender.sendStatus({ id: 5 }), /not a function/, 'sendStatus error')
     t.throws(() => sender.sendMessage(1, 5), /not a function/, 'sendMessage error')
     t.end()

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -265,7 +265,6 @@ export namespace ETH {
   export interface StatusMsg extends Array<Buffer | Buffer[]> {}
 
   export type StatusOpts = {
-    version: number
     td: Buffer
     bestHash: Buffer
     latestBlock?: number


### PR DESCRIPTION
This PR integrates the ETH/64 protocol from the latest devp2p `master` into the client. This is tested with ETH/64 only to exclude the possibility that ETH/63 is taking over all the load (ETH/62 has been removed since it is reaching EOL anyhow).