### PR TITLE
Trie: cache CheckpointTrie in memory

### DIFF
--- a/packages/trie/src/checkpointDb.ts
+++ b/packages/trie/src/checkpointDb.ts
@@ -1,0 +1,162 @@
+import { LevelUp } from 'levelup'
+import { DB } from './db'
+const level = require('level-mem')
+
+export const ENCODING_OPTS = { keyEncoding: 'binary', valueEncoding: 'binary' }
+
+export type Checkpoint = {
+  keyValueMap: Map<Buffer, Buffer | null>,
+  root: Buffer
+}
+
+export type BatchDBOp = PutBatch | DelBatch
+export interface PutBatch {
+  type: 'put'
+  key: Buffer
+  value: Buffer
+}
+export interface DelBatch {
+  type: 'del'
+  key: Buffer
+}
+
+/**
+ * DB is a thin wrapper around the underlying levelup db,
+ * which validates inputs and sets encoding type.
+ */
+export class CheckpointDB extends DB {
+  public checkpoints: Checkpoint[]
+
+  /**
+   * Initialize a DB instance. If `leveldb` is not provided, DB
+   * defaults to an [in-memory store](https://github.com/Level/memdown).
+   * @param leveldb - An abstract-leveldown compliant store
+   */
+  constructor(leveldb?: LevelUp) {
+    super(leveldb)
+    // Roots of trie at the moment of checkpoint
+    this.checkpoints = []
+  }
+
+  /**
+   * Is the DB during a checkpoint phase?
+   */
+  get isCheckpoint() {
+    return this.checkpoints.length > 0
+  }
+
+  /**
+   * Adds a new checkpoint to the stack
+   * @param root
+   */
+  checkpoint(root: Buffer) {
+    this.checkpoints.push({ keyValueMap: new Map<Buffer, Buffer>(), root })
+  }
+
+  /**
+   * Commits the latest checkpoint
+   */
+  async commit() {
+    const { keyValueMap } = this.checkpoints.pop()!
+    if (!this.isCheckpoint) {
+      // This was the final checkpoint, we should now commit and flush everything to disk
+      const batchOp: BatchDBOp[] = []
+      keyValueMap.forEach(function(value, key) {
+        if (value === null) {
+          batchOp.push({
+            type: 'del',
+            key
+          })
+        } else {
+          batchOp.push({
+            type: 'put',
+            key,
+            value
+          })
+        }
+      })
+      await this.batch(batchOp)
+    } else {
+      // dump everything into the current (higher level) cache
+      const currentKeyValueMap = this.checkpoints[this.checkpoints.length - 1].keyValueMap
+      keyValueMap.forEach(function(value, key){ 
+        currentKeyValueMap.set(key, value)
+      })
+
+    }
+
+  }
+
+  /**
+   * Reverts the latest checkpoint
+   */
+  async revert() {
+   const { root } = this.checkpoints.pop()!
+   return root
+  }
+
+  /**
+   * Retrieves a raw value from leveldb.
+   * @param key
+   * @returns A Promise that resolves to `Buffer` if a value is found or `null` if no value is found.
+   */
+  async get(key: Buffer): Promise<Buffer | null> {
+    // Lookup the value in our cache. We return the latest checkpointed value (which should be the value on disk)
+    for (let index = this.checkpoints.length; index >= 0; index--) {
+      const value = this.checkpoints[index].keyValueMap.get(key)
+      if (value != undefined) {
+        return value
+      }
+    }
+    // Nothing has been found in cache, look up from disk
+    // TODO: put value in cache.
+    return await super.get(key)
+  }
+
+  /**
+   * Writes a value directly to leveldb.
+   * @param key The key as a `Buffer`
+   * @param value The value to be stored
+   */
+  async put(key: Buffer, val: Buffer): Promise<void> {
+    if (this.isCheckpoint) {
+      // put value in cache 
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key, val)
+    } else { 
+      await super.put(key, val)
+    }
+  }
+
+  /**
+   * Removes a raw value in the underlying leveldb.
+   * @param keys
+   */
+  async del(key: Buffer): Promise<void> {
+    if (this.isCheckpoint) {
+      // delete the value in the current cache
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key, null)
+    } else {
+      // delete the value on disk
+      await this._leveldb.del(key, ENCODING_OPTS)
+    }
+  }
+
+  /**
+   * Performs a batch operation on db.
+   * @param opStack A stack of levelup operations
+   */
+  async batch(opStack: BatchDBOp[]): Promise<void> {
+    if (this.isCheckpoint) {
+      for (const op of opStack) {
+        if (op.type === 'put') {
+          await this.put(op.key, op.value)
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        } else if (op.type === 'del') {
+          await this.del(op.key)
+        }
+      }
+    } else {
+      await super.batch(opStack)
+    }
+  }
+}

--- a/packages/trie/src/checkpointDb.ts
+++ b/packages/trie/src/checkpointDb.ts
@@ -55,12 +55,12 @@ export class CheckpointDB extends DB {
         if (value === null) {
           batchOp.push({
             type: 'del',
-            key: Buffer.from(key),
+            key: Buffer.from(key, 'hex'),
           })
         } else {
           batchOp.push({
             type: 'put',
-            key: Buffer.from(key),
+            key: Buffer.from(key, 'hex'),
             value,
           })
         }
@@ -91,7 +91,7 @@ export class CheckpointDB extends DB {
   async get(key: Buffer): Promise<Buffer | null> {
     // Lookup the value in our cache. We return the latest checkpointed value (which should be the value on disk)
     for (let index = this.checkpoints.length - 1; index >= 0; index--) {
-      const value = this.checkpoints[index].keyValueMap.get(key.toString())
+      const value = this.checkpoints[index].keyValueMap.get(key.toString('hex'))
       if (value !== undefined) {
         return value
       }
@@ -109,7 +109,7 @@ export class CheckpointDB extends DB {
   async put(key: Buffer, val: Buffer): Promise<void> {
     if (this.isCheckpoint) {
       // put value in cache
-      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString(), val)
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('hex'), val)
     } else {
       await super.put(key, val)
     }
@@ -122,7 +122,7 @@ export class CheckpointDB extends DB {
   async del(key: Buffer): Promise<void> {
     if (this.isCheckpoint) {
       // delete the value in the current cache
-      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString(), null)
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('hex'), null)
     } else {
       // delete the value on disk
       await this._leveldb.del(key, ENCODING_OPTS)

--- a/packages/trie/src/checkpointDb.ts
+++ b/packages/trie/src/checkpointDb.ts
@@ -1,7 +1,5 @@
 import { LevelUp } from 'levelup'
-import { DB, BatchDBOp } from './db'
-
-export const ENCODING_OPTS = { keyEncoding: 'binary', valueEncoding: 'binary' }
+import { DB, BatchDBOp, ENCODING_OPTS } from './db'
 
 export type Checkpoint = {
   // We cannot use a Buffer => Buffer map directly. If you create two Buffers with the same internal value,
@@ -55,12 +53,12 @@ export class CheckpointDB extends DB {
         if (value === null) {
           batchOp.push({
             type: 'del',
-            key: Buffer.from(key, 'hex'),
+            key: Buffer.from(key, 'binary'),
           })
         } else {
           batchOp.push({
             type: 'put',
-            key: Buffer.from(key, 'hex'),
+            key: Buffer.from(key, 'binary'),
             value,
           })
         }
@@ -69,9 +67,7 @@ export class CheckpointDB extends DB {
     } else {
       // dump everything into the current (higher level) cache
       const currentKeyValueMap = this.checkpoints[this.checkpoints.length - 1].keyValueMap
-      keyValueMap.forEach(function (value, key) {
-        currentKeyValueMap.set(key, value)
-      })
+      keyValueMap.forEach((value, key) => currentKeyValueMap.set(key, value))
     }
   }
 
@@ -91,7 +87,7 @@ export class CheckpointDB extends DB {
   async get(key: Buffer): Promise<Buffer | null> {
     // Lookup the value in our cache. We return the latest checkpointed value (which should be the value on disk)
     for (let index = this.checkpoints.length - 1; index >= 0; index--) {
-      const value = this.checkpoints[index].keyValueMap.get(key.toString('hex'))
+      const value = this.checkpoints[index].keyValueMap.get(key.toString('binary'))
       if (value !== undefined) {
         return value
       }
@@ -101,7 +97,7 @@ export class CheckpointDB extends DB {
     const value = await super.get(key)
     if (this.isCheckpoint) {
       // Since we are a checkpoint, put this value in cache, so future `get` calls will not look the key up again from disk.
-      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('hex'), value)
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('binary'), value)
     }
 
     return value
@@ -115,7 +111,7 @@ export class CheckpointDB extends DB {
   async put(key: Buffer, val: Buffer): Promise<void> {
     if (this.isCheckpoint) {
       // put value in cache
-      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('hex'), val)
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('binary'), val)
     } else {
       await super.put(key, val)
     }
@@ -128,7 +124,7 @@ export class CheckpointDB extends DB {
   async del(key: Buffer): Promise<void> {
     if (this.isCheckpoint) {
       // delete the value in the current cache
-      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('hex'), null)
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('binary'), null)
     } else {
       // delete the value on disk
       await this._leveldb.del(key, ENCODING_OPTS)

--- a/packages/trie/src/checkpointDb.ts
+++ b/packages/trie/src/checkpointDb.ts
@@ -97,8 +97,14 @@ export class CheckpointDB extends DB {
       }
     }
     // Nothing has been found in cache, look up from disk
-    // TODO: put value in cache if we are a checkpoint.
-    return await super.get(key)
+
+    const value = await super.get(key)
+    if (this.isCheckpoint) {
+      // Since we are a checkpoint, put this value in cache, so future `get` calls will not look the key up again from disk.
+      this.checkpoints[this.checkpoints.length - 1].keyValueMap.set(key.toString('hex'), value)
+    }
+
+    return value
   }
 
   /**

--- a/packages/trie/src/checkpointTrie.ts
+++ b/packages/trie/src/checkpointTrie.ts
@@ -16,7 +16,7 @@ export class CheckpointTrie extends BaseTrie {
    * Is the trie during a checkpoint phase?
    */
   get isCheckpoint() {
-    return this.db.checkpoints.length > 0
+    return this.db.isCheckpoint
   }
 
   /**

--- a/packages/trie/src/checkpointTrie.ts
+++ b/packages/trie/src/checkpointTrie.ts
@@ -65,7 +65,7 @@ export class CheckpointTrie extends BaseTrie {
     const db = this.db.copy()
     const trie = new CheckpointTrie(db._leveldb, this.root)
     if (includeCheckpoints && this.isCheckpoint) {
-      trie.db.checkpoints = this.db.checkpoints.slice()
+      trie.db.checkpoints = [...this.db.checkpoints]
     }
     return trie
   }

--- a/packages/trie/src/checkpointTrie.ts
+++ b/packages/trie/src/checkpointTrie.ts
@@ -1,11 +1,15 @@
 import { Trie as BaseTrie } from './baseTrie'
+import { CheckpointDB } from './checkpointDb'
 
 /**
  * Adds checkpointing to the {@link BaseTrie}
  */
 export class CheckpointTrie extends BaseTrie {
+  db: CheckpointDB
+  
   constructor(...args: any) {
     super(...args)
+    this.db = new CheckpointDB(...args)
   }
 
   /**
@@ -34,7 +38,7 @@ export class CheckpointTrie extends BaseTrie {
     }
 
     await this.lock.wait()
-    this.db.commit()
+    await this.db.commit()
     this.lock.signal()
   }
 

--- a/packages/trie/src/checkpointTrie.ts
+++ b/packages/trie/src/checkpointTrie.ts
@@ -6,7 +6,7 @@ import { CheckpointDB } from './checkpointDb'
  */
 export class CheckpointTrie extends BaseTrie {
   db: CheckpointDB
-  
+
   constructor(...args: any) {
     super(...args)
     this.db = new CheckpointDB(...args)

--- a/packages/trie/src/db.ts
+++ b/packages/trie/src/db.ts
@@ -3,11 +3,6 @@ const level = require('level-mem')
 
 export const ENCODING_OPTS = { keyEncoding: 'binary', valueEncoding: 'binary' }
 
-export type Checkpoint = {
-  root: Buffer
-  revertOps: BatchDBOp[]
-}
-
 export type BatchDBOp = PutBatch | DelBatch
 export interface PutBatch {
   type: 'put'
@@ -24,8 +19,6 @@ export interface DelBatch {
  * which validates inputs and sets encoding type.
  */
 export class DB {
-  public checkpoints: Checkpoint[]
-
   _leveldb: LevelUp
 
   /**
@@ -34,51 +27,7 @@ export class DB {
    * @param leveldb - An abstract-leveldown compliant store
    */
   constructor(leveldb?: LevelUp) {
-    // Roots of trie at the moment of checkpoint
-    this.checkpoints = []
-
     this._leveldb = leveldb || level()
-  }
-
-  /**
-   * Is the DB during a checkpoint phase?
-   */
-  get isCheckpoint() {
-    return this.checkpoints.length > 0
-  }
-
-  /**
-   * Adds a new checkpoint to the stack
-   * @param root
-   */
-  checkpoint(root: Buffer) {
-    this.checkpoints.push({ root, revertOps: [] })
-  }
-
-  /**
-   * Commits the latest checkpoint
-   */
-  commit() {
-    const { root, revertOps } = this.checkpoints.pop()!
-    // On nested checkpoints put the revertOps on the parent
-    // stack in case there is a revert
-    if (this.isCheckpoint) {
-      this.checkpoints[this.checkpoints.length - 1].revertOps.concat(revertOps)
-    }
-    return root
-  }
-
-  /**
-   * Reverts the latest checkpoint
-   */
-  async revert() {
-    const { root, revertOps } = this.checkpoints.pop()!
-    await this.batch(revertOps.reverse())
-    return root
-  }
-
-  private addCPRevertOperation(op: BatchDBOp) {
-    this.checkpoints[this.checkpoints.length - 1].revertOps.push(op)
   }
 
   /**
@@ -106,30 +55,7 @@ export class DB {
    * @param value The value to be stored
    */
   async put(key: Buffer, val: Buffer): Promise<void> {
-    const revertOps: BatchDBOp[] = []
-    // In CP mode check for an old value to be put
-    // on the revert ops stack
-    if (this.isCheckpoint) {
-      const oldValue = await this.get(key)
-      if (oldValue !== null) {
-        revertOps.push({
-          type: 'put',
-          key: key,
-          value: oldValue,
-        })
-      }
-    }
     await this._leveldb.put(key, val, ENCODING_OPTS)
-    // In CP mode add del to the revert ops stack
-    if (this.isCheckpoint) {
-      revertOps.push({
-        type: 'del',
-        key: key,
-      })
-      for (const revertOp of revertOps) {
-        this.addCPRevertOperation(revertOp)
-      }
-    }
   }
 
   /**
@@ -137,25 +63,7 @@ export class DB {
    * @param keys
    */
   async del(key: Buffer): Promise<void> {
-    const revertOps: BatchDBOp[] = []
-    // In CP mode check for an old value to be put
-    // on the revert ops stack
-    if (this.isCheckpoint) {
-      const oldValue = await this.get(key)
-      if (oldValue !== null) {
-        revertOps.push({
-          type: 'put',
-          key: key,
-          value: oldValue,
-        })
-      }
-    }
     await this._leveldb.del(key, ENCODING_OPTS)
-    if (this.isCheckpoint) {
-      for (const revertOp of revertOps) {
-        this.addCPRevertOperation(revertOp)
-      }
-    }
   }
 
   /**
@@ -163,18 +71,7 @@ export class DB {
    * @param opStack A stack of levelup operations
    */
   async batch(opStack: BatchDBOp[]): Promise<void> {
-    if (this.isCheckpoint) {
-      for (const op of opStack) {
-        if (op.type === 'put') {
-          await this.put(op.key, op.value)
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        } else if (op.type === 'del') {
-          await this.del(op.key)
-        }
-      }
-    } else {
-      await this._leveldb.batch(opStack, ENCODING_OPTS)
-    }
+    await this._leveldb.batch(opStack, ENCODING_OPTS)
   }
 
   /**

--- a/packages/trie/src/secure.ts
+++ b/packages/trie/src/secure.ts
@@ -92,7 +92,7 @@ export class SecureTrie extends CheckpointTrie {
     const db = this.db.copy()
     const secureTrie = new SecureTrie(db._leveldb, this.root)
     if (includeCheckpoints && this.isCheckpoint) {
-      secureTrie.db.checkpoints = this.db.checkpoints.slice()
+      secureTrie.db.checkpoints = [...this.db.checkpoints]
     }
     return secureTrie
   }

--- a/packages/trie/src/secure.ts
+++ b/packages/trie/src/secure.ts
@@ -89,8 +89,11 @@ export class SecureTrie extends CheckpointTrie {
    * @param includeCheckpoints - If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.
    */
   copy(includeCheckpoints = true): SecureTrie {
-    const trie = super.copy(includeCheckpoints)
-    const db = trie.db.copy()
-    return new SecureTrie(db._leveldb, this.root)
+    const db = this.db.copy()
+    const secureTrie = new SecureTrie(db._leveldb, this.root)
+    if (includeCheckpoints && this.isCheckpoint) {
+      secureTrie.db.checkpoints = this.db.checkpoints.slice()
+    }
+    return secureTrie
   }
 }

--- a/packages/trie/test/checkpointDb.spec.ts
+++ b/packages/trie/test/checkpointDb.spec.ts
@@ -1,0 +1,74 @@
+import tape from 'tape'
+import { CheckpointDB as DB } from '../src/checkpointDb'
+import { BatchDBOp } from '../src/db'
+
+tape('DB tests', (t) => {
+  const k = Buffer.from('k1')
+  const v = Buffer.from('v1')
+  const v2 = Buffer.from('v2')
+  const v3 = Buffer.from('v3')
+
+  t.test('Checkpointing: revert -> put (add)', async (st) => {
+    const db = new DB()
+    db.checkpoint(Buffer.from('1', 'hex'))
+    await db.put(k, v)
+    st.deepEqual(await db.get(k), v, 'before revert: v1')
+    await db.revert()
+    st.deepEqual(await db.get(k), null, 'after revert: null')
+    st.end()
+  })
+
+  t.test('Checkpointing: revert -> put (update)', async (st) => {
+    const db = new DB()
+    await db.put(k, v)
+    st.deepEqual(await db.get(k), v, 'before CP: v1')
+    db.checkpoint(Buffer.from('1', 'hex'))
+    await db.put(k, v2)
+    await db.put(k, v3)
+    await db.revert()
+    st.deepEqual(await db.get(k), v, 'after revert: v1')
+    st.end()
+  })
+
+  t.test('Checkpointing: revert -> put (update) batched', async (st) => {
+    const db = new DB()
+    await db.put(k, v)
+    st.deepEqual(await db.get(k), v, 'before CP: v1')
+    db.checkpoint(Buffer.from('1', 'hex'))
+    const ops = [
+      { type: 'put', key: k, value: v2 },
+      { type: 'put', key: k, value: v3 },
+    ] as BatchDBOp[]
+    await db.batch(ops)
+    await db.revert()
+    st.deepEqual(await db.get(k), v, 'after revert: v1')
+    st.end()
+  })
+
+  t.test('Checkpointing: revert -> del', async (st) => {
+    const db = new DB()
+    await db.put(k, v)
+    st.deepEqual(await db.get(k), v, 'before CP: v1')
+    db.checkpoint(Buffer.from('1', 'hex'))
+    await db.del(k)
+    st.deepEqual(await db.get(k), null, 'before revert: null')
+    await db.revert()
+    st.deepEqual(await db.get(k), v, 'after revert: v1')
+    st.end()
+  })
+
+  t.test('Checkpointing: nested checkpoints -> commit -> revert', async (st) => {
+    const db = new DB()
+    await db.put(k, v)
+    st.deepEqual(await db.get(k), v, 'before CP: v1')
+    db.checkpoint(Buffer.from('1', 'hex'))
+    await db.put(k, v2)
+    db.checkpoint(Buffer.from('2', 'hex'))
+    await db.put(k, v3)
+    await db.commit()
+    st.deepEqual(await db.get(k), v3, 'after commit (second CP): v3')
+    await db.revert()
+    st.deepEqual(await db.get(k), v, 'after revert (first CP): v1')
+    st.end()
+  })
+})

--- a/packages/trie/test/db.spec.ts
+++ b/packages/trie/test/db.spec.ts
@@ -8,7 +8,6 @@ tape('DB tests', (t) => {
   const v = Buffer.from('v1')
   const k2 = Buffer.from('k2')
   const v2 = Buffer.from('v2')
-  const v3 = Buffer.from('v3')
 
   t.test('Operations: puts and gets value', async (st) => {
     await db.put(k, v)
@@ -32,70 +31,6 @@ tape('DB tests', (t) => {
     await db.batch(ops)
     const res = await db.get(k2)
     st.ok(v2.equals(res!))
-    st.end()
-  })
-
-  t.test('Checkpointing: revert -> put (add)', async (st) => {
-    const db = new DB()
-    db.checkpoint(Buffer.from('1', 'hex'))
-    await db.put(k, v)
-    st.deepEqual(await db.get(k), v, 'before revert: v1')
-    await db.revert()
-    st.deepEqual(await db.get(k), null, 'after revert: null')
-    st.end()
-  })
-
-  t.test('Checkpointing: revert -> put (update)', async (st) => {
-    const db = new DB()
-    await db.put(k, v)
-    st.deepEqual(await db.get(k), v, 'before CP: v1')
-    db.checkpoint(Buffer.from('1', 'hex'))
-    await db.put(k, v2)
-    await db.put(k, v3)
-    await db.revert()
-    st.deepEqual(await db.get(k), v, 'after revert: v1')
-    st.end()
-  })
-
-  t.test('Checkpointing: revert -> put (update) batched', async (st) => {
-    const db = new DB()
-    await db.put(k, v)
-    st.deepEqual(await db.get(k), v, 'before CP: v1')
-    db.checkpoint(Buffer.from('1', 'hex'))
-    const ops = [
-      { type: 'put', key: k, value: v2 },
-      { type: 'put', key: k, value: v3 },
-    ] as BatchDBOp[]
-    await db.batch(ops)
-    await db.revert()
-    st.deepEqual(await db.get(k), v, 'after revert: v1')
-    st.end()
-  })
-
-  t.test('Checkpointing: revert -> del', async (st) => {
-    const db = new DB()
-    await db.put(k, v)
-    st.deepEqual(await db.get(k), v, 'before CP: v1')
-    db.checkpoint(Buffer.from('1', 'hex'))
-    await db.del(k)
-    st.deepEqual(await db.get(k), null, 'before revert: null')
-    await db.revert()
-    st.deepEqual(await db.get(k), v, 'after revert: v1')
-    st.end()
-  })
-
-  t.test('Checkpointing: nested checkpoints -> commit -> revert', async (st) => {
-    const db = new DB()
-    await db.put(k, v)
-    st.deepEqual(await db.get(k), v, 'before CP: v1')
-    db.checkpoint(Buffer.from('1', 'hex'))
-    await db.put(k, v2)
-    db.checkpoint(Buffer.from('2', 'hex'))
-    await db.put(k, v3)
-    db.commit()
-    st.deepEqual(await db.get(k), v3, 'after commit (second CP): v3')
-    await db.revert()
-    st.deepEqual(await db.get(k), v, 'after revert (first CP): v1')
     st.end()
   })
 })

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -73,6 +73,10 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
     common,
   })
 
+  // Need to await the init promise: in some tests, we do not run the iterator (which awaits the initPromise)
+  // If the initPromise does not finish, the `rawHead` of `blockchain.meta()` is still `undefined`.
+  await blockchain.initPromise
+
   // set up pre-state
   await setupPreConditions(vm.stateManager._trie, testData)
 


### PR DESCRIPTION
This PR: 

- Seperates the DB used by `BaseTrie` and the extended DB used by `CheckpointTrie` (and `SecureTrie`) into two DBs; the base `DB` and the `CheckpointDB`. 
- All checkpoint operations are cached into memory. This makes reverting operations very easy (just throw away the latest cache) and also does not write to disk (so less I/O operations)